### PR TITLE
feat(viewer): make default viewer layout configurable

### DIFF
--- a/src/neuroglancer/viewer.ts
+++ b/src/neuroglancer/viewer.ts
@@ -150,6 +150,7 @@ export class Viewer extends RefCounted implements ViewerState {
 
   layerSpecification: TopLevelLayerListSpecification;
   layout: RootLayoutContainer;
+  defaultLayout: string = '4panel';
 
   state = new CompoundTrackable();
 
@@ -325,7 +326,7 @@ export class Viewer extends RefCounted implements ViewerState {
       gridContainer.appendChild(topRow);
     }
 
-    this.layout = this.registerDisposer(new RootLayoutContainer(this, '4panel'));
+    this.layout = this.registerDisposer(new RootLayoutContainer(this, this.defaultLayout));
     gridContainer.appendChild(this.layout.element);
     this.display.onResize();
 


### PR DESCRIPTION
In ndviz I set the default layout to `xy`. Mostly it's for legacy reasons, but I find it useful for data that is anistropic or not properly downsampled -- improves load times a bit. This change makes the default layer layout configurable so I can override it in the ndviz viewer constructor. 