### PR TITLE
NDStore v1.1.0 compatibility 

### DIFF
--- a/src/neuroglancer/datasource/ndstore/backend.ts
+++ b/src/neuroglancer/datasource/ndstore/backend.ts
@@ -43,10 +43,12 @@ class VolumeChunkSource extends ParameterizedVolumeChunkSource<VolumeChunkSource
       let chunkPosition = this.computeChunkBounds(chunk);
       let chunkDataSize = chunk.chunkDataSize!;
       for (let i = 0; i < 3; ++i) {
-        path += `/${chunkPosition[i]},${chunkPosition[i] + chunkDataSize[i]}`;
+        path += `/${chunkPosition[i]},${chunkPosition[i] + chunkDataSize[i]}/`;
       }
     }
-    path += `/neariso/`;
+    if (parameters.neariso) {
+      path += `neariso/`;
+    }
     return sendHttpRequest(
                openShardedHttpRequest(parameters.baseUrls, path), 'arraybuffer', cancellationToken)
         .then(response => this.chunkDecoder(chunk, response));

--- a/src/neuroglancer/datasource/ndstore/backend.ts
+++ b/src/neuroglancer/datasource/ndstore/backend.ts
@@ -35,7 +35,7 @@ class VolumeChunkSource extends ParameterizedVolumeChunkSource<VolumeChunkSource
 
   download(chunk: VolumeChunk, cancellationToken: CancellationToken) {
     let {parameters} = this;
-    let path = `/ocp/ca/${parameters.key}/${parameters.channel}/` +
+    let path = `/nd/sd/${parameters.key}/${parameters.channel}/` +
         `${parameters.encoding}/${parameters.resolution}`;
     {
       // chunkPosition must not be captured, since it will be invalidated by the next call to

--- a/src/neuroglancer/datasource/ndstore/backend.ts
+++ b/src/neuroglancer/datasource/ndstore/backend.ts
@@ -43,11 +43,11 @@ class VolumeChunkSource extends ParameterizedVolumeChunkSource<VolumeChunkSource
       let chunkPosition = this.computeChunkBounds(chunk);
       let chunkDataSize = chunk.chunkDataSize!;
       for (let i = 0; i < 3; ++i) {
-        path += `/${chunkPosition[i]},${chunkPosition[i] + chunkDataSize[i]}/`;
+        path += `/${chunkPosition[i]},${chunkPosition[i] + chunkDataSize[i]}`;
       }
     }
     if (parameters.neariso) {
-      path += `neariso/`;
+      path += `/neariso/`;
     }
     return sendHttpRequest(
                openShardedHttpRequest(parameters.baseUrls, path), 'arraybuffer', cancellationToken)

--- a/src/neuroglancer/datasource/ndstore/base.ts
+++ b/src/neuroglancer/datasource/ndstore/base.ts
@@ -20,7 +20,7 @@ export class VolumeChunkSourceParameters {
   channel: string;
   resolution: string;
   encoding: string;
-  neariso: boolean; 
+  neariso: boolean;
 
   static RPC_ID = 'ndstore/VolumeChunkSource';
 

--- a/src/neuroglancer/datasource/ndstore/base.ts
+++ b/src/neuroglancer/datasource/ndstore/base.ts
@@ -20,6 +20,7 @@ export class VolumeChunkSourceParameters {
   channel: string;
   resolution: string;
   encoding: string;
+  neariso: boolean; 
 
   static RPC_ID = 'ndstore/VolumeChunkSource';
 

--- a/src/neuroglancer/datasource/ndstore/frontend.ts
+++ b/src/neuroglancer/datasource/ndstore/frontend.ts
@@ -120,6 +120,7 @@ export class MultiscaleVolumeChunkSource implements GenericMultiscaleVolumeChunk
   scales: ScaleInfo[];
 
   encoding: string;
+  neariso: boolean;
 
   constructor(
       public chunkManager: ChunkManager, public baseUrls: string[], public key: string,
@@ -150,6 +151,13 @@ export class MultiscaleVolumeChunkSource implements GenericMultiscaleVolumeChunk
       }
     }
     this.encoding = encoding;
+
+    this.neariso = true; 
+    let neariso = verifyOptionalString(parameters['neariso']);
+    if (neariso === 'false') {
+      this.neariso = false; 
+    } 
+
   }
 
   getSources(volumeSourceOptions: VolumeSourceOptions) {
@@ -175,6 +183,7 @@ export class MultiscaleVolumeChunkSource implements GenericMultiscaleVolumeChunk
             channel: this.channel,
             resolution: scaleInfo.key,
             encoding: this.encoding,
+            neariso: this.neariso
           }));
     });
   }

--- a/src/neuroglancer/datasource/ndstore/frontend.ts
+++ b/src/neuroglancer/datasource/ndstore/frontend.ts
@@ -190,7 +190,7 @@ const pathPattern = /^([^\/?]+)(?:\/([^\/?]+))?(?:\?(.*))?$/;
 export function getTokenInfo(chunkManager: ChunkManager, hostnames: string[], token: string): Promise<TokenInfo> {
   return chunkManager.memoize.getUncounted(
       {type: 'ndstore:getTokenInfo', hostnames, token},
-      () => sendHttpRequest(openShardedHttpRequest(hostnames, `/ocp/ca/${token}/info/`), 'json')
+      () => sendHttpRequest(openShardedHttpRequest(hostnames, `/nd/sd/${token}/info/`), 'json')
                 .then(parseTokenInfo));
 }
 
@@ -225,7 +225,7 @@ export function getVolume(chunkManager: ChunkManager, path: string) {
 export function getPublicTokens(chunkManager: ChunkManager, hostnames: string[]) {
   return chunkManager.memoize.getUncounted(
       {type: 'dvid:getPublicTokens', hostnames},
-      () => sendHttpRequest(openShardedHttpRequest(hostnames, '/ocp/ca/public_tokens/'), 'json')
+      () => sendHttpRequest(openShardedHttpRequest(hostnames, '/nd/sd/public_tokens/'), 'json')
                 .then(value => parseArray(value, verifyString)));
 }
 

--- a/src/neuroglancer/datasource/ndstore/frontend.ts
+++ b/src/neuroglancer/datasource/ndstore/frontend.ts
@@ -152,11 +152,11 @@ export class MultiscaleVolumeChunkSource implements GenericMultiscaleVolumeChunk
     }
     this.encoding = encoding;
 
-    this.neariso = true; 
+    this.neariso = true;
     let neariso = verifyOptionalString(parameters['neariso']);
     if (neariso === 'false') {
-      this.neariso = false; 
-    } 
+      this.neariso = false;
+    }
 
   }
 


### PR DESCRIPTION
This pull request makes two small changes for compatibility with data stored in the latest version of NDStore. First, all URLs have been changed from `ocp/ca` to `nd/sd`. Second, a parameter has been added to allow the user to disable neariso tables and access data from the standard resolution hierarchy if a given project does not have neariso tables generated. 