### PR TITLE
Update brainmaps datasources to use new binary endpoints. 

### DIFF
--- a/src/neuroglancer/datasource/brainmaps/api.ts
+++ b/src/neuroglancer/datasource/brainmaps/api.ts
@@ -26,6 +26,46 @@ export const PRODUCTION_INSTANCE = 0;
 export const INSTANCE_NAMES: string[] = [];
 
 /**
+ * API-related interfaces.
+ */
+
+export interface ChangeSpecPayload {
+  change_stack_id?: string;
+  time_stamp?: number;
+  skip_equivalences?: boolean;
+}
+
+export interface ChangeStackAwarePayload {
+  change_spec?: ChangeSpecPayload;
+}
+
+export interface GeometryPayload {
+  corner: string;
+  size: string;
+  scale: number;
+}
+
+export interface GeometryAwarePayload {
+  geometry: GeometryPayload;
+}
+
+export interface ImageFormatOptionsPayload {
+  image_format?: 'AUTO'|'JPEG'|'PNG'|'JSON';
+  jpeg_quality?: number;
+  compressed_segmentation_block_size?: string;
+}
+
+export interface SubvolumePayload extends ChangeStackAwarePayload, GeometryAwarePayload {
+  image_format_options?: ImageFormatOptionsPayload;
+  subvolume_format?: 'RAW'|'SINGLE_IMAGE';
+}
+
+export interface MeshFragmentPayload extends ChangeStackAwarePayload {
+  fragment_key: string;
+  object_id: string;
+}
+
+/**
  * Maps a BrainmapsInstance to the list of base URL shards to use for accessing it.
  */
 export const INSTANCE_BASE_URLS: string[][] = [];
