### PR TITLE
User event emitter prototype

### DIFF
--- a/src/neuroglancer/display_context.ts
+++ b/src/neuroglancer/display_context.ts
@@ -18,14 +18,20 @@ import {RefCounted} from 'neuroglancer/util/disposable';
 import {NullarySignal} from 'neuroglancer/util/signal';
 import {GL, initializeWebGL} from 'neuroglancer/webgl/context';
 
+import {UserEventEmitter} from 'neuroglancer/ui/user_events';
+
 export abstract class RenderedPanel extends RefCounted {
+  eventEmitter: UserEventEmitter;
   gl: GL;
+
   constructor(public context: DisplayContext, public element: HTMLElement) {
     super();
     this.gl = context.gl;
     this.registerEventListener(
         element, 'mouseenter', (_event: MouseEvent) => { this.context.setActivePanel(this); });
     context.addPanel(this);
+
+    this.eventEmitter = new UserEventEmitter(element);
   }
 
   scheduleRedraw() { this.context.scheduleRedraw(); }

--- a/src/neuroglancer/rendered_data_panel.ts
+++ b/src/neuroglancer/rendered_data_panel.ts
@@ -21,8 +21,6 @@ import {AXES_NAMES, kAxes, vec3} from 'neuroglancer/util/geom';
 import {getWheelZoomAmount} from 'neuroglancer/util/wheel_zoom';
 import {ViewerState} from 'neuroglancer/viewer_state';
 
-import {UserEventEmitter} from 'neuroglancer/ui/user_events';
-
 require('./rendered_data_panel.css');
 
 export const KEY_COMMANDS = new Map<string, (this: RenderedDataPanel) => void>();
@@ -60,7 +58,6 @@ export abstract class RenderedDataPanel extends RenderedPanel {
   abstract updateMouseState(state: MouseSelectionState): boolean;
 
   private mouseStateUpdater = this.updateMouseState.bind(this);
-  private eventEmitter: UserEventEmitter;
 
   navigationState: NavigationState;
 
@@ -149,8 +146,6 @@ export abstract class RenderedDataPanel extends RenderedPanel {
         if (mouseState.updateUnconditionally()) {
           this.viewer.layerManager.invokeAction('annotate');
         }
-      } else {
-        this.startDragViewport(e);
       }
     } else if (e.button === 2) {
       let {mouseState} = this.viewer;

--- a/src/neuroglancer/ui/user_events.ts
+++ b/src/neuroglancer/ui/user_events.ts
@@ -1,0 +1,85 @@
+import {RefCounted} from 'neuroglancer/util/disposable';
+
+interface TypedEventListener<T> extends EventListener {
+  (e: T): void;
+}
+
+type ListenerConfig<T> = TypedEventListener<T> | [TypedEventListener<T>, boolean];
+
+// Used to perform type narrowing on a ListenerConfig.
+function getListenerConfig<T>(listenerConfig: ListenerConfig<T>): [TypedEventListener<T>, boolean|undefined] {
+    if (Array.isArray(listenerConfig)) {
+      return listenerConfig;
+    } else {
+      return [listenerConfig, false];
+    }
+}
+
+interface EventConfig {
+  mousemove?: ListenerConfig<MouseEvent>;
+  mousedown?: ListenerConfig<MouseEvent>;
+  mouseleave?: ListenerConfig<MouseEvent>;
+  dblclick?: ListenerConfig<Event>;
+}
+
+function keys<T>(obj: T): [keyof T] {
+  return Object.keys(obj) as any;
+}
+
+type ListenerType = EventConfig[keyof EventConfig];
+type DisposerRef = () => void;
+type Disposers = {
+  [K in keyof EventConfig]: DisposerRef;
+}
+
+export class UserEventEmitter extends RefCounted {
+
+  private activeListeners = new Map<DisposerRef, ListenerType>();
+
+  constructor(private element: HTMLElement) {
+    super();
+  }
+
+  on(eventConfig: EventConfig) {
+    let disposers: Disposers = {};
+    for (let key of keys(eventConfig)) {
+      let {element} = this;
+      let listenerConfig = eventConfig[key];
+      if (listenerConfig === undefined) {
+        continue;
+      }
+      let [listener, useCapture] = getListenerConfig(listenerConfig);
+      element.addEventListener(key, listener, useCapture)
+      let disposer = () => {
+        element.removeEventListener(key, listener);
+        this.removeDisposer(disposer);
+      }
+      this.activeListeners.set(disposer, listener);
+      disposers[key] = disposer;
+    }
+    return disposers;
+  }
+
+  off(disposers: DisposerRef[]|DisposerRef) {
+    if (!Array.isArray(disposers)) {
+      disposers = [disposers];
+    }
+
+    for (let disposer of disposers) {
+      disposer();
+    }
+  }
+
+  disposed() {
+    for (let disposer of this.activeListeners.keys()) {
+      disposer();
+    }
+    super.dispose();
+  }
+
+  private removeDisposer(disposer: DisposerRef) {
+    if(this.activeListeners.has(disposer)) {
+      this.activeListeners.delete(disposer);
+    }
+  }
+}

--- a/src/neuroglancer/ui/user_events.ts
+++ b/src/neuroglancer/ui/user_events.ts
@@ -4,23 +4,65 @@ interface TypedEventListener<T> extends EventListener {
   (e: T): void;
 }
 
-type ListenerConfig<T> = TypedEventListener<T> | [TypedEventListener<T>, boolean];
+type ListenerConfig<T> = TypedEventListener<T>|[TypedEventListener<T>, boolean];
 
 // Used to perform type narrowing on a ListenerConfig.
-function getListenerConfig<T>(listenerConfig: ListenerConfig<T>): [TypedEventListener<T>, boolean|undefined] {
-    if (Array.isArray(listenerConfig)) {
-      return listenerConfig;
-    } else {
-      return [listenerConfig, false];
-    }
+function getListenerConfig<T>(listenerConfig: ListenerConfig<T>):
+    [TypedEventListener<T>, boolean | undefined] {
+  if (Array.isArray(listenerConfig)) {
+    return listenerConfig;
+  } else {
+    return [listenerConfig, false];
+  }
 }
 
-interface EventConfig {
+// Flatten and type narrow disposers.
+function getDisposerList<T>(inputDisposers: Disposers | DisposerRef[] | DisposerRef):
+    DisposerRef[] {
+  if (Array.isArray(inputDisposers)) {
+    return inputDisposers;
+  };
+  if (typeof(inputDisposers) === 'function') {
+    return [inputDisposers];
+  }
+  let list = [];
+  for (let key of keys(inputDisposers)) {
+    list.push(inputDisposers[key]);
+  }
+  return list;
+}
+
+export interface MouseDragEvent extends MouseEvent {
+  start: DragPosition;
+  current: DragPosition;
+  delta: DragPosition;
+  target: HTMLElement;
+}
+
+export interface DomEvents {
   mousemove?: ListenerConfig<MouseEvent>;
   mousedown?: ListenerConfig<MouseEvent>;
   mouseleave?: ListenerConfig<MouseEvent>;
-  dblclick?: ListenerConfig<Event>;
+  mouseup?: ListenerConfig<MouseEvent>;
+  dblclick?: ListenerConfig<MouseEvent>;
+  wheel?: ListenerConfig<WheelEvent>;
+  click?: ListenerConfig<MouseEvent>;
 }
+
+export interface CustomEvents {
+  // Custom, non-dom events.
+  mousedrag?: ListenerConfig<MouseDragEvent>;
+}
+
+type CustomListeners = {
+  [K in keyof CustomEvents]: CustomEvents[K][];
+}
+
+export const CUSTOM_EVENT_TYPES: [keyof CustomEvents] = [
+  'mousedrag',
+];
+
+export interface EventConfig extends DomEvents, CustomEvents {}
 
 function keys<T>(obj: T): [keyof T] {
   return Object.keys(obj) as any;
@@ -32,39 +74,52 @@ type Disposers = {
   [K in keyof EventConfig]: DisposerRef;
 }
 
-export class UserEventEmitter extends RefCounted {
+type DragPosition = {
+  x: number,
+  y: number
+};
 
+export class UserEventEmitter extends RefCounted {
+  dragging = false;
+
+  private dragStart: DragPosition|null = null;
+  private dragLast: DragPosition;
+  private dragDisposers: Disposers = {};
+
+  private customListeners: CustomListeners = {};
   private activeListeners = new Map<DisposerRef, ListenerType>();
 
   constructor(private element: HTMLElement) {
     super();
+
+    // Must stay in constructor to ensure that it is called before any subsequent handlers.
+    this.on({
+      mousedown: this.onMousedown.bind(this),
+    });
   }
 
-  on(eventConfig: EventConfig) {
+  on(eventConfig: EventConfig, element: EventTarget = this.element): Disposers {
     let disposers: Disposers = {};
     for (let key of keys(eventConfig)) {
-      let {element} = this;
-      let listenerConfig = eventConfig[key];
-      if (listenerConfig === undefined) {
+      let listener = eventConfig[key];
+      if (listener === undefined) {
         continue;
       }
-      let [listener, useCapture] = getListenerConfig(listenerConfig);
-      element.addEventListener(key, listener, useCapture)
-      let disposer = () => {
-        element.removeEventListener(key, listener);
-        this.removeDisposer(disposer);
+      let disposer: DisposerRef;
+      if (CUSTOM_EVENT_TYPES.indexOf(key as any) < 0) {
+        disposer = this.addDomListener(element, key, listener);
+      } else {
+        disposer = this.addCustomListener(element, key as any, listener);
       }
+
       this.activeListeners.set(disposer, listener);
       disposers[key] = disposer;
     }
     return disposers;
   }
 
-  off(disposers: DisposerRef[]|DisposerRef) {
-    if (!Array.isArray(disposers)) {
-      disposers = [disposers];
-    }
-
+  off(inputDisposers: Disposers|DisposerRef[]|DisposerRef) {
+    let disposers = getDisposerList(inputDisposers);
     for (let disposer of disposers) {
       disposer();
     }
@@ -77,9 +132,89 @@ export class UserEventEmitter extends RefCounted {
     super.dispose();
   }
 
-  private removeDisposer(disposer: DisposerRef) {
-    if(this.activeListeners.has(disposer)) {
-      this.activeListeners.delete(disposer);
+  private addDomListener<T>(
+      element: EventTarget, key: keyof EventConfig, listenerConfig: ListenerConfig<T>) {
+    let [listener, useCapture] = getListenerConfig(listenerConfig);
+
+
+    element.addEventListener(key, listener, useCapture);
+    let disposer = () => {
+      element.removeEventListener(key, listener);
+      if (this.activeListeners.has(disposer)) {
+        this.activeListeners.delete(disposer);
+      }
+    };
+    return disposer;
+  }
+
+  private addCustomListener<T>(
+      element: EventTarget, key: keyof CustomEvents, listenerConfig: ListenerConfig<T>) {
+    element;
+    let [listener] = getListenerConfig(listenerConfig);
+
+    if (!this.customListeners[key]) {
+      this.customListeners[key] = [];
     }
+    this.customListeners[key].push(listener);
+    let disposer = () => {
+      this.customListeners[key] = this.customListeners[key].filter(l => l !== listener);
+    };
+    return disposer;
+  }
+
+  private onMousedown(e: MouseEvent) {
+    this.dragLast = this.dragStart = {
+      x: e.screenX,
+      y: e.screenY,
+    };
+
+    this.dragDisposers = this.on(
+        {
+          mousemove: this.onMousedrag.bind(this),
+          mouseup: this.onMousedragend.bind(this),
+        },
+        document);
+  }
+
+  private onMousedragend() {
+    this.dragging = false;
+    this.dragStart = null;
+    this.off(this.dragDisposers);
+    this.dragDisposers = {};
+  }
+
+  private onMousedrag(e: MouseEvent) {
+    this.dragging = true;
+    if (!this.dragStart) {
+      return;
+    }
+    let dragCurrent: DragPosition = {
+      x: e.screenX,
+      y: e.screenY,
+    };
+    let delta: DragPosition = {
+      x: this.dragLast.x - dragCurrent.x,
+      y: this.dragLast.y - dragCurrent.y,
+    };
+    this.dragLast = dragCurrent;
+
+    let dragEvent: MouseDragEvent = {
+      ...e,
+      start: this.dragStart,
+      current: dragCurrent,
+      delta,
+      target: this.element,
+      // Need to set some manually here, since you can't enumerate Event properties :(
+      shiftKey: e.shiftKey,
+      ctrlKey: e.ctrlKey,
+      altKey: e.altKey,
+    };
+
+    this.customListeners['mousedrag'].forEach(listenerConfig => {
+      if (listenerConfig) {
+        let [listener] = getListenerConfig(listenerConfig);
+        listener(dragEvent);
+      }
+    });
   }
 }

--- a/src/neuroglancer/util/disposable.ts
+++ b/src/neuroglancer/util/disposable.ts
@@ -18,6 +18,10 @@ export interface Disposable { dispose: () => void; }
 
 export type Disposer = Disposable | (() => void);
 
+export interface TypedEventListener<E> extends EventListener {
+  (event: E): any;
+}
+
 export class RefCounted implements Disposable {
   public refCount = 1;
   wasDisposed: boolean|undefined;
@@ -70,7 +74,7 @@ export class RefCounted implements Disposable {
     }
     return f;
   }
-  registerEventListener(target: EventTarget, eventType: string, listener: any, arg?: any) {
+  registerEventListener<E>(target: EventTarget, eventType: string, listener: TypedEventListener<E>, arg?: any) {
     target.addEventListener(eventType, listener, arg);
     this.registerDisposer(() => target.removeEventListener(eventType, listener, arg));
   }


### PR DESCRIPTION
This is a prototype for an event handling system. It's a bit lower level than `invokeAction` in `LayerManager`, intended to be the place to hook all user-generated events (e.g. clicks, mousemoves, etc). It can also implement custom events like mousedrag, removing the need for `startRelativeMouseDrag`. 

Events are hooked by using the `.on()` syntax, and each handler is strongly typed. To disable a handler, use the `Disposer` functions returned from `.on()`.  For example, to hook mouse movements but disable them on a mouse down, you'd do the following:

```
let disposers = this.eventEmitter.on({
  mousemove: (e: MouseEvent) => console.log('Mouse moved:', e),
  mousedown: () => disposers['mousemove'](),
});
```

One major advantage of this is that it allows external apps (e.g. Wintermute) to hook into user events that occur on layers. It currently does not pass any additional state/context along with the event, but I'd imagine that would be more appropriate somewhere within layerManager as this is solely for hooking user actions.

Todos:

- Implement event bubbling (might only be necessary for custom events, since DOM events inherently bubble)
- Integration with layerManager's action system
- Keyboard support 
- Providing additional context (e.g. which mesh/ID was clicked on, what layer, etc)