### PR TITLE
Feat(datasource/precomputed): Support skeletons

### DIFF
--- a/src/neuroglancer/datasource/precomputed/base.ts
+++ b/src/neuroglancer/datasource/precomputed/base.ts
@@ -36,3 +36,11 @@ export class MeshSourceParameters {
 
   static RPC_ID = 'precomputed/MeshSource';
 }
+
+
+export class SkeletonSourceParameters {
+  baseUrls: string[];
+  path: string;
+
+  static RPC_ID = 'precomputed/SkeletonSource';
+}

--- a/src/neuroglancer/datasource/precomputed/register_default.ts
+++ b/src/neuroglancer/datasource/precomputed/register_default.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {PrecomputedDataSource} from 'neuroglancer/datasource/precomputed/frontend';
 import {registerProvider} from 'neuroglancer/datasource/default_provider';
+import {PrecomputedDataSource} from 'neuroglancer/datasource/precomputed/frontend';
 
 registerProvider('precomputed', () => new PrecomputedDataSource());


### PR DESCRIPTION
Adds support for the skeleton layer in the precomputed datasource. Need to add `getSkeletonSource()` or similar to the `MultiscaleVolumeChunkSource` to add skeletons from a field in the `info` file. 