### PR TITLE
Feature: ClipBounds

### DIFF
--- a/src/neuroglancer/segmentation_display_state/backend.ts
+++ b/src/neuroglancer/segmentation_display_state/backend.ts
@@ -19,16 +19,18 @@ import 'neuroglancer/shared_disjoint_sets';
 import 'neuroglancer/uint64_set';
 
 import {withChunkManager} from 'neuroglancer/chunk_manager/backend';
-import {VisibleSegmentsState} from 'neuroglancer/segmentation_display_state/base';
+import {Bounds, VisibleSegmentsState} from 'neuroglancer/segmentation_display_state/base';
 import {SharedDisjointUint64Sets} from 'neuroglancer/shared_disjoint_sets';
 import {Uint64Set} from 'neuroglancer/uint64_set';
 import {withSharedVisibility} from 'neuroglancer/visibility_priority/backend';
 import {RPC, SharedObjectCounterpart} from 'neuroglancer/worker_rpc';
+import {SharedWatchableValue} from 'neuroglancer/shared_watchable_value';
 
 const Base = withSharedVisibility(withChunkManager(SharedObjectCounterpart));
 
 export class SegmentationLayerSharedObjectCounterpart extends Base implements VisibleSegmentsState {
   visibleSegments: Uint64Set;
+  clipBounds: SharedWatchableValue<Bounds>;
   segmentEquivalences: SharedDisjointUint64Sets;
 
   constructor(rpc: RPC, options: any) {
@@ -36,6 +38,7 @@ export class SegmentationLayerSharedObjectCounterpart extends Base implements Vi
     // No need to increase the reference count of visibleSegments or
     // segmentEquivalences since our owner will hold a reference to their owners.
     this.visibleSegments = <Uint64Set>rpc.get(options['visibleSegments']);
+    this.clipBounds = <SharedWatchableValue<Bounds>>rpc.get(options['clipBounds']);
     this.segmentEquivalences = <SharedDisjointUint64Sets>rpc.get(options['segmentEquivalences']);
 
     const scheduleUpdateChunkPriorities = () => {
@@ -43,5 +46,6 @@ export class SegmentationLayerSharedObjectCounterpart extends Base implements Vi
     };
     this.registerDisposer(this.visibleSegments.changed.add(scheduleUpdateChunkPriorities));
     this.registerDisposer(this.segmentEquivalences.changed.add(scheduleUpdateChunkPriorities));
+    this.registerDisposer(this.clipBounds.changed.add(scheduleUpdateChunkPriorities));
   }
 }

--- a/src/neuroglancer/segmentation_display_state/base.ts
+++ b/src/neuroglancer/segmentation_display_state/base.ts
@@ -17,18 +17,27 @@
 import {SharedDisjointUint64Sets} from 'neuroglancer/shared_disjoint_sets';
 import {Uint64Set} from 'neuroglancer/uint64_set';
 import {Uint64} from 'neuroglancer/util/uint64';
+import {vec3} from 'neuroglancer/util/geom';
+import {SharedWatchableValue} from 'neuroglancer/shared_watchable_value';
+
+export interface Bounds {
+  center: vec3;
+  size: vec3;
+}
 
 export interface VisibleSegmentsState {
   visibleSegments: Uint64Set;
   segmentEquivalences: SharedDisjointUint64Sets;
+  clipBounds: SharedWatchableValue<Bounds|undefined>;
 }
 
 /**
  * Returns a string key for identifying a uint64 object id.  This is faster than
  * Uint64.prototype.toString().
  */
