### PR TITLE
Increase visibility of some private members

### DIFF
--- a/src/neuroglancer/mesh/frontend.ts
+++ b/src/neuroglancer/mesh/frontend.ts
@@ -99,7 +99,7 @@ vColor = vec4(lightingFactor * uColor.rgb, uColor.a);
 }
 
 export class MeshLayer extends PerspectiveViewRenderLayer {
-  private meshShaderManager = new MeshShaderManager();
+  protected meshShaderManager = new MeshShaderManager();
   private shaders = new Map<ShaderModule, ShaderProgram>();
   private sharedObject: SegmentationLayerSharedObject;
 
@@ -120,7 +120,7 @@ export class MeshLayer extends PerspectiveViewRenderLayer {
     sharedObject.visibility.add(this.visibility);
   }
 
-  private getShader(emitter: ShaderModule) {
+  protected getShader(emitter: ShaderModule) {
     let {shaders} = this;
     let shader = shaders.get(emitter);
     if (shader === undefined) {

--- a/src/neuroglancer/perspective_view/panel.ts
+++ b/src/neuroglancer/perspective_view/panel.ts
@@ -106,7 +106,7 @@ gl_FragColor = vec4(accum.rgb / accum.a, revealage);
 export class PerspectivePanel extends RenderedDataPanel {
   viewer: PerspectiveViewerState;
 
-  private visibleLayerTracker = makeRenderedPanelVisibleLayerTracker(
+  protected visibleLayerTracker = makeRenderedPanelVisibleLayerTracker(
       this.viewer.layerManager, PerspectiveViewRenderLayer, this);
 
   sliceViews = new Set<SliceView>();
@@ -115,20 +115,20 @@ export class PerspectivePanel extends RenderedDataPanel {
   modelViewMat = mat4.create();
   width = 0;
   height = 0;
-  private pickIDs = new PickIDManager();
+  protected pickIDs = new PickIDManager();
   private axesLineHelper = this.registerDisposer(AxesLineHelper.get(this.gl));
   sliceViewRenderHelper =
       this.registerDisposer(SliceViewRenderHelper.get(this.gl, perspectivePanelEmit));
 
-  private offscreenFramebuffer = this.registerDisposer(new FramebufferConfiguration(this.gl, {
+  protected offscreenFramebuffer = this.registerDisposer(new FramebufferConfiguration(this.gl, {
     colorBuffers: makeTextureBuffers(this.gl, OffscreenTextures.NUM_TEXTURES),
     depthBuffer: new DepthBuffer(this.gl)
   }));
 
-  private transparentConfiguration_: FramebufferConfiguration<TextureBuffer>|undefined;
+  protected transparentConfiguration_: FramebufferConfiguration<TextureBuffer>|undefined;
 
-  private offscreenCopyHelper = this.registerDisposer(OffscreenCopyHelper.get(this.gl));
-  private transparencyCopyHelper =
+  protected offscreenCopyHelper = this.registerDisposer(OffscreenCopyHelper.get(this.gl));
+  protected transparencyCopyHelper =
       this.registerDisposer(OffscreenCopyHelper.get(this.gl, defineTransparencyCopyShader, 2));
 
   constructor(context: DisplayContext, element: HTMLElement, viewer: PerspectiveViewerState) {
@@ -383,7 +383,7 @@ export class PerspectivePanel extends RenderedDataPanel {
         this.offscreenFramebuffer.colorBuffers[OffscreenTextures.COLOR].texture);
   }
 
-  private drawSliceViews(renderContext: PerspectiveViewRenderContext) {
+  protected drawSliceViews(renderContext: PerspectiveViewRenderContext) {
     let {sliceViewRenderHelper} = this;
     let {lightDirection, ambientLighting, directionalLighting, dataToDevice} = renderContext;
 
@@ -405,7 +405,7 @@ export class PerspectivePanel extends RenderedDataPanel {
     }
   }
 
-  private drawAxisLines() {
+  protected drawAxisLines() {
     let {gl} = this;
     let mat = tempMat4;
     mat4.identity(mat);

--- a/src/neuroglancer/single_mesh/frontend.ts
+++ b/src/neuroglancer/single_mesh/frontend.ts
@@ -352,11 +352,11 @@ const SharedObjectWithSharedVisibility = withSharedVisibility(SharedObject);
 class SingleMeshLayerSharedObject extends SharedObjectWithSharedVisibility {}
 
 export class SingleMeshLayer extends PerspectiveViewRenderLayer {
-  private shaderManager: SingleMeshShaderManager|undefined;
+  protected shaderManager: SingleMeshShaderManager|undefined;
   private shaders = new Map<ShaderModule, ShaderProgram|null>();
   private sharedObject = this.registerDisposer(new SingleMeshLayerSharedObject());
   private fallbackFragmentMain = DEFAULT_FRAGMENT_MAIN;
-  private countingBuffer = this.registerDisposer(getCountingBuffer(this.gl));
+  protected countingBuffer = this.registerDisposer(getCountingBuffer(this.gl));
 
   constructor(public source: SingleMeshSource, public displayState: SingleMeshDisplayState) {
     super();
@@ -399,12 +399,12 @@ export class SingleMeshLayer extends PerspectiveViewRenderLayer {
     super.disposed();
   }
 
-  private makeShaderManager(fragmentMain = this.displayState.fragmentMain.value) {
+  protected makeShaderManager(fragmentMain = this.displayState.fragmentMain.value) {
     return new SingleMeshShaderManager(
         this.displayState.attributeNames.value, this.source.info.vertexAttributes, fragmentMain);
   }
 
-  private getShader(emitter: ShaderModule): ShaderProgram|null {
+  protected getShader(emitter: ShaderModule): ShaderProgram|null {
     let {shaders} = this;
     let shader = shaders.get(emitter);
     if (shader === undefined) {

--- a/src/neuroglancer/sliceview/volume/segmentation_renderlayer.ts
+++ b/src/neuroglancer/sliceview/volume/segmentation_renderlayer.ts
@@ -57,7 +57,7 @@ export interface SliceViewSegmentationDisplayState extends SegmentationDisplaySt
 }
 
 export class SegmentationRenderLayer extends RenderLayer {
-  private segmentColorShaderManager = new SegmentColorShaderManager('segmentColorHash');
+  protected segmentColorShaderManager = new SegmentColorShaderManager('segmentColorHash');
   private hashTableManager = new HashSetShaderManager('visibleSegments');
   private gpuHashTable = GPUHashTable.get(this.gl, this.displayState.visibleSegments.hashTable);
 


### PR DESCRIPTION
Hello.
First, thank you very much for your work. It's truly awesome and helped us really a lot.

In our project we are extending some of neuroglancer classes to implement custom functionality specific to our needs. But we need access to some members of base classes which are declared `private`. It is possible with typescript, so it does not block us, but produces unnecessary clatter in diffs and might be harder to maintain.
Is there any strong reason to keep them private? Otherwise we suggest to promote at least the ones we use to `protected` to make our work easier.

Thank you in advance
Best regards, Pavel