@@ -48,18 +88,26 @@ export function setupBrainmapsInstance(
 
 setupBrainmapsInstance(PRODUCTION_INSTANCE, 'brainmaps.googleapis.com', 'prod', 'Brain Maps');
 
+export interface HttpCall {
+  method: 'GET'|'POST';
+  path: string;
+  responseType: 'arraybuffer'|'json'|string;
+  payload?: string;
+}
+
+
 export function makeRequest(
-    instance: BrainmapsInstance, method: string, path: string, responseType: 'arraybuffer',
+    instance: BrainmapsInstance, httpCall: HttpCall,
     cancellationToken?: CancellationToken): Promise<ArrayBuffer>;
 export function makeRequest(
-    instance: BrainmapsInstance, method: string, path: string, responseType: 'json',
+    instance: BrainmapsInstance, httpCall: HttpCall,
     cancellationToken?: CancellationToken): Promise<any>;
 export function makeRequest(
-    instance: BrainmapsInstance, method: string, path: string, responseType: string,
+    instance: BrainmapsInstance, httpCall: HttpCall,
     cancellationToken?: CancellationToken): any;
 
 export function makeRequest(
-    instance: BrainmapsInstance, method: string, path: string, responseType: string,
+    instance: BrainmapsInstance, httpCall: HttpCall,
     cancellationToken: CancellationToken = uncancelableToken): any {
   /**
    * undefined means request not yet attempted.  null means request
@@ -81,8 +129,8 @@ export function makeRequest(
         --numPendingRequests;
         return;
       }
-      xhr = openShardedHttpRequest(INSTANCE_BASE_URLS[instance], path, method);
-      xhr.responseType = responseType;
+      xhr = openShardedHttpRequest(INSTANCE_BASE_URLS[instance], httpCall.path, httpCall.method);
+      xhr.responseType = httpCall.responseType;
       xhr.setRequestHeader('Authorization', `${token['tokenType']} ${token['accessToken']}`);
       xhr.onloadend = function(this: XMLHttpRequest) {
         if (xhr === null) {
@@ -103,7 +151,7 @@ export function makeRequest(
           reject(HttpError.fromXhr(this));
         }
       };
-      xhr.send();
+      xhr.send(httpCall.payload);
     }
     getToken().then(start);
   });

--- a/src/neuroglancer/datasource/brainmaps/backend.ts
+++ b/src/neuroglancer/datasource/brainmaps/backend.ts
@@ -17,7 +17,7 @@
 import 'neuroglancer/datasource/brainmaps/api_backend';
 
 import {registerChunkSource} from 'neuroglancer/chunk_manager/backend';
-import {makeRequest} from 'neuroglancer/datasource/brainmaps/api';
+import {makeRequest, HttpCall, ChangeSpecPayload, ChangeStackAwarePayload, MeshFragmentPayload, SubvolumePayload} from 'neuroglancer/datasource/brainmaps/api';
 import {ChangeSpec, MeshSourceParameters, SkeletonSourceParameters, VolumeChunkEncoding, VolumeSourceParameters} from 'neuroglancer/datasource/brainmaps/base';
 import {decodeJsonManifestChunk, decodeTriangleVertexPositionsAndIndices, FragmentChunk, ManifestChunk, ParameterizedMeshSource} from 'neuroglancer/mesh/backend';
 import {decodeSkeletonVertexPositionsAndIndices, ParameterizedSkeletonSource, SkeletonChunk} from 'neuroglancer/skeleton/backend';
@@ -29,90 +29,92 @@ import {CancellationToken} from 'neuroglancer/util/cancellation';
 import {Endianness} from 'neuroglancer/util/endian';
 import {vec3Key} from 'neuroglancer/util/geom';
 import {verifyObject, verifyObjectProperty, verifyStringArray} from 'neuroglancer/util/json';
-import {inflate} from 'pako';
-
-export function decodeGzippedRawChunk(chunk: VolumeChunk, response: ArrayBuffer) {
-  decodeRawChunk(chunk, inflate(new Uint8Array(response)).buffer);
-}
-
-export function decodeGzippedCompressedSegmentationChunk(
-    chunk: VolumeChunk, response: ArrayBuffer) {
-  decodeCompressedSegmentationChunk(chunk, inflate(new Uint8Array(response)).buffer);
-}
 
 const CHUNK_DECODERS = new Map([
   [
     VolumeChunkEncoding.RAW,
-    decodeGzippedRawChunk,
+    decodeRawChunk,
   ],
   [VolumeChunkEncoding.JPEG, decodeJpegChunk],
   [
     VolumeChunkEncoding.COMPRESSED_SEGMENTATION,
-    decodeGzippedCompressedSegmentationChunk,
+    decodeCompressedSegmentationChunk,
   ]
 ]);
 
-function getChangeStackParams(changeStack: ChangeSpec|undefined) {
-  let result = '';
-  if (changeStack !== undefined) {
-    result += `/change_spec.change_stack_id=${changeStack.changeStackId}`;
-    if (changeStack.timeStamp !== undefined) {
-      result += `/change_spec.time_stamp=${Math.round(changeStack.timeStamp)}`;
-    }
-    if (changeStack.skipEquivalences) {
-      result += `/change_spec.skip_equivalences=true`;
-    }
+function applyChangeStack(changeStack: ChangeSpec|undefined, payload: ChangeStackAwarePayload) {
+  if (!changeStack) {
+    return;
   }
-  return result;
+  payload.change_spec = {
+    change_stack_id: changeStack.changeStackId,
+  };
+  if (changeStack.timeStamp) {
+    payload.change_spec.time_stamp = changeStack.timeStamp;
+  }
+  if (changeStack.skipEquivalences) {
+    payload.change_spec.skip_equivalences = changeStack.skipEquivalences;
+  }
 }
 
 @registerChunkSource(VolumeSourceParameters)
 class VolumeChunkSource extends ParameterizedVolumeChunkSource<VolumeSourceParameters> {
-  extraParams = this.getExtraParams();
   chunkDecoder = CHUNK_DECODERS.get(this.parameters.encoding)!;
 
-  private getEncodingParams() {
+  private applyEncodingParams(payload: SubvolumePayload) {
     let {encoding} = this.parameters;
     const compression_suffix = `/image_format_options.gzip_compression_level=6`;
     switch (encoding) {
       case VolumeChunkEncoding.RAW:
-        return `/subvolume_format=RAW${compression_suffix}`;
+        payload.subvolume_format = 'RAW';
+        break;
       case VolumeChunkEncoding.JPEG:
-        return '/subvolume_format=SINGLE_IMAGE/image_format_options.image_format=JPEG/' +
-            'image_format_options.jpeg_quality=70';
+        payload.subvolume_format = 'SINGLE_IMAGE';
+        payload.image_format_options = {
+          image_format: 'JPEG',
+          jpeg_quality: 70,
+        };
+        return;
       case VolumeChunkEncoding.COMPRESSED_SEGMENTATION:
-        return `/subvolume_format=RAW/image_format_options.compressed_segmentation_block_size=` +
-            vec3Key(this.spec.compressedSegmentationBlockSize!) + compression_suffix;
+        payload.subvolume_format = 'RAW';
+        payload.image_format_options = {
+          compressed_segmentation_block_size: vec3Key(this.spec.compressedSegmentationBlockSize!),
+        };
+        break;
       default:
         throw new Error(`Invalid encoding: ${encoding}`);
     }
   }
 
-  private getChangeStackParams() {
-    let {parameters} = this;
-    let changeStack = parameters['changeSpec'];
-    return getChangeStackParams(changeStack);
-  }
-
-  private getExtraParams() {
-    return this.getEncodingParams() + this.getChangeStackParams();
-  }
-
   download(chunk: VolumeChunk, cancellationToken: CancellationToken) {
     let {parameters} = this;
     let path: string;
-    {
-      // chunkPosition must not be captured, since it will be invalidated by the next call to
-      // computeChunkBounds.
-      let chunkPosition = this.computeChunkBounds(chunk);
-      let chunkDataSize = chunk.chunkDataSize!;
-      path = `/v1beta2/binary/volumes/binary/volumes/subvolume/` +
-          `header.volume_id=${parameters['volumeId']}/` +
-          `geometry.corner=${vec3Key(chunkPosition)}/` +
-          `geometry.size=${vec3Key(chunkDataSize)}/` +
-          `geometry.scale=${parameters['scaleIndex']}${this.extraParams}?alt=media`;
-    }
-    return makeRequest(parameters['instance'], 'GET', path, 'arraybuffer', cancellationToken)
+    
+    // chunkPosition must not be captured, since it will be invalidated by the next call to
+    // computeChunkBounds.
+    let chunkPosition = this.computeChunkBounds(chunk);
+    let chunkDataSize = chunk.chunkDataSize!;
+    path = `/v1/volumes/${parameters['volumeId']}/subvolume:binary`;
+
+    let payload: SubvolumePayload = {
+      geometry: {
+        corner: vec3Key(chunkPosition),
+        size: vec3Key(chunkDataSize),
+        scale: parameters.scaleIndex,
+      },
+    };
+
+    this.applyEncodingParams(payload);
+    applyChangeStack(parameters.changeSpec, payload);
+
+    let httpCall: HttpCall = {
+      method: 'POST',
+      payload: JSON.stringify(payload),
+      path,
+      responseType: 'arraybuffer'
+    };
+     
+    return makeRequest(parameters['instance'], httpCall, cancellationToken)
         .then(response => this.chunkDecoder(chunk, response));
   }
 };
@@ -134,7 +136,6 @@ function decodeManifestChunkWithSupervoxelIds(chunk: ManifestChunk, response: an
 }
 
 function decodeFragmentChunk(chunk: FragmentChunk, response: ArrayBuffer) {
-  response = inflate(new Uint8Array(response)).buffer;
   let dv = new DataView(response);
   let numVertices = dv.getUint32(0, true);
   let numVerticesHigh = dv.getUint32(4, true);
@@ -147,14 +148,6 @@ function decodeFragmentChunk(chunk: FragmentChunk, response: ArrayBuffer) {
 
 @registerChunkSource(MeshSourceParameters)
 class MeshSource extends ParameterizedMeshSource<MeshSourceParameters> {
-  private getChangeStackParams() {
-    let {parameters} = this;
-    let changeStack = parameters['changeSpec'];
-    return getChangeStackParams(changeStack);
-  }
-
-  private extraParams = this.getChangeStackParams();
-
   private manifestDecoder = this.parameters.changeSpec !== undefined ?
       decodeManifestChunkWithSupervoxelIds :
       decodeManifestChunk;
@@ -170,10 +163,15 @@ class MeshSource extends ParameterizedMeshSource<MeshSourceParameters> {
 
   download(chunk: ManifestChunk, cancellationToken: CancellationToken) {
     let {parameters} = this;
-    const path = `/v1beta2/objects/${parameters['volumeId']}/meshes/` +
+    const path = `/v1/objects/${parameters['volumeId']}/meshes/` +
         `${parameters['meshName']}:listfragments?object_id=${chunk.objectId}` +
         this.listFragmentsParams;
-    return makeRequest(parameters['instance'], 'GET', path, 'json', cancellationToken)
+    let httpCall: HttpCall = {
+      method: 'GET',
+      path,
+      responseType: 'json',
+    };
+    return makeRequest(parameters['instance'], httpCall, cancellationToken)
         .then(response => this.manifestDecoder(chunk, response));
   }
 
@@ -189,17 +187,30 @@ class MeshSource extends ParameterizedMeshSource<MeshSourceParameters> {
       objectId = chunk.manifestChunk!.objectId.toString();
     }
 
-    const path = `/v1beta2/binary/objects/binary/objects/fragment/` +
-        `header.volume_id=${parameters['volumeId']}/` +
-        `mesh_name=${parameters['meshName']}/fragment_key=${fragmentId}/` +
-        `object_id=${objectId}/header.gzip_compression_level=6?alt=media`;
-    return makeRequest(parameters['instance'], 'GET', path, 'arraybuffer', cancellationToken)
+    const path = `/v1/objects/${parameters['volumeId']}` +
+      `/meshes/${parameters['meshName']}` +
+      '/fragment:binary';
+    
+    let payload: MeshFragmentPayload = {
+      fragment_key: fragmentId,
+      object_id: objectId,
+    };
+
+    applyChangeStack(parameters.changeSpec, payload);
+    
+    let httpCall: HttpCall = {
+      method: 'POST',
+      path,
+      payload: JSON.stringify(payload),
+      responseType: 'arraybuffer',
+    };
+
+    return makeRequest(parameters['instance'], httpCall, cancellationToken)
         .then(response => decodeFragmentChunk(chunk, response));
   }
 }
 
 function decodeSkeletonChunk(chunk: SkeletonChunk, response: ArrayBuffer) {
-  response = inflate(new Uint8Array(response)).buffer;
   let dv = new DataView(response);
   let numVertices = dv.getUint32(0, true);
   let numVerticesHigh = dv.getUint32(4, true);
@@ -223,7 +234,12 @@ export class SkeletonSource extends ParameterizedSkeletonSource<SkeletonSourcePa
     const path = `/v1beta2/binary/objects/binary/objects/skeleton/` +
         `header.volume_id=${parameters['volumeId']}/mesh_name=${parameters['meshName']}/` +
         `object_id=${chunk.objectId}/header.gzip_compression_level=6?alt=media`;
-    return makeRequest(parameters['instance'], 'GET', path, 'arraybuffer', cancellationToken)
+    let httpCall: HttpCall = {
+      method: 'GET',
+      path,
+      responseType: 'arraybuffer',
+    };
+    return makeRequest(parameters['instance'], httpCall, cancellationToken)
         .then(response => decodeSkeletonChunk(chunk, response));
   }
 }

--- a/src/neuroglancer/datasource/brainmaps/frontend.ts
+++ b/src/neuroglancer/datasource/brainmaps/frontend.ts
@@ -231,8 +231,8 @@ export function getVolume(
       {type: 'brainmaps:getVolume', instance, volumeId, changeSpec, options},
       () => Promise
                 .all([
-                  makeRequest(instance, 'GET', `/v1beta2/volumes/${volumeId}`, 'json'),
-                  makeRequest(instance, 'GET', `/v1beta2/objects/${volumeId}/meshes`, 'json'),
+                  makeRequest(instance, {method: 'GET', path: `/v1beta2/volumes/${volumeId}`, responseType: 'json'}),
+                  makeRequest(instance, {method: 'GET', path: `/v1beta2/objects/${volumeId}/meshes`, responseType: 'json'}),
                 ])
                 .then(
                     ([volumeInfoResponse, meshesResponse]) => new MultiscaleVolumeChunkSource(
@@ -319,8 +319,8 @@ export function getVolumeList(chunkManager: ChunkManager, instance: BrainmapsIns
   return chunkManager.memoize.getUncounted({instance, type: 'brainmaps:getVolumeList'}, () => {
     let promise = Promise
                       .all([
-                        makeRequest(instance, 'GET', '/v1beta2/projects', 'json'),
-                        makeRequest(instance, 'GET', '/v1beta2/volumes', 'json')
+                        makeRequest(instance, {method: 'GET', path: '/v1beta2/projects', responseType: 'json'}),
+                        makeRequest(instance, {method: 'GET', path: '/v1beta2/volumes', responseType: 'json'})
                       ])
                       .then(
                           ([projectsResponse, volumesResponse]) =>
@@ -344,7 +344,7 @@ export function getChangeStackList(
   return chunkManager.memoize.getUncounted(
       {instance, type: 'brainmaps:getChangeStackList', volumeId}, () => {
         let promise: Promise<string[]> =
-            makeRequest(instance, 'GET', `/v1beta2/changes/${volumeId}/change_stacks`, 'json')
+            makeRequest(instance, {method: 'GET', path: `/v1beta2/changes/${volumeId}/change_stacks`, responseType: 'json'})
                 .then(response => parseChangeStackList(response));
         const description = `change stacks for ${volumeId}`;
         StatusMessage.forPromise(promise, {


### PR DESCRIPTION
Since the new binary endpoints respect the "Accept-encoding: gzip" header, decoding in javascript via pako is no longer necessary.