### PR TITLE
bugfix: chunk compression should use actual size of chunk

### DIFF
--- a/src/neuroglancer/sliceview/backend_chunk_decoders/postprocess.ts
+++ b/src/neuroglancer/sliceview/backend_chunk_decoders/postprocess.ts
@@ -33,10 +33,10 @@ export function postProcessRawData(chunk: VolumeChunk, data: ArrayBufferView) {
     tempBuffer.clear();
     switch (dataType) {
     case DataType.UINT32:
-      encodeChannelUint32(tempBuffer, spec.compressedSegmentationBlockSize, <Uint32Array>data, spec.chunkDataSize);
+      encodeChannelUint32(tempBuffer, spec.compressedSegmentationBlockSize, <Uint32Array>data, chunk.chunkDataSize);
       break;
     case DataType.UINT64:
-      encodeChannelUint64(tempBuffer, spec.compressedSegmentationBlockSize, <Uint32Array>data, spec.chunkDataSize);
+      encodeChannelUint64(tempBuffer, spec.compressedSegmentationBlockSize, <Uint32Array>data, chunk.chunkDataSize);
       break;
     default:
       throw new Error(`Unsupported data type for compressed segmentation: ${DataType[dataType]}`);


### PR DESCRIPTION
The actual size of a chunk can be smaller than the one reported in the
VolumeChunkSpecification, if the requested chunk was not fully contained
in the volume.