### PR TITLE
Fix: Return an array from getVisibleLayers instead of an iterator

### DIFF
--- a/src/neuroglancer/layer.ts
+++ b/src/neuroglancer/layer.ts
@@ -567,7 +567,7 @@ export class VisibleRenderLayerTracker<RenderLayerType extends VisibilityTracked
 
   getVisibleLayers() {
     (<any>this.throttledUpdateVisibleLayers).flush();
-    return this.visibleLayers.keys();
+    return [...this.visibleLayers.keys()];
   }
 }
 


### PR DESCRIPTION
Quick fix that makes getVisibleLayers return an array instead of an iterator. This caused problems when the return value was stored, e.g.:

```
let visibleLayers = layerManager.getVisibleLayers();

for (let layer of visibleLayers) {
  console.log(layer); // <--- all layers printed
}
for (let layer of visibleLayers) {
  console.log(layer); // <--- Not hit, since visibleLayers iterator is exhausted and not reset.
}
```