### PR TITLE
improved dvid backend support

### DIFF
--- a/src/neuroglancer/datasource/dvid/backend.ts
+++ b/src/neuroglancer/datasource/dvid/backend.ts
@@ -42,7 +42,12 @@ class VolumeChunkSource extends GenericVolumeChunkSource {
       // computeChunkBounds.
       let chunkPosition = this.computeChunkBounds(chunk);
       let {chunkDataSize} = chunk;
-      path = `/api/node/${params['nodeKey']}/${params['dataInstanceKey']}/raw/0_1_2/${chunkDataSize[0]}_${chunkDataSize[1]}_${chunkDataSize[2]}/${chunkPosition[0]}_${chunkPosition[1]}_${chunkPosition[2]}/nd`;
+ 
+      if (params['level'] == "0") {
+        path = `/api/node/${params['nodeKey']}/${params['dataInstanceKey']}/raw/0_1_2/${chunkDataSize[0]}_${chunkDataSize[1]}_${chunkDataSize[2]}/${chunkPosition[0]}_${chunkPosition[1]}_${chunkPosition[2]}/nd`;
+      } else {
+        path = `/api/node/${params['nodeKey']}/${params['dataInstanceKey']}_${params['level']}/raw/0_1_2/${chunkDataSize[0]}_${chunkDataSize[1]}_${chunkDataSize[2]}/${chunkPosition[0]}_${chunkPosition[1]}_${chunkPosition[2]}/nd`;
+      }
     }
     handleChunkDownloadPromise(
         chunk, sendHttpRequest(openShardedHttpRequest(params.baseUrls, path), 'arraybuffer'),

--- a/src/neuroglancer/datasource/dvid/backend.ts
+++ b/src/neuroglancer/datasource/dvid/backend.ts
@@ -15,12 +15,12 @@
  */
 
 import {handleChunkDownloadPromise} from 'neuroglancer/chunk_manager/backend';
-import {VolumeChunkSourceParameters, volumeSourceToString, TileChunkSourceParameters, tileSourceToString, TileEncoding} from 'neuroglancer/datasource/dvid/base';
+import {TileChunkSourceParameters, TileEncoding, VolumeChunkSourceParameters, tileSourceToString, volumeSourceToString} from 'neuroglancer/datasource/dvid/base';
 import {VolumeChunk, VolumeChunkSource as GenericVolumeChunkSource} from 'neuroglancer/sliceview/backend';
 import {ChunkDecoder} from 'neuroglancer/sliceview/backend_chunk_decoders';
 import {decodeJpegChunk} from 'neuroglancer/sliceview/backend_chunk_decoders/jpeg';
 import {decodeRawChunk} from 'neuroglancer/sliceview/backend_chunk_decoders/raw';
-import {sendHttpRequest, openShardedHttpRequest} from 'neuroglancer/util/http_request';
+import {openShardedHttpRequest, sendHttpRequest} from 'neuroglancer/util/http_request';
 import {RPC, registerSharedObject} from 'neuroglancer/worker_rpc';
 
 const TILE_CHUNK_DECODERS = new Map<TileEncoding, ChunkDecoder>([
@@ -42,12 +42,9 @@ class VolumeChunkSource extends GenericVolumeChunkSource {
       // computeChunkBounds.
       let chunkPosition = this.computeChunkBounds(chunk);
       let {chunkDataSize} = chunk;
- 
-      if (params['level'] == "0") {
-        path = `/api/node/${params['nodeKey']}/${params['dataInstanceKey']}/raw/0_1_2/${chunkDataSize[0]}_${chunkDataSize[1]}_${chunkDataSize[2]}/${chunkPosition[0]}_${chunkPosition[1]}_${chunkPosition[2]}/nd`;
-      } else {
-        path = `/api/node/${params['nodeKey']}/${params['dataInstanceKey']}_${params['level']}/raw/0_1_2/${chunkDataSize[0]}_${chunkDataSize[1]}_${chunkDataSize[2]}/${chunkPosition[0]}_${chunkPosition[1]}_${chunkPosition[2]}/nd`;
-      }
+
+      path =
+          `/api/node/${params['nodeKey']}/${params['dataInstanceKey']}/raw/0_1_2/${chunkDataSize[0]}_${chunkDataSize[1]}_${chunkDataSize[2]}/${chunkPosition[0]}_${chunkPosition[1]}_${chunkPosition[2]}/nd`;
     }
     handleChunkDownloadPromise(
         chunk, sendHttpRequest(openShardedHttpRequest(params.baseUrls, path), 'arraybuffer'),
@@ -72,10 +69,11 @@ class TileChunkSource extends GenericVolumeChunkSource {
 
     // Needed by decoder.
     chunk.chunkDataSize = this.spec.chunkDataSize;
-    let path = `/api/node/${params['nodeKey']}/${params['dataInstanceKey']}/tile/${params['dims']}/${params['level']}/${chunkGridPosition[0]}_${chunkGridPosition[1]}_${chunkGridPosition[2]}`;
+    let path =
+        `/api/node/${params['nodeKey']}/${params['dataInstanceKey']}/tile/${params['dims']}/${params['level']}/${chunkGridPosition[0]}_${chunkGridPosition[1]}_${chunkGridPosition[2]}`;
     handleChunkDownloadPromise(
         chunk, sendHttpRequest(openShardedHttpRequest(params.baseUrls, path), 'arraybuffer'),
-      this.chunkDecoder);
+        this.chunkDecoder);
   }
   toString() { return tileSourceToString(this.parameters); }
 };

--- a/src/neuroglancer/datasource/dvid/base.ts
+++ b/src/neuroglancer/datasource/dvid/base.ts
@@ -14,24 +14,28 @@
  * limitations under the License.
  */
 
-export interface VolumeChunkSourceParameters {
+export interface DVIDSourceParameters {
   baseUrls: string[];
   nodeKey: string;
   dataInstanceKey: string;
+};
+
+export interface VolumeChunkSourceParameters extends DVIDSourceParameters {
+  level: string;
 };
 
 export enum TileEncoding {
   JPEG
 };
 
-export interface TileChunkSourceParameters extends VolumeChunkSourceParameters {
+export interface TileChunkSourceParameters extends DVIDSourceParameters {
   dims: string;
   level: string;
   encoding: TileEncoding;
 };
 
 export function volumeSourceToString(parameters: VolumeChunkSourceParameters) {
-  return `dvid:volume:${parameters['baseUrls'][0]}/${parameters['nodeKey']}/${parameters['dataInstanceKey']}`;
+  return `dvid:volume:${parameters['baseUrls'][0]}/${parameters['nodeKey']}/${parameters['dataInstanceKey']}/${parameters['level']}`;
 }
 
 export function tileSourceToString(parameters: TileChunkSourceParameters) {

--- a/src/neuroglancer/datasource/dvid/base.ts
+++ b/src/neuroglancer/datasource/dvid/base.ts
@@ -18,21 +18,23 @@ export interface DVIDSourceParameters {
   baseUrls: string[];
   nodeKey: string;
   dataInstanceKey: string;
-};
+}
+;
 
-export interface VolumeChunkSourceParameters extends DVIDSourceParameters {
-  level: string;
-};
+export interface VolumeChunkSourceParameters extends DVIDSourceParameters { level: string; }
+;
 
 export enum TileEncoding {
   JPEG
-};
+}
+;
 
 export interface TileChunkSourceParameters extends DVIDSourceParameters {
   dims: string;
   level: string;
   encoding: TileEncoding;
-};
+}
+;
 
 export function volumeSourceToString(parameters: VolumeChunkSourceParameters) {
   return `dvid:volume:${parameters['baseUrls'][0]}/${parameters['nodeKey']}/${parameters['dataInstanceKey']}/${parameters['level']}`;

--- a/src/neuroglancer/datasource/dvid/base.ts
+++ b/src/neuroglancer/datasource/dvid/base.ts
@@ -19,22 +19,18 @@ export interface DVIDSourceParameters {
   nodeKey: string;
   dataInstanceKey: string;
 }
-;
 
 export interface VolumeChunkSourceParameters extends DVIDSourceParameters { level: string; }
-;
 
 export enum TileEncoding {
   JPEG
 }
-;
 
 export interface TileChunkSourceParameters extends DVIDSourceParameters {
   dims: string;
   level: string;
   encoding: TileEncoding;
 }
-;
 
 export function volumeSourceToString(parameters: VolumeChunkSourceParameters) {
   return `dvid:volume:${parameters['baseUrls'][0]}/${parameters['nodeKey']}/${parameters['dataInstanceKey']}/${parameters['level']}`;

--- a/src/neuroglancer/datasource/dvid/frontend.ts
+++ b/src/neuroglancer/datasource/dvid/frontend.ts
@@ -128,12 +128,13 @@ export class TileLevelInfo {
 /**
  * Dimensions for which tiles are computed.
  *
- * FIXME: DVID does not seem to properly indicate which dimensions are available.
+ * DVID does not indicate which dimensions are available but it
+ * provides blank tiles if the dimension asked for is not there.
  */
 const TILE_DIMS = [
   [0, 1],
-  // [0, 2],
-  // [1, 2],
+  [0, 2],
+  [1, 2],
 ];
 
 export class TileChunkSource extends GenericVolumeChunkSource {
@@ -199,10 +200,12 @@ export class TileDataInstanceInfo extends DataInstanceInfo {
       let alternatives = TILE_DIMS.map(dims => {
         let voxelSize = vec3.clone(this.voxelSize);
         let chunkDataSize = vec3.fromValues(1, 1, 1);
-        for (let dim of dims) {
+        // tiles are always NxMx1
+        for (let i = 0; i < 2; ++i) {
           voxelSize[dim] = levelInfo.resolution[dim];
           chunkDataSize[dim] = levelInfo.tileSize[dim];
         }
+
         let chunkLayout = ChunkLayout.get(vec3.multiply(vec3.create(), voxelSize, chunkDataSize));
         let lowerVoxelBound = vec3.create(), upperVoxelBound = vec3.create();
         for (let i = 0; i < 3; ++i) {

--- a/src/neuroglancer/datasource/dvid/frontend.ts
+++ b/src/neuroglancer/datasource/dvid/frontend.ts
@@ -20,16 +20,16 @@
  */
 
 import {ChunkManager} from 'neuroglancer/chunk_manager/frontend';
-import {DVIDSourceParameters, VolumeChunkSourceParameters, volumeSourceToString, TileChunkSourceParameters, tileSourceToString, TileEncoding} from 'neuroglancer/datasource/dvid/base';
-import {registerDataSourceFactory, CompletionResult} from 'neuroglancer/datasource/factory';
-import {DataType, VolumeType, VolumeChunkSpecification} from 'neuroglancer/sliceview/base';
+import {DVIDSourceParameters, TileChunkSourceParameters, TileEncoding, VolumeChunkSourceParameters, tileSourceToString, volumeSourceToString} from 'neuroglancer/datasource/dvid/base';
+import {CompletionResult, registerDataSourceFactory} from 'neuroglancer/datasource/factory';
+import {DataType, VolumeChunkSpecification, VolumeType} from 'neuroglancer/sliceview/base';
 import {ChunkLayout} from 'neuroglancer/sliceview/chunk_layout';
-import {VolumeChunkSource as GenericVolumeChunkSource, MultiscaleVolumeChunkSource as GenericMultiscaleVolumeChunkSource} from 'neuroglancer/sliceview/frontend';
+import {MultiscaleVolumeChunkSource as GenericMultiscaleVolumeChunkSource, VolumeChunkSource as GenericVolumeChunkSource} from 'neuroglancer/sliceview/frontend';
 import {StatusMessage} from 'neuroglancer/status';
 import {applyCompletionOffset, getPrefixMatchesWithDescriptions} from 'neuroglancer/util/completion';
-import {vec3, Vec3} from 'neuroglancer/util/geom';
+import {Vec3, vec3} from 'neuroglancer/util/geom';
 import {openShardedHttpRequest, sendHttpRequest} from 'neuroglancer/util/http_request';
-import {parseFixedLengthArray, parseIntVec, stableStringify, verifyObject, verifyObjectProperty, verifyInt, verifyPositiveInt, verifyString, parseArray, verifyMapKey, verifyFinitePositiveFloat, verifyObjectAsMap} from 'neuroglancer/util/json';
+import {parseArray, parseFixedLengthArray, parseIntVec, stableStringify, verifyFinitePositiveFloat, verifyInt, verifyMapKey, verifyObject, verifyObjectAsMap, verifyObjectProperty, verifyPositiveInt, verifyString} from 'neuroglancer/util/json';
 import {CancellablePromise} from 'neuroglancer/util/promise';
 
 let serverDataTypes = new Map<string, DataType>();
@@ -40,7 +40,7 @@ serverDataTypes.set('uint64', DataType.UINT64);
 export class DataInstanceBaseInfo {
   get typeName(): string { return this.obj['TypeName']; }
 
-  constructor (public obj: any) {
+  constructor(public obj: any) {
     verifyObject(obj);
     verifyObjectProperty(obj, 'TypeName', verifyString);
   }
@@ -52,16 +52,15 @@ export class DataInstanceInfo {
 
 export class VolumeChunkSource extends GenericVolumeChunkSource {
   constructor(
-    chunkManager: ChunkManager, spec: VolumeChunkSpecification, public parameters: VolumeChunkSourceParameters) {
+      chunkManager: ChunkManager, spec: VolumeChunkSpecification,
+      public parameters: VolumeChunkSourceParameters) {
     super(chunkManager, spec);
     this.initializeCounterpart(chunkManager.rpc, {
       'type': 'dvid/VolumeChunkSource',
       'parameters': parameters,
     });
   }
-  toString () {
-    return volumeSourceToString(this.parameters);
-  }
+  toString() { return volumeSourceToString(this.parameters); }
 };
 
 export class VolumeDataInstanceInfo extends DataInstanceInfo {
@@ -71,7 +70,9 @@ export class VolumeDataInstanceInfo extends DataInstanceInfo {
   voxelSize: Vec3;
   numChannels: number;
   numLevels: number;
-  constructor(obj: any, name: string, base: DataInstanceBaseInfo, public volumeType: VolumeType, instanceNames: Array<string>) {
+  constructor(
+      obj: any, name: string, base: DataInstanceBaseInfo, public volumeType: VolumeType,
+      instanceNames: Array<string>) {
     super(obj, name, base);
     let extended = verifyObjectProperty(obj, 'Extended', verifyObject);
     let extendedValues = verifyObjectProperty(extended, 'Values', x => parseArray(x, verifyObject));
@@ -80,12 +81,12 @@ export class VolumeDataInstanceInfo extends DataInstanceInfo {
           'Expected Extended.Values property to have length >= 1, but received: ${JSON.stringify(extendedValues)}.');
     }
     this.numLevels = 1;
-    
+
     // dvid does not have explicit datatype support for multiscale but
     // by convention different levels are specified with unique
-    // instances where levels are distinguished by the suffix '_LEVELNUM'    
+    // instances where levels are distinguished by the suffix '_LEVELNUM'
     let instSet = new Set<string>(instanceNames);
-    while (instSet.has(name + "_" + this.numLevels.toString())) {
+    while (instSet.has(name + '_' + this.numLevels.toString())) {
       this.numLevels += 1;
     }
 
@@ -106,30 +107,43 @@ export class VolumeDataInstanceInfo extends DataInstanceInfo {
     for (let level = 0; level < this.numLevels; ++level) {
       let voxelSize = vec3.clone(this.voxelSize);
       // does not have to correspond to internal dvid chunk size
-      let chunkDataSize = vec3.fromValues(64, 64, 64);
-      voxelSize[0] = voxelSize[0]*Math.pow(2,level)
-      voxelSize[1] = voxelSize[1]*Math.pow(2,level)
-      voxelSize[2] = voxelSize[2]*Math.pow(2,level)
-        
-      let chunkLayout = ChunkLayout.get(vec3.multiply(vec3.create(), voxelSize, chunkDataSize));
-      let lowerVoxelBound = vec3.create(), upperVoxelBound = vec3.create();
+      voxelSize[0] = voxelSize[0] * Math.pow(2, level);
+      voxelSize[1] = voxelSize[1] * Math.pow(2, level);
+      voxelSize[2] = voxelSize[2] * Math.pow(2, level);
+
+      let lowerVoxelBound = vec3.create();
+      let upperVoxelBound = vec3.create();
       for (let i = 0; i < 3; ++i) {
-        lowerVoxelBound[i] = Math.floor(this.lowerVoxelBound[i] * (this.voxelSize[i] / voxelSize[i]));
-        upperVoxelBound[i] = Math.ceil(this.upperVoxelBound[i] * (this.voxelSize[i] / voxelSize[i]));
+        lowerVoxelBound[i] =
+            Math.floor(this.lowerVoxelBound[i] * (this.voxelSize[i] / voxelSize[i]));
+        upperVoxelBound[i] =
+            Math.ceil(this.upperVoxelBound[i] * (this.voxelSize[i] / voxelSize[i]));
       }
-      let spec = new VolumeChunkSpecification(
-          chunkLayout, chunkDataSize, this.numChannels, this.dataType, lowerVoxelBound,
-        upperVoxelBound);
+      let dataInstanceKey = parameters.dataInstanceKey;
+      if (level > 0) {
+        dataInstanceKey += '_' + level.toString();
+      }
+
       let volParameters: VolumeChunkSourceParameters = {
         'baseUrls': parameters.baseUrls,
         'nodeKey': parameters.nodeKey,
-        'dataInstanceKey': parameters.dataInstanceKey,
+        'dataInstanceKey': dataInstanceKey,
         'level': level.toString(),
       };
-      let alternatives = [chunkManager.getChunkSource(
-        VolumeChunkSource, stableStringify(volParameters),
-        () => new VolumeChunkSource(chunkManager, spec, volParameters))];
-      
+      let alternatives = Array
+                             .from(VolumeChunkSpecification.getDefaults({
+                               voxelSize: voxelSize,
+                               dataType: this.dataType,
+                               numChannels: this.numChannels,
+                               lowerVoxelBound: this.lowerVoxelBound,
+                               upperVoxelBound: this.upperVoxelBound,
+                               volumeType: this.volumeType,
+                             }))
+                             .map(spec => {
+                               return chunkManager.getChunkSource(
+                                   VolumeChunkSource, stableStringify(volParameters),
+                                   () => new VolumeChunkSource(chunkManager, spec, volParameters));
+                             });
       sources.push(alternatives);
     }
     return sources;
@@ -144,12 +158,12 @@ export class TileLevelInfo {
   resolution: Vec3;
   tileSize: Vec3;
 
-  constructor (obj: any) {
+  constructor(obj: any) {
     verifyObject(obj);
     this.resolution = verifyObjectProperty(
-      obj, 'Resolution', x => parseFixedLengthArray(vec3.create(), x, verifyFinitePositiveFloat));
+        obj, 'Resolution', x => parseFixedLengthArray(vec3.create(), x, verifyFinitePositiveFloat));
     this.tileSize = verifyObjectProperty(
-      obj, 'TileSize', x => parseFixedLengthArray(vec3.create(), x, verifyPositiveInt));
+        obj, 'TileSize', x => parseFixedLengthArray(vec3.create(), x, verifyPositiveInt));
   }
 };
 
@@ -167,22 +181,21 @@ const TILE_DIMS = [
 
 export class TileChunkSource extends GenericVolumeChunkSource {
   constructor(
-    chunkManager: ChunkManager, spec: VolumeChunkSpecification, public parameters: TileChunkSourceParameters) {
+      chunkManager: ChunkManager, spec: VolumeChunkSpecification,
+      public parameters: TileChunkSourceParameters) {
     super(chunkManager, spec);
     this.initializeCounterpart(chunkManager.rpc, {
       'type': 'dvid/TileChunkSource',
       'parameters': parameters,
     });
   }
-  toString () {
-    return tileSourceToString(this.parameters);
-  }
+  toString() { return tileSourceToString(this.parameters); }
 };
 
 export class TileDataInstanceInfo extends DataInstanceInfo {
-  get dataType () { return DataType.UINT8; }
-  get volumeType () { return VolumeType.IMAGE; }
-  get numChannels () { return 1; }
+  get dataType() { return DataType.UINT8; }
+  get volumeType() { return VolumeType.IMAGE; }
+  get numChannels() { return 1; }
 
   encoding: TileEncoding;
 
@@ -196,10 +209,11 @@ export class TileDataInstanceInfo extends DataInstanceInfo {
   lowerVoxelBound: Vec3;
   upperVoxelBound: Vec3;
 
-  constructor (obj: any, name: string, base: DataInstanceBaseInfo) {
+  constructor(obj: any, name: string, base: DataInstanceBaseInfo) {
     super(obj, name, base);
     let extended = verifyObjectProperty(obj, 'Extended', verifyObject);
-    this.levels = verifyObjectProperty(extended, 'Levels', x => verifyObjectAsMap(x, y => new TileLevelInfo(y)));
+    this.levels = verifyObjectProperty(
+        extended, 'Levels', x => verifyObjectAsMap(x, y => new TileLevelInfo(y)));
     let baseLevel = this.levels.get('0');
     if (baseLevel === undefined) {
       throw new Error(`Level 0 is not defined.`);
@@ -222,7 +236,8 @@ export class TileDataInstanceInfo extends DataInstanceInfo {
     }
   }
 
-  getSources(chunkManager: ChunkManager, parameters: DVIDSourceParameters): GenericVolumeChunkSource[][] {
+  getSources(chunkManager: ChunkManager, parameters: DVIDSourceParameters):
+      GenericVolumeChunkSource[][] {
     let sources: TileChunkSource[][] = [];
     for (let [level, levelInfo] of this.levels) {
       let alternatives = TILE_DIMS.map(dims => {
@@ -237,12 +252,14 @@ export class TileDataInstanceInfo extends DataInstanceInfo {
         let chunkLayout = ChunkLayout.get(vec3.multiply(vec3.create(), voxelSize, chunkDataSize));
         let lowerVoxelBound = vec3.create(), upperVoxelBound = vec3.create();
         for (let i = 0; i < 3; ++i) {
-          lowerVoxelBound[i] = Math.floor(this.lowerVoxelBound[i] * (this.voxelSize[i] / voxelSize[i]));
-          upperVoxelBound[i] = Math.ceil(this.upperVoxelBound[i] * (this.voxelSize[i] / voxelSize[i]));
+          lowerVoxelBound[i] =
+              Math.floor(this.lowerVoxelBound[i] * (this.voxelSize[i] / voxelSize[i]));
+          upperVoxelBound[i] =
+              Math.ceil(this.upperVoxelBound[i] * (this.voxelSize[i] / voxelSize[i]));
         }
         let spec = new VolumeChunkSpecification(
             chunkLayout, chunkDataSize, this.numChannels, this.dataType, lowerVoxelBound,
-          upperVoxelBound);
+            upperVoxelBound);
         let tileParameters: TileChunkSourceParameters = {
           'baseUrls': parameters.baseUrls,
           'nodeKey': parameters.nodeKey,
@@ -252,8 +269,8 @@ export class TileDataInstanceInfo extends DataInstanceInfo {
           'dims': `${dims[0]}_${dims[1]}`,
         };
         return chunkManager.getChunkSource(
-          VolumeChunkSource, stableStringify(tileParameters),
-          () => new TileChunkSource(chunkManager, spec, tileParameters));
+            VolumeChunkSource, stableStringify(tileParameters),
+            () => new TileChunkSource(chunkManager, spec, tileParameters));
       });
       sources.push(alternatives);
     }
@@ -261,20 +278,22 @@ export class TileDataInstanceInfo extends DataInstanceInfo {
   }
 };
 
-export function parseDataInstance(obj: any, name: string, instanceNames: Array<string>): DataInstanceInfo {
+export function parseDataInstance(
+    obj: any, name: string, instanceNames: Array<string>): DataInstanceInfo {
   verifyObject(obj);
   let baseInfo = verifyObjectProperty(obj, 'Base', x => new DataInstanceBaseInfo(x));
   switch (baseInfo.typeName) {
-  case 'uint8blk':
-  case 'grayscale8':
-    return new VolumeDataInstanceInfo(obj, name, baseInfo, VolumeType.IMAGE, instanceNames);
-  case 'imagetile':
-    return new TileDataInstanceInfo(obj, name, baseInfo);
-  case 'labels64':
-  case 'labelblk':
-    return new VolumeDataInstanceInfo(obj, name, baseInfo, VolumeType.SEGMENTATION, instanceNames);
-  default:
-    throw new Error(`DVID data type ${JSON.stringify(baseInfo.typeName)} is not supported.`);
+    case 'uint8blk':
+    case 'grayscale8':
+      return new VolumeDataInstanceInfo(obj, name, baseInfo, VolumeType.IMAGE, instanceNames);
+    case 'imagetile':
+      return new TileDataInstanceInfo(obj, name, baseInfo);
+    case 'labels64':
+    case 'labelblk':
+      return new VolumeDataInstanceInfo(
+          obj, name, baseInfo, VolumeType.SEGMENTATION, instanceNames);
+    default:
+      throw new Error(`DVID data type ${JSON.stringify(baseInfo.typeName)} is not supported.`);
   }
 }
 
@@ -285,22 +304,23 @@ export class RepositoryInfo {
   dataInstances = new Map<string, DataInstanceInfo>();
   uuid: string;
   vnodes = new Set<string>();
-  constructor (obj: any) {
+  constructor(obj: any) {
     if (obj instanceof RepositoryInfo) {
       this.alias = obj.alias;
       this.description = obj.description;
       // just copy references
       this.errors = obj.errors;
-      this.dataInstances = obj.dataInstances; 
-      return;  
-    } 
+      this.dataInstances = obj.dataInstances;
+      return;
+    }
     verifyObject(obj);
     this.alias = verifyObjectProperty(obj, 'Alias', verifyString);
     this.description = verifyObjectProperty(obj, 'Description', verifyString);
     let dataInstanceObjs = verifyObjectProperty(obj, 'DataInstances', verifyObject);
-    for (let key of Object.keys(dataInstanceObjs)) {
+    let instanceKeys = Object.keys(dataInstanceObjs);
+    for (let key of instanceKeys) {
       try {
-        this.dataInstances.set(key, parseDataInstance(dataInstanceObjs[key], key, Object.keys(dataInstanceObjs)));
+        this.dataInstances.set(key, parseDataInstance(dataInstanceObjs[key], key, instanceKeys));
       } catch (parseError) {
         let message = `Failed to parse data instance ${JSON.stringify(key)}: ${parseError.message}`;
         console.log(message);
@@ -311,7 +331,7 @@ export class RepositoryInfo {
     let dagObj = verifyObjectProperty(obj, 'DAG', verifyObject);
     let nodeObjs = verifyObjectProperty(dagObj, 'Nodes', verifyObject);
     for (let key of Object.keys(nodeObjs)) {
-        this.vnodes.add(key);
+      this.vnodes.add(key);
     }
   }
 };
@@ -319,20 +339,20 @@ export class RepositoryInfo {
 export function parseRepositoriesInfo(obj: any) {
   try {
     let result = verifyObjectAsMap(obj, x => new RepositoryInfo(x));
-    
+
     // make all versions available for viewing
     let allVersions = new Map<string, RepositoryInfo>();
     for (let [key, info] of result) {
       allVersions.set(key, info);
       for (let key2 of info.vnodes) {
-        if (key2 != key) {
-          // create new repo 
+        if (key2 !== key) {
+          // create new repo
           let rep = new RepositoryInfo(info);
           allVersions.set(key2, rep);
         }
       }
     }
-    
+
     for (let [key, info] of allVersions) {
       info.uuid = key;
     }
@@ -344,11 +364,9 @@ export function parseRepositoriesInfo(obj: any) {
 
 export class ServerInfo {
   repositories: Map<string, RepositoryInfo>;
-  constructor(obj: any) {
-    this.repositories = parseRepositoriesInfo(obj);
-  }
+  constructor(obj: any) { this.repositories = parseRepositoriesInfo(obj); }
 
-  getNode (nodeKey: string) {
+  getNode(nodeKey: string) {
     // FIXME: Support non-root nodes.
     let matches: string[] = [];
     for (let key of this.repositories.keys()) {
@@ -357,7 +375,8 @@ export class ServerInfo {
       }
     }
     if (matches.length !== 1) {
-      throw new Error(`Node key ${JSON.stringify(nodeKey)} matches ${JSON.stringify(matches)} nodes.`);
+      throw new Error(
+          `Node key ${JSON.stringify(nodeKey)} matches ${JSON.stringify(matches)} nodes.`);
     }
     return this.repositories.get(nodeKey);
   }
@@ -382,9 +401,9 @@ export function getServerInfo(baseUrls: string[]) {
 }
 
 export class MultiscaleVolumeChunkSource implements GenericMultiscaleVolumeChunkSource {
-  get dataType () { return this.info.dataType; }
-  get numChannels () { return this.info.numChannels; }
-  get volumeType () { return this.info.volumeType; }
+  get dataType() { return this.info.dataType; }
+  get numChannels() { return this.info.numChannels; }
+  get volumeType() { return this.info.volumeType; }
 
   constructor(
       public baseUrls: string[], public nodeKey: string, public dataInstanceKey: string,
@@ -392,9 +411,9 @@ export class MultiscaleVolumeChunkSource implements GenericMultiscaleVolumeChunk
 
   getSources(chunkManager: ChunkManager) {
     return this.info.getSources(chunkManager, {
-                    'baseUrls': this.baseUrls,
-                    'nodeKey': this.nodeKey,
-                    'dataInstanceKey': this.dataInstanceKey,
+      'baseUrls': this.baseUrls,
+      'nodeKey': this.nodeKey,
+      'dataInstanceKey': this.dataInstanceKey,
     });
   }
 
@@ -406,27 +425,23 @@ export class MultiscaleVolumeChunkSource implements GenericMultiscaleVolumeChunk
 
 let existingVolumes = new Map<string, MultiscaleVolumeChunkSource>();
 export function getShardedVolume(baseUrls: string[], nodeKey: string, dataInstanceKey: string) {
-  return getServerInfo(baseUrls).then(
-    serverInfo => {
-      let repositoryInfo = serverInfo.getNode(nodeKey);
-      let dataInstanceInfo = repositoryInfo.dataInstances.get(dataInstanceKey);
-      if (!(dataInstanceInfo instanceof VolumeDataInstanceInfo) &&
-          !(dataInstanceInfo instanceof TileDataInstanceInfo)) {
-        throw new Error(`Invalid data instance ${dataInstanceKey}.`);
-      }
-      let cacheKey = stableStringify({
-        'baseUrls': baseUrls,
-        'nodeKey': repositoryInfo.uuid,
-        'dataInstanceKey': dataInstanceKey
-      });
-      let result = existingVolumes.get(cacheKey);
-      if (result === undefined) {
-        result = new MultiscaleVolumeChunkSource(
+  return getServerInfo(baseUrls).then(serverInfo => {
+    let repositoryInfo = serverInfo.getNode(nodeKey);
+    let dataInstanceInfo = repositoryInfo.dataInstances.get(dataInstanceKey);
+    if (!(dataInstanceInfo instanceof VolumeDataInstanceInfo) &&
+        !(dataInstanceInfo instanceof TileDataInstanceInfo)) {
+      throw new Error(`Invalid data instance ${dataInstanceKey}.`);
+    }
+    let cacheKey = stableStringify(
+        {'baseUrls': baseUrls, 'nodeKey': repositoryInfo.uuid, 'dataInstanceKey': dataInstanceKey});
+    let result = existingVolumes.get(cacheKey);
+    if (result === undefined) {
+      result = new MultiscaleVolumeChunkSource(
           baseUrls, repositoryInfo.uuid, dataInstanceKey, dataInstanceInfo);
-        existingVolumes.set(cacheKey, result);
-      }
-      return result;
-    });
+      existingVolumes.set(cacheKey, result);
+    }
+    return result;
+  });
 }
 
 const urlPattern = /^((?:http|https):\/\/[^\/]+)\/([^\/]+)\/([^\/]+)$/;
@@ -439,7 +454,8 @@ export function getVolume(url: string) {
   return getShardedVolume([match[1]], match[2], match[3]);
 }
 
-export function completeInstanceName(repositoryInfo: RepositoryInfo, prefix: string): CompletionResult {
+export function completeInstanceName(
+    repositoryInfo: RepositoryInfo, prefix: string): CompletionResult {
   return {
     offset: 0,
     completions: getPrefixMatchesWithDescriptions<DataInstanceInfo>(


### PR DESCRIPTION
DVID does not have a specific datatype for multi-scale chunk data.  However, a power of two pyramid is created by convention.  For example, for a data instance 'grayscale', 'grayscale_1', 'grayscale_2', etc represents multiple levels.  I made a small modification to the dvid frontend to check for this convention.

As noted by the author, DVID also does not indicate which tiles are available for its imagetile datatype (XY, YZ, and/or XZ).  However, by default, DVID returns a blank tile if nothing is available.  I changed the default to expect all orientations given that the performance is really slow anyway for XZ and YZ if only XY is assumed.

I added some basic parsing of the DVID dag so that the version history can be observed (segmentation can now be viewed at different points in time).  In the future, it might make sense to allow the user to specify the repo id and then choose a specific version.  For now, I just show all the version nodes for every repository in DVID.