### PR TITLE
Render datasource fixes

### DIFF
--- a/src/neuroglancer/datasource/render/frontend.ts
+++ b/src/neuroglancer/datasource/render/frontend.ts
@@ -180,6 +180,7 @@ export class MultiscaleVolumeChunkSource implements GenericMultiscaleVolumeChunk
   dims: vec3;
 
   encoding: string;
+  numLevels: number|undefined;
 
   constructor(
       public chunkManager: ChunkManager, public baseUrls: string[], public ownerInfo: OwnerInfo,
@@ -215,6 +216,8 @@ export class MultiscaleVolumeChunkSource implements GenericMultiscaleVolumeChunk
     }
     this.encoding = encoding;
 
+    this.numLevels = verifyOptionalInt(parameters['numlevels']);
+
     this.dims = vec3.create();
 
     let tileSize = verifyOptionalInt(parameters['tilesize']);
@@ -230,7 +233,10 @@ export class MultiscaleVolumeChunkSource implements GenericMultiscaleVolumeChunk
   getSources(volumeSourceOptions: VolumeSourceOptions) {
     let sources: VolumeChunkSource[][] = [];
 
-    let numLevels = computeStackHierarchy(this.stackInfo, this.dims[0]);
+    let numLevels = this.numLevels; 
+    if (numLevels === undefined) {
+      numLevels = computeStackHierarchy(this.stackInfo, this.dims[0]);
+    }
 
     for (let level = 0; level < numLevels; level++) {
       let voxelSize = vec3.clone(this.stackInfo.voxelResolution);

--- a/src/neuroglancer/datasource/render/frontend.ts
+++ b/src/neuroglancer/datasource/render/frontend.ts
@@ -24,7 +24,7 @@ import {CompletionResult, registerDataSourceFactory} from 'neuroglancer/datasour
 import {TileChunkSourceParameters} from 'neuroglancer/datasource/render/base';
 import {DataType, VolumeChunkSpecification, VolumeSourceOptions, VolumeType} from 'neuroglancer/sliceview/base';
 import {defineParameterizedVolumeChunkSource, MultiscaleVolumeChunkSource as GenericMultiscaleVolumeChunkSource, VolumeChunkSource} from 'neuroglancer/sliceview/frontend';
-import {applyCompletionOffset, getPrefixMatchesWithDescriptions} from 'neuroglancer/util/completion';
+import {applyCompletionOffset, getPrefixMatchesWithDescriptions, getPrefixMatches} from 'neuroglancer/util/completion';
 import {vec3} from 'neuroglancer/util/geom';
 import {openShardedHttpRequest, sendHttpRequest} from 'neuroglancer/util/http_request';
 import {parseArray, parseQueryStringParameters, verifyFloat, verifyInt, verifyOptionalInt, verifyObject, verifyObjectProperty, verifyOptionalString, verifyString} from 'neuroglancer/util/json';
@@ -37,6 +37,10 @@ const VALID_STACK_STATES = new Set<string>(['COMPLETE']);
 
 interface OwnerInfo {
   owner: string;
+  projects: Map<string, ProjectInfo>;
+}
+
+interface ProjectInfo {
   stacks: Map<string, StackInfo>;
 }
 
@@ -54,20 +58,29 @@ function parseOwnerInfo(obj: any): OwnerInfo {
     throw new Error(`No stacks found for owner object.`);
   }
 
-  let stacks = new Map<string, StackInfo>();
-
+  let projects = new Map<string, ProjectInfo>();
   // Get the owner from the first stack
   let owner = verifyObjectProperty(stackObjs[0], 'stackId', parseStackOwner);
 
   for (let stackObj of stackObjs) {
     let stackName = verifyObjectProperty(stackObj, 'stackId', parseStackName);
     let stackInfo = parseStackInfo(stackObj);
+
     if (stackInfo !== undefined) {
-      stacks.set(stackName, stackInfo);
+      let projectName = stackInfo.project;
+      let projectInfo = projects.get(projectName);
+
+      if (projectInfo === undefined) {
+        let stacks = new Map<string, StackInfo>();
+        projects.set(projectName, {stacks});
+        projectInfo = projects.get(projectName);
+      }
+
+      projectInfo!.stacks.set(stackName, stackInfo);
     }
   }
 
-  return {owner, stacks};
+  return {owner, projects};
 }
 
 function parseStackName(stackIdObj: any): string {
@@ -170,19 +183,24 @@ export class MultiscaleVolumeChunkSource implements GenericMultiscaleVolumeChunk
 
   constructor(
       public chunkManager: ChunkManager, public baseUrls: string[], public ownerInfo: OwnerInfo,
-      stack: string|undefined, public parameters: {[index: string]: any}) {
+      stack: string|undefined, public project: string, public parameters: {[index: string]: any}) {
+    let projectInfo = ownerInfo.projects.get(project);
+    if (projectInfo === undefined) {
+      throw new Error(`Specificed project ${JSON.stringify(project)} does not exist for specified owner ${JSON.stringify(ownerInfo.owner)}`);
+    }
+
     if (stack === undefined) {
-      const stackNames = Array.from(ownerInfo.stacks.keys());
+      const stackNames = Array.from(projectInfo.stacks.keys());
       if (stackNames.length !== 1) {
         throw new Error(`Dataset contains multiple stacks: ${JSON.stringify(stackNames)}`);
       }
       stack = stackNames[0];
     }
-    const stackInfo = ownerInfo.stacks.get(stack);
+    const stackInfo = projectInfo.stacks.get(stack);
     if (stackInfo === undefined) {
       throw new Error(
           `Specified stack ${JSON.stringify(stack)} is not one of the supported stacks: ` +
-          JSON.stringify(Array.from(ownerInfo.stacks.keys())));
+          JSON.stringify(Array.from(projectInfo.stacks.keys())));
     }
     this.stack = stack;
     this.stackInfo = stackInfo;
@@ -201,7 +219,8 @@ export class MultiscaleVolumeChunkSource implements GenericMultiscaleVolumeChunk
 
     let tileSize = verifyOptionalInt(parameters['tilesize']);
     if (tileSize === undefined) {
-      tileSize = 1024; // Default tile size is 1024 x 1024 
+      // Default tile size is 1024 x 1024
+      tileSize = 1024;
     }
     this.dims[0] = tileSize;
     this.dims[1] = tileSize;
@@ -294,6 +313,7 @@ export function getShardedVolume(chunkManager: ChunkManager, hostnames: string[]
     throw new Error(`Invalid volume path ${JSON.stringify(path)}`);
   }
   const owner = match[1];
+  const project = match[2];
   const stack = match[3];
 
   const parameters = parseQueryStringParameters(match[4] || '');
@@ -303,34 +323,47 @@ export function getShardedVolume(chunkManager: ChunkManager, hostnames: string[]
       () => getOwnerInfo(chunkManager, hostnames, owner)
                 .then(
                     ownerInfo => new MultiscaleVolumeChunkSource(
-                        chunkManager, hostnames, ownerInfo, stack, parameters)));
+                        chunkManager, hostnames, ownerInfo, stack, project, parameters)));
 }
 
