### PR TITLE
A first pass at render support 

### DIFF
--- a/src/neuroglancer/datasource/render/backend.ts
+++ b/src/neuroglancer/datasource/render/backend.ts
@@ -1,0 +1,55 @@
+/**
+ * @license
+ * Copyright 2016 Google Inc.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {handleChunkDownloadPromise, registerChunkSource} from 'neuroglancer/chunk_manager/backend';
+import {TileChunkSourceParameters} from 'neuroglancer/datasource/render/base';
+import {ParameterizedVolumeChunkSource, VolumeChunk} from 'neuroglancer/sliceview/backend';
+import {ChunkDecoder} from 'neuroglancer/sliceview/backend_chunk_decoders';
+import {decodeJpegChunk} from 'neuroglancer/sliceview/backend_chunk_decoders/jpeg';
+import {openShardedHttpRequest, sendHttpRequest} from 'neuroglancer/util/http_request';
+
+let chunkDecoders = new Map<string, ChunkDecoder>();
+chunkDecoders.set('jpg', decodeJpegChunk);
+
+@registerChunkSource(TileChunkSourceParameters)
+class TileChunkSource extends ParameterizedVolumeChunkSource<TileChunkSourceParameters> {
+  chunkDecoder = chunkDecoders.get(this.parameters.encoding)!;
+
+  download(chunk: VolumeChunk) {
+    let {parameters} = this;
+    let {chunkGridPosition} = chunk;
+
+    // Needed by JPEG decoder.
+    chunk.chunkDataSize = this.spec.chunkDataSize;
+
+    // calculate scale
+    let scale = 1.0 / Math.pow(2, parameters.level);
+
+    let xTile = chunkGridPosition[0] * chunk.chunkDataSize[0];
+    let yTile = chunkGridPosition[1] * chunk.chunkDataSize[1];
+
+    // GET
+    // /v1/owner/{owner}/project/{project}/stack/{stack}/z/{z}/box/{x},{y},{width},{height},{scale}/png-image
+    let path =
+        `/render-ws/v1/owner/${parameters.owner}/project/${parameters.project
+        }/stack/${parameters.stack}/z/${chunkGridPosition[2]}/box/${xTile},${yTile},${chunk
+            .chunkDataSize[0]},${chunk.chunkDataSize[1]},${scale}/jpeg-image`;
+
+    handleChunkDownloadPromise(
+        chunk, sendHttpRequest(openShardedHttpRequest(parameters.baseUrls, path), 'arraybuffer'),
+        this.chunkDecoder);
+  }
+};

--- a/src/neuroglancer/datasource/render/base.ts
+++ b/src/neuroglancer/datasource/render/base.ts
@@ -1,0 +1,36 @@
+/**
+ * @license
+ * Copyright 2016 Google Inc.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export class RenderSourceParameters {
+  baseUrls: string[];
+  owner: string;
+  project: string;
+  stack: string;
+  encoding: string;
+}
+
+export class TileChunkSourceParameters extends RenderSourceParameters {
+  dims: string;
+  level: number;
+  encoding: string;
+
+  static RPC_ID = 'render/TileChunkSource';
+
+  static stringify(parameters: TileChunkSourceParameters) {
+    return `render:tile:${parameters.baseUrls[0]}/${parameters.owner
+        }/${parameters.project}/${parameters.stack}/${parameters.level}/${parameters.encoding}`;
+  }
+}

--- a/src/neuroglancer/datasource/render/frontend.ts
+++ b/src/neuroglancer/datasource/render/frontend.ts
@@ -1,0 +1,342 @@
+/**
+ * @license
+ * Copyright 2016 Google Inc.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @file
+ * Support for Render (https://github.com/saalfeldlab/render) servers.
+ */
+
+import {ChunkManager} from 'neuroglancer/chunk_manager/frontend';
+import {CompletionResult, registerDataSourceFactory} from 'neuroglancer/datasource/factory';
+import {TileChunkSourceParameters} from 'neuroglancer/datasource/render/base';
+import {DataType, VolumeChunkSpecification, VolumeSourceOptions, VolumeType} from 'neuroglancer/sliceview/base';
+import {defineParameterizedVolumeChunkSource, MultiscaleVolumeChunkSource as GenericMultiscaleVolumeChunkSource, VolumeChunkSource} from 'neuroglancer/sliceview/frontend';
+import {applyCompletionOffset, getPrefixMatchesWithDescriptions} from 'neuroglancer/util/completion';
+import {Vec3, vec3} from 'neuroglancer/util/geom';
+import {openShardedHttpRequest, sendHttpRequest} from 'neuroglancer/util/http_request';
+import {parseArray, parseQueryStringParameters, verifyFloat, verifyInt, verifyObject, verifyObjectProperty, verifyOptionalString, verifyString} from 'neuroglancer/util/json';
+import {CancellablePromise, cancellableThen} from 'neuroglancer/util/promise';
+
+const VALID_ENCODINGS = new Set<string>(['jpg']);
+
+const TileChunkSource = defineParameterizedVolumeChunkSource(TileChunkSourceParameters);
+
+interface OwnerInfo {
+  owner: string;
+  stacks: Map<string, StackInfo>;
+}
+
+interface StackInfo {
+  lowerVoxelBound: Vec3;
+  upperVoxelBound: Vec3;
+  voxelResolution: Vec3; /* in nm */
+  mipMapLevels: number;
+  project: string;
+}
+
+function parseOwnerInfo(obj: any): OwnerInfo {
+  let stackObjs = parseArray(obj, verifyObject);
+
+  if (stackObjs.length < 1) {
+    throw new Error(`No stacks found for owner object.`);
+  }
+
+  let stacks = new Map<string, StackInfo>();
+
+  // Get the owner from the first stack
+  let owner = verifyObjectProperty(stackObjs[0], 'stackId', parseStackOwner);
+
+  for (let stackObj of stackObjs) {
+    let stackName = verifyObjectProperty(stackObj, 'stackId', parseStackName);
+
+    stacks.set(stackName, parseStackInfo(stackObj));
+  }
+
+  return {owner, stacks};
+}
+
+function parseStackName(stackIdObj: any): string {
+  verifyObject(stackIdObj);
+  return verifyObjectProperty(stackIdObj, 'stack', verifyString);
+}
+
+function parseStackOwner(stackIdObj: any): string {
+  verifyObject(stackIdObj);
+  return verifyObjectProperty(stackIdObj, 'owner', verifyString);
+}
+
+function parseStackInfo(obj: any): StackInfo {
+  verifyObject(obj);
+  let lowerVoxelBound: Vec3 = verifyObjectProperty(obj, 'stats', parseLowerVoxelBounds);
+  let upperVoxelBound: Vec3 = verifyObjectProperty(obj, 'stats', parseUpperVoxelBounds);
+
+  let voxelResolution: Vec3 = verifyObjectProperty(obj, 'currentVersion', parseStackVersionInfo);
+
+  let mipMapLevels: number =
+      verifyObjectProperty(obj, 'currentMipmapPathBuilder', parseMipMapLevels);
+
+  let project: string = verifyObjectProperty(obj, 'stackId', parseStackProject);
+
+  return {lowerVoxelBound, upperVoxelBound, voxelResolution, mipMapLevels, project};
+}
+
+function parseUpperVoxelBounds(stackStatsObj: any): Vec3 {
+  verifyObject(stackStatsObj);
+  let stackBounds = verifyObjectProperty(stackStatsObj, 'stackBounds', verifyObject);
+
+  let upperVoxelBound: Vec3 = vec3.create();
+
+  upperVoxelBound[0] = verifyObjectProperty(stackBounds, 'maxX', verifyInt);
+  upperVoxelBound[1] = verifyObjectProperty(stackBounds, 'maxY', verifyInt);
+  upperVoxelBound[2] = verifyObjectProperty(stackBounds, 'maxZ', verifyInt);
+
+  for (let i = 0; i < 3; i++) {
+    upperVoxelBound[i] += 1;
+  }
+
+  return upperVoxelBound;
+}
+
+function parseLowerVoxelBounds(stackStatsObj: any): Vec3 {
+  verifyObject(stackStatsObj);
+  let stackBounds = verifyObjectProperty(stackStatsObj, 'stackBounds', verifyObject);
+
+  let lowerVoxelBound: Vec3 = vec3.create();
+
+  lowerVoxelBound[0] = verifyObjectProperty(stackBounds, 'minX', verifyInt);
+  lowerVoxelBound[1] = verifyObjectProperty(stackBounds, 'minY', verifyInt);
+  lowerVoxelBound[2] = verifyObjectProperty(stackBounds, 'minZ', verifyInt);
+
+  return lowerVoxelBound;
+}
+
+function parseStackVersionInfo(stackVersionObj: any): Vec3 {
+  verifyObject(stackVersionObj);
+  let voxelResolution: Vec3 = vec3.create();
+  try {
+    voxelResolution[0] = verifyObjectProperty(stackVersionObj, 'stackResolutionX', verifyFloat);
+    voxelResolution[1] = verifyObjectProperty(stackVersionObj, 'stackResolutionY', verifyFloat);
+    voxelResolution[2] = verifyObjectProperty(stackVersionObj, 'stackResolutionZ', verifyFloat);
+  } catch (ignoredError) {
+    // default is 1, 1, 1
+    voxelResolution[0] = 1;
+    voxelResolution[1] = 1;
+    voxelResolution[2] = 1;
+  }
+
+  return voxelResolution;
+}
+
+function parseMipMapLevels(currentMipMapPathBuilderObj: any): number {
+  let levels = 0;
+  /*
+  try {
+    levels = verifyObjectProperty(currentMipMapPathBuilderObj, 'numberOfLevels', verifyInt);
+  } catch (ignoredError) {
+    // TODO: Something better than console.log for passing messages?
+    console.log('No Mip Map Levels specified. Using default of 0.');
+  }
+  */
+  return levels;
+}
+
+function parseStackProject(stackIdObj: any): string {
+  verifyObject(stackIdObj);
+  return verifyObjectProperty(stackIdObj, 'project', verifyString);
+}
+
+export class MultiscaleVolumeChunkSource implements GenericMultiscaleVolumeChunkSource {
+  get dataType() {
+    return DataType.UINT8;
+  }
+  get numChannels() {
+    return 3;
+  }  // TODO: parse RGB(A) vs single channel
+  get volumeType() {
+    return VolumeType.IMAGE;
+  }
+
+  stack: string;
+  stackInfo: StackInfo;
+
+  dims: Vec3;
+
+  encoding: string;
+
+  constructor(
+      public chunkManager: ChunkManager, public baseUrls: string[], public ownerInfo: OwnerInfo,
+      stack: string|undefined, public parameters: {[index: string]: any}) {
+    if (stack === undefined) {
+      const stackNames = Array.from(ownerInfo.stacks.keys());
+      if (stackNames.length !== 1) {
+        throw new Error(`Dataset contains multiple stacks: ${JSON.stringify(stackNames)}`);
+      }
+      stack = stackNames[0];
+    }
+    const stackInfo = ownerInfo.stacks.get(stack);
+    if (stackInfo === undefined) {
+      throw new Error(`Specified stack ${JSON.stringify(stack)} is not one of the supported stacks ${JSON.stringify(Array.from(ownerInfo.stacks.keys()))}`);
+    }
+    this.stack = stack;
+    this.stackInfo = stackInfo;
+
+    let encoding = verifyOptionalString(parameters['encoding']);
+    if (encoding === undefined) {
+      encoding = 'jpg';
+    } else {
+      if (!VALID_ENCODINGS.has(encoding)) {
+        throw new Error(`Invalid encoding: ${JSON.stringify(encoding)}.`);
+      }
+    }
+    this.encoding = encoding;
+
+    this.dims = vec3.create();
+    this.dims[0] = 512;
+    this.dims[1] = 512;
+    this.dims[2] = 1;
+  }
+
+  getSources(volumeSourceOptions: VolumeSourceOptions) {
+    let sources: VolumeChunkSource[][] = [];
+
+    for (let level = 0; level <= this.stackInfo.mipMapLevels; level++) {
+      let voxelSize = vec3.clone(this.stackInfo.voxelResolution);
+      let chunkDataSize = vec3.fromValues(1, 1, 1);
+      // tiles are NxMx1
+      for (let i = 0; i < 2; ++i) {
+        voxelSize[i] = voxelSize[i] * Math.pow(2, level);
+        chunkDataSize[i] = this.dims[i];
+      }
+
+      let lowerVoxelBound = vec3.create(), upperVoxelBound = vec3.create();
+
+      for (let i = 0; i < 3; i++) {
+        lowerVoxelBound[i] = Math.floor(
+            this.stackInfo.lowerVoxelBound[i] * (this.stackInfo.voxelResolution[i] / voxelSize[i]));
+        upperVoxelBound[i] = Math.ceil(
+            this.stackInfo.upperVoxelBound[i] * (this.stackInfo.voxelResolution[i] / voxelSize[i]));
+      }
+
+      let spec = VolumeChunkSpecification.make({
+        voxelSize,
+        chunkDataSize,
+        numChannels: this.numChannels,
+        dataType: this.dataType, lowerVoxelBound, upperVoxelBound, volumeSourceOptions,
+      });
+
+      let source = TileChunkSource.get(this.chunkManager, spec, {
+        'baseUrls': this.baseUrls,
+        'owner': this.ownerInfo.owner,
+        'project': this.stackInfo.project,
+        'stack': this.stack,
+        'encoding': this.encoding,
+        'level': level,
+        'dims': `${this.dims[0]}_${this.dims[1]}`,
+      });
+
+      sources.push([source]);
+    }
+    return sources;
+  }
+
+  /**
+   * Meshes are not supported.
+   */
+  getMeshSource(): null {
+    return null;
+  }
+};
+
+export function getOwnerInfo(chunkManager: ChunkManager, hostnames: string[], owner: string) {
+  return chunkManager.memoize.getUncounted(
+      {'hostnames': hostnames, 'owner': owner},
+      () => sendHttpRequest(
+                openShardedHttpRequest(hostnames, `/render-ws/v1/owner/${owner}/stacks`), 'json')
+                .then(parseOwnerInfo));
+}
+
+const pathPattern = /^([^\/?]+)(?:\/([^\/?]+))?(?:\/([^\/?]+))?(?:\?(.*))?$/;
+
+export function getShardedVolume(chunkManager: ChunkManager, hostnames: string[], path: string) {
+  const match = path.match(pathPattern);
+  if (match === null) {
+    throw new Error(`Invalid volume path ${JSON.stringify(path)}`);
+  }
+  const owner = match[1];
+  const stack = match[3];
+
+  const parameters = parseQueryStringParameters(match[4] || '');
+
+  return chunkManager.memoize.getUncounted(
+      {'hostnames': hostnames, 'path': path},
+      () => getOwnerInfo(chunkManager, hostnames, owner)
+                .then(
+                    ownerInfo => new MultiscaleVolumeChunkSource(
+                        chunkManager, hostnames, ownerInfo, stack, parameters)));
+}
+
+const urlPattern = /^((?:http|https):\/\/[^\/?]+)\/(.*)$/;
+
+export function getVolume(chunkManager: ChunkManager, path: string) {
+  let match = path.match(urlPattern);
+  if (match === null) {
+    throw new Error(`Invalid render volume path: ${JSON.stringify(path)}`);
+  }
+  return getShardedVolume(chunkManager, [match[1]], match[2]);
+}
+
+export function stackAndProjectCompleter(
+    chunkManager: ChunkManager, hostnames: string[],
+    path: string): CancellablePromise<CompletionResult> {
+  const stackMatch = path.match(/^(?:([^\/]+)(?:\/([^\/]+))\/?(?:\/([^\/]*)))?$/);
+  if (stackMatch === null) {
+    // URL has incorrect format, don't return any results.
+    return Promise.reject<CompletionResult>(null);
+  }
+  if (stackMatch[2] === undefined) {
+    // let projectPrefix = stackMatch[2] || '';
+    // TODO, complete the project? for now reject
+    return Promise.reject<CompletionResult>(null);
+  }
+  return cancellableThen(getOwnerInfo(chunkManager, hostnames, stackMatch[1]), ownerInfo => {
+    let completions =
+        getPrefixMatchesWithDescriptions(stackMatch[3], ownerInfo.stacks, x => x[0], x => {
+          return `${x[1].project}`;
+        });
+    return {offset: stackMatch[1].length + stackMatch[2].length + 2, completions};
+  });
+}
+
+export function volumeCompleter(
+    url: string, chunkManager: ChunkManager): CancellablePromise<CompletionResult> {
+  let match = url.match(urlPattern);
+  if (match === null) {
+    // We don't yet have a full hostname.
+    return Promise.reject<CompletionResult>(null);
+  }
+  let hostnames = [match[1]];
+  let path = match[2];
+
+  return cancellableThen(
+      stackAndProjectCompleter(chunkManager, hostnames, path),
+      completions => applyCompletionOffset(match![1].length + 1, completions));
+}
+
+registerDataSourceFactory('render', {
+  description: 'Render',
+  volumeCompleter: volumeCompleter,
+  getVolume: getVolume,
+});

