### PR TITLE
fix(render): incorrect transpose arguments when decoding jpeg stack

### DIFF
--- a/config/webpack_helpers.js
+++ b/config/webpack_helpers.js
@@ -59,6 +59,7 @@ const DEFAULT_DATA_SOURCES = exports.DEFAULT_DATA_SOURCES = [
   'neuroglancer/datasource/brainmaps',
   'neuroglancer/datasource/ndstore',
   'neuroglancer/datasource/dvid',
+  'neuroglancer/datasource/render',
   'neuroglancer/datasource/openconnectome',
   'neuroglancer/datasource/precomputed',
   'neuroglancer/datasource/python',

--- a/src/neuroglancer/sliceview/decode_jpeg_stack.ts
+++ b/src/neuroglancer/sliceview/decode_jpeg_stack.ts
@@ -34,7 +34,7 @@ export function decodeJpegStack(data: Uint8Array, chunkDataSize: vec3, numCompon
     return parser.getData(parser.width, parser.height, /*forceRGBOutput=*/false);
   } else if (parser.numComponents === 3) {
     let output = parser.getData(parser.width, parser.height, /*forceRGBOutput=*/false);
-    return transposeArray2d(output, parser.width, parser.height);
+    return transposeArray2d(output, parser.width * parser.height, 3);
   } else {
     throw new Error(
       `JPEG data has an unsupported number of components: components=${parser.numComponents}`);


### PR DESCRIPTION
Added render datasource files to the webpack configuration. In addition, the arguments to the transpose function in decode_jpeg_stack for 3 channel jpegs were incorrect. The major axis should be width*height, and the minor axis is 3.

Sorry about that -- not sure how that bug slipped through the original pull request. 