-const urlPattern = /^((?:http|https):\/\/[^\/?]+)\/(.*)$/;
+const urlPattern = /^((?:(?:(?:http|https):\/\/[^,\/]+)[^\/?])+)\/(.*)$/;
 
 export function getVolume(chunkManager: ChunkManager, path: string) {
   let match = path.match(urlPattern);
   if (match === null) {
     throw new Error(`Invalid render volume path: ${JSON.stringify(path)}`);
   }
-  return getShardedVolume(chunkManager, [match[1]], match[2]);
+  let hostnames: string[] = match[1].split(',');
+  return getShardedVolume(chunkManager, hostnames, match[2]);
 }
 
 export function stackAndProjectCompleter(
     chunkManager: ChunkManager, hostnames: string[], path: string): Promise<CompletionResult> {
-  const stackMatch = path.match(/^(?:([^\/]+)(?:\/([^\/]+))\/?(?:\/([^\/]*)))?$/);
+
+  const stackMatch = path.match(/^(?:([^\/]+)(?:\/([^\/]*))?(?:\/([^\/]*))?)?$/);
   if (stackMatch === null) {
     // URL has incorrect format, don't return any results.
     return Promise.reject<CompletionResult>(null);
   }
   if (stackMatch[2] === undefined) {
-    // let projectPrefix = stackMatch[2] || '';
-    // TODO, complete the project? for now reject
+    // Don't autocomplete the owner
     return Promise.reject<CompletionResult>(null);
   }
+  if (stackMatch[3] === undefined) {
+    // Try to complete the project
+    return getOwnerInfo(chunkManager, hostnames, stackMatch[1]).then(ownerInfo => {
+      let completions =
+              getPrefixMatchesWithDescriptions(stackMatch[2], ownerInfo.projects, x => x[0] + '/', () => undefined);
+      return {offset: stackMatch[1].length + 1, completions};
+    });
+  }
   return getOwnerInfo(chunkManager, hostnames, stackMatch[1]).then(ownerInfo => {
+    let projectInfo = ownerInfo.projects.get(stackMatch[2]);
+    if (projectInfo === undefined) {
+      return Promise.reject<CompletionResult>(null);
+    }
     let completions =
-        getPrefixMatchesWithDescriptions(stackMatch[3], ownerInfo.stacks, x => x[0], x => {
+        getPrefixMatchesWithDescriptions(stackMatch[3], projectInfo.stacks, x => x[0], x => {
           return `${x[1].project}`;
         });
     return {offset: stackMatch[1].length + stackMatch[2].length + 2, completions};
@@ -344,7 +377,7 @@ export function volumeCompleter(
     // We don't yet have a full hostname.
     return Promise.reject<CompletionResult>(null);
   }
-  let hostnames = [match[1]];
+  let hostnames: string[] = match[1].split(',');
   let path = match[2];
 
   return stackAndProjectCompleter(chunkManager, hostnames, path)


### PR DESCRIPTION
The most important fix here is proper autocompletion of projects and remediation of a bug that prevented proper handling of two stacks with the same project name. A numlevels parameter has also been added to override the number of generated mipmap levels pending better support for automatically retrieving that information from Render. Typically one would use this parameter to set the number of mipmap levels to 0 for datasets without generated mipmaps.