--- a/src/neuroglancer/sliceview/backend_chunk_decoders/jpeg.ts
+++ b/src/neuroglancer/sliceview/backend_chunk_decoders/jpeg.ts
@@ -19,5 +19,5 @@ import {postProcessRawData} from 'neuroglancer/sliceview/backend_chunk_decoders/
 import {decodeJpegStack} from 'neuroglancer/sliceview/decode_jpeg_stack';
 
 export function decodeJpegChunk(chunk: VolumeChunk, response: ArrayBuffer) {
-  postProcessRawData(chunk, decodeJpegStack(new Uint8Array(response), chunk.chunkDataSize!));
+  postProcessRawData(chunk, decodeJpegStack(new Uint8Array(response), chunk.chunkDataSize!, chunk.source!.spec.numChannels));
 }

--- a/src/neuroglancer/sliceview/decode_jpeg_stack.ts
+++ b/src/neuroglancer/sliceview/decode_jpeg_stack.ts
@@ -15,19 +15,28 @@
  */
 
 import {JpegDecoder} from 'jpgjs';
-import {Vec3, vec3} from 'neuroglancer/util/geom';
+import {vec3} from 'neuroglancer/util/geom';
+import {transposeArray2d} from 'neuroglancer/util/array';
 
-export function decodeJpegStack(data: Uint8Array, chunkDataSize: Vec3) {
+export function decodeJpegStack(data: Uint8Array, chunkDataSize: vec3, numComponents: number) {
   let parser = new JpegDecoder();
   parser.parse(data);
-  if (parser.numComponents !== 1) {
-    throw new Error('JPEG data does not have the expected number of components');
-  }
-
   // Just check that the total number pixels matches the expected value.
   if (parser.width * parser.height !== chunkDataSize[0] * chunkDataSize[1] * chunkDataSize[2]) {
     throw new Error(
         `JPEG data does not have the expected dimensions: width=${parser.width}, height=${parser.height}, chunkDataSize=${vec3.str(chunkDataSize)}`);
   }
-  return parser.getData(parser.width, parser.height, /*forceRGBOutput=*/false);
+  if (parser.numComponents !== numComponents) {
+    throw new Error(
+        `JPEG data does not have the expected number of components: components=${parser.numComponents}, expected=${numComponents}`);
+  }
+  if (parser.numComponents === 1) {
+    return parser.getData(parser.width, parser.height, /*forceRGBOutput=*/false);
+  } else if (parser.numComponents === 3) {
+    let output = parser.getData(parser.width, parser.height, /*forceRGBOutput=*/false);
+    return transposeArray2d(output, parser.width, parser.height);
+  } else {
+    throw new Error(
+      `JPEG data has an unsupported number of components: components=${parser.numComponents}`);
+  }
 }

--- a/src/neuroglancer/util/array.spec.ts
+++ b/src/neuroglancer/util/array.spec.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {partitionArray} from 'neuroglancer/util/array';
+import {partitionArray, transposeArray2d} from 'neuroglancer/util/array';
 
 describe('partitionArray', () => {
   it('basic test', () => {
@@ -23,4 +23,36 @@ describe('partitionArray', () => {
     expect(arr).toEqual([0, 1, 2, 8, 4, 6, 7, 5, 3, 9, 10]);
     expect(newEnd).toBe(6);
   });
+});
+
+describe('transposeArray2d', () => {
+
+  it('square', () => {
+    let arr = new Uint8Array(4), out = new Uint8Array(4);
+    arr.set([0, 1, 2, 3]);
+    out.set([0, 2, 1, 3]);
+    expect(transposeArray2d(arr, 2, 2)).toEqual(out);
+  });
+
+  it('minor > major rectangle', () => {
+    let arr = new Uint8Array(6), out = new Uint8Array(6);
+    arr.set([0, 1, 2, 3, 4, 5]);
+    out.set([0, 3, 1, 4, 2, 5]);
+    expect(transposeArray2d(arr, 2, 3)).toEqual(out);
+  });
+
+  it('major > minor rectangle', () => {
+    let arr = new Uint8Array(8), out = new Uint8Array(8);
+    arr.set([0, 1, 2, 3, 4, 5, 6, 7]);
+    out.set([0, 2, 4, 6, 1, 3, 5, 7]);
+    expect(transposeArray2d(arr, 4, 2)).toEqual(out);
+  });
+
+  it('single axis', () => {
+    let arr = new Uint8Array(3), out = new Uint8Array(3);
+    arr.set([0, 1, 2]);
+    out.set([0, 1, 2]);
+    expect(transposeArray2d(arr, 3, 1)).toEqual(out);
+  });
+
 });

--- a/src/neuroglancer/util/array.ts
+++ b/src/neuroglancer/util/array.ts
@@ -77,3 +77,18 @@ export function getFortranOrderStrides(size: ArrayLike<number>, baseStride = 1) 
   }
   return strides;
 }
+
+/**
+ * Converts an array of shape [majorSize, minorSize] to 
+ * [minorSize, majorSize].
+ */
+export function transposeArray2d<T extends TypedArray>(array: T, majorSize: number, minorSize: number): T {
+  let transpose = new (<any>array.constructor)(array.length);
+  for (let i = 0; i < majorSize * minorSize; i += minorSize) {
+    for (let j = 0; j < minorSize; j++) {
+      let index: number = i / minorSize;
+      transpose[j * majorSize + index] = array[i + j];
+    }
+  }
+  return transpose;
+}


### PR DESCRIPTION
This pull request adds support for render (https://github.com/saalfeldlab/render) as a datasource. Major features are complete, including stack name auto-completion in the add dialogue, metadata parsing from render, and of course displaying render tiles. The major incomplete feature is handling multi-scale render data (i.e. render data w/ generated mipmaps). 

decode_jpeg_stack has also been modified to support 3-channel (RGB) jpegs. A test was added in decode_jpeg_stack.spec.ts. 