-export function getObjectKey(objectId: Uint64): string {
-  return `${objectId.low},${objectId.high}`;
+export function getObjectKey(objectId: Uint64, bounds?: Bounds): string {
+  let boundsSuffix = bounds ? `_${bounds.center.toString()}_${bounds.size.toString()}` : '';
+  return `${objectId.low},${objectId.high}${boundsSuffix}`;
 }
 
 export function forEachVisibleSegment(

--- a/src/neuroglancer/segmentation_display_state/frontend.ts
+++ b/src/neuroglancer/segmentation_display_state/frontend.ts
@@ -144,7 +144,7 @@ export function forEachSegmentToDraw<SegmentData>(
     displayState: SegmentationDisplayState, objects: Map<string, SegmentData>,
     callback: (rootObjectId: Uint64, objectId: Uint64, segmentData: SegmentData) => void) {
   forEachVisibleSegment(displayState, (objectId, rootObjectId) => {
-    const key = getObjectKey(objectId);
+    const key = getObjectKey(objectId, displayState.clipBounds.value);
     const segmentData = objects.get(key);
     if (segmentData !== undefined) {
       callback(rootObjectId, objectId, segmentData);
@@ -156,6 +156,7 @@ const Base = withSharedVisibility(SharedObject);
 export class SegmentationLayerSharedObject extends Base {
   constructor(public chunkManager: ChunkManager, public displayState: SegmentationDisplayState) {
     super();
+    this.registerDisposer(displayState.clipBounds.changed.add(() => chunkManager.chunkQueueManager.scheduleChunkUpdate()));
   }
 
   initializeCounterpartWithChunkManager(options: any) {
@@ -163,6 +164,7 @@ export class SegmentationLayerSharedObject extends Base {
     options['chunkManager'] = this.chunkManager.rpcId;
     options['visibleSegments'] = displayState.visibleSegments.rpcId;
     options['segmentEquivalences'] = displayState.segmentEquivalences.rpcId;
+    options['clipBounds'] = displayState.clipBounds.rpcId;
     super.initializeCounterpart(this.chunkManager.rpc!, options);
   }
 }

--- a/src/neuroglancer/segmentation_user_layer.ts
+++ b/src/neuroglancer/segmentation_user_layer.ts
@@ -31,13 +31,16 @@ import {SegmentationRenderLayer, SliceViewSegmentationDisplayState} from 'neurog
 import {trackableAlphaValue} from 'neuroglancer/trackable_alpha';
 import {TrackableBoolean, TrackableBooleanCheckbox} from 'neuroglancer/trackable_boolean';
 import {Uint64Set} from 'neuroglancer/uint64_set';
-import {parseArray, verifyObjectProperty, verifyOptionalString} from 'neuroglancer/util/json';
+import {parseArray, verifyObjectProperty, verifyOptionalString, verify3dVec} from 'neuroglancer/util/json';
 import {Uint64} from 'neuroglancer/util/uint64';
 import {makeWatchableShaderError} from 'neuroglancer/webgl/dynamic_shader';
 import {RangeWidget} from 'neuroglancer/widget/range';
 import {SegmentSetWidget} from 'neuroglancer/widget/segment_set_widget';
 import {ShaderCodeWidget} from 'neuroglancer/widget/shader_code_widget';
 import {Uint64EntryWidget} from 'neuroglancer/widget/uint64_entry_widget';
+import {SharedWatchableValue} from 'neuroglancer/shared_watchable_value';
+import {Bounds} from 'neuroglancer/segmentation_display_state/base';
+import {vec3} from 'neuroglancer/util/geom';
 
 require('neuroglancer/noselect.css');
 require('./segmentation_user_layer.css');
@@ -56,6 +59,7 @@ export class SegmentationUserLayer extends UserLayer {
         selectedAlpha: trackableAlphaValue(0.5),
         notSelectedAlpha: trackableAlphaValue(0),
         objectAlpha: trackableAlphaValue(1.0),
+        clipBounds: SharedWatchableValue.make<Bounds|undefined>(this.manager.worker, undefined),
         hideSegmentZero: new TrackableBoolean(true, true),
         visibleSegments: Uint64Set.makeWithCounterpart(this.manager.worker),
         segmentEquivalences: SharedDisjointUint64Sets.makeWithCounterpart(this.manager.worker),
@@ -159,6 +163,20 @@ export class SegmentationUserLayer extends UserLayer {
         });
       }
     });
+
+    verifyObjectProperty(x, 'clipBounds', y => {
+      if (y === undefined) {
+        return;
+      }
+      let center: vec3|undefined, size: vec3|undefined;
+      verifyObjectProperty(y, 'center', z => center = verify3dVec(z));
+      verifyObjectProperty(y, 'size', z => size = verify3dVec(z));
+      if (!center || !size) {
+        return;
+      }
+      let bounds = {center, size};
+      this.displayState.clipBounds.value = bounds;
+    });
   }
 
   addMesh(meshSource: MeshSource) {
@@ -182,6 +200,13 @@ export class SegmentationUserLayer extends UserLayer {
     let {segmentEquivalences} = this.displayState;
     if (segmentEquivalences.size > 0) {
       x['equivalences'] = segmentEquivalences.toJSON();
+    }
+    let {clipBounds} = this.displayState;
+    if (clipBounds.value) {
+      x['clipBounds'] = {
+        center: clipBounds.value.center,
+        size: clipBounds.value.size,
+      };
     }
     x['transform'] = this.displayState.objectToDataTransform.toJSON();
     x['skeletonShader'] = this.displayState.fragmentMain.toJSON();

--- a/src/neuroglancer/util/uint64.ts
+++ b/src/neuroglancer/util/uint64.ts
@@ -169,4 +169,44 @@ export class Uint64 {
   toJSON() {
     return this.toString();
   }
+
+  lshift(bits: number) {
+    bits &= 63;
+    if (bits == 0) {
+      return this.clone();
+    } else {
+      let {low, high} = this;
+      if (bits < 32) {
+        return new Uint64(low << bits, (high << bits) | (low >>> (32 - bits)));
+      } else {
+        return new Uint64(0, low << (bits - 32));
+      }
+    }
+  }
+
+  rshift(bits: number) {
+    bits &= 63;
+    if (bits == 0) {
+      return this.clone();
+    } else {
+      let {low, high} = this;
+      if (bits < 32) {
+        return new Uint64((low >>> bits) | (high << (32 - bits)), high >> bits);
+      } else {
+        return new Uint64(high >> (bits - 32), high >= 0 ? 0 : -1);
+      }
+    }
+  }
+
+  or(other: Uint64) {
+    return new Uint64(this.low | other.low, this.high | other.high);
+  }
+
+  xor(other: Uint64) {
+    return new Uint64(this.low ^ other.low, this.high ^ other.high);
+  }
+
+  and(other: Uint64) {
+    return new Uint64(this.low & other.low, this.high & other.high);
+  }
 }


### PR DESCRIPTION
Add a shared_trackable_value class that allows two-way communication of values from frontend<->backend. Example use case is for applying (optional) ClipBounds to meshes.