### PR TITLE
small change to use neuroglancer-python in nyroglancer, version bump

### DIFF
--- a/python/neuroglancer/__init__.py
+++ b/python/neuroglancer/__init__.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 from __future__ import absolute_import
+from .base_viewer import BaseViewer
 from .server import set_static_content_source, set_server_bind_address, is_server_running, stop
 from .static import dist_dev_static_content_source
 from .viewer import Viewer, view

--- a/python/setup.py
+++ b/python/setup.py
@@ -68,7 +68,7 @@ class bundle_client(build):
 
 setup(
     name = 'neuroglancer',
-    version = '0.0.5',
+    version = '0.0.6',
     description = 'Python data backend for neuroglancer, a WebGL-based viewer for volumetric data',
     author = 'Jeremy Maitin-Shepard, Jan Funke',
     author_email = 'jbms@google.com, jfunke@iri.upc.edu',

--- a/python/setup.py
+++ b/python/setup.py
@@ -10,12 +10,26 @@ static_files = [ 'main.bundle.js', 'chunk_worker.bundle.js', 'styles.css', 'inde
 
 class bundle_client(build):
 
+    user_options = [
+
+        ('client-bundle-type=', None, 'The nodejs bundle type. "min" (default) creates condensed static files for production, "dev" creates human-readable files.')
+    ]
+
+    def initialize_options(self):
+
+        self.client_bundle_type = 'min'
+
+    def finalize_options(self):
+
+        if self.client_bundle_type not in  [ 'min', 'dev' ]:
+            raise RuntimeError('client-bundle-type has to be one of "min" or "dev"')
+
     def run(self):
 
         this_dir = os.path.abspath(os.path.dirname(__file__))
         project_dir = os.path.join(this_dir, '..')
 
-        build_dir = os.path.join(project_dir, 'dist/min')
+        build_dir = os.path.join(project_dir, 'dist/' + self.client_bundle_type)
         static_dir = os.path.join(this_dir, 'neuroglancer/static')
 
         print "Project dir " + project_dir
@@ -25,11 +39,16 @@ class bundle_client(build):
         prev_dir = os.path.abspath('.')
         os.chdir(project_dir)
 
+        target = {
+            "min" : "build-min",
+            "dev" : "build"
+        }
+
         try:
             call(['npm', 'i'])
-            res = call(['npm', 'run', 'build-min'])
+            res = call(['npm', 'run', target[self.client_bundle_type]])
         except:
-            raise RuntimeError('Could not run \'npm run build-min\'. Make sure node.js >= v5.9.0 is installed and in your path.')
+            raise RuntimeError('Could not run \'npm run build-%s\'. Make sure node.js >= v5.9.0 is installed and in your path.' % self.client_bundle_type)
 
         if res != 0:
             raise RuntimeError('failed to bundle neuroglancer node.js project')


### PR DESCRIPTION
This is the current version uploaded to PyPI, 0.0.6, which is now used by nyroglancer.