### PR TITLE
Use 'dtype=np.float32' instead of 'float' for np.zeros()

### DIFF
--- a/python/neuroglancer/downsample.py
+++ b/python/neuroglancer/downsample.py
@@ -25,7 +25,7 @@ def downsample_with_averaging(array, factor):
     """
     factor = tuple(factor)
     output_shape = tuple(int(math.ceil(s / f)) for s, f in zip(array.shape, factor))
-    temp = np.zeros(output_shape, float)
+    temp = np.zeros(output_shape, dtype=np.float32)
     counts = np.zeros(output_shape, np.int)
     for offset in np.ndindex(factor):
         part = array[tuple(np.s_[o::f] for o, f in zip(offset, factor))]


### PR DESCRIPTION
This fixes

  TypeError: 'float' object cannot be interpreted as an index