### PR TITLE
(fix brainmaps): Update types for TS2.3.1

### DIFF
--- a/src/neuroglancer/datasource/brainmaps/api.ts
+++ b/src/neuroglancer/datasource/brainmaps/api.ts
@@ -95,7 +95,7 @@ setupBrainmapsInstance(PRODUCTION_INSTANCE, 'brainmaps.googleapis.com', 'prod', 
 export interface HttpCall {
   method: 'GET'|'POST';
   path: string;
-  responseType: 'arraybuffer'|'json'|string;
+  responseType: XMLHttpRequestResponseType;
   payload?: string;
 }
 

--- a/src/neuroglancer/util/http_request.ts
+++ b/src/neuroglancer/util/http_request.ts
@@ -78,9 +78,8 @@ export function openShardedHttpRequest(baseUrls: string|string[], path: string, 
 export function sendHttpRequest(
   xhr: XMLHttpRequest, responseType: 'arraybuffer', token?: CancellationToken): Promise<ArrayBuffer>;
 export function sendHttpRequest(xhr: XMLHttpRequest, responseType: 'json', token?: CancellationToken): Promise<any>;
-export function sendHttpRequest(xhr: XMLHttpRequest, responseType: string, token?: CancellationToken): any;
-
-export function sendHttpRequest(xhr: XMLHttpRequest, responseType: string, token: CancellationToken = uncancelableToken) {
+export function sendHttpRequest(xhr: XMLHttpRequest, responseType: XMLHttpRequestResponseType, token?: CancellationToken): any;
+export function sendHttpRequest(xhr: XMLHttpRequest, responseType: XMLHttpRequestResponseType, token: CancellationToken = uncancelableToken) {
   xhr.responseType = responseType;
   return new Promise((resolve, reject) => {
     const abort = () => { xhr.abort(); };


### PR DESCRIPTION
Typescript 2.3 was released <= 1 day ago and has one breaking change in that XMLHttpRequest's responseType was changed from "string" to an explicit type. 

Note: Might also want to update to enforce that ts 2.3.1 is required in package.json