### PR TITLE
feat(sliceview): Support per-layer blend functions

### DIFF
--- a/src/neuroglancer/image_user_layer.ts
+++ b/src/neuroglancer/image_user_layer.ts
@@ -22,6 +22,7 @@ import {Overlay} from 'neuroglancer/overlay';
 import {VolumeType} from 'neuroglancer/sliceview/volume/base';
 import {FRAGMENT_MAIN_START, getTrackableFragmentMain, ImageRenderLayer} from 'neuroglancer/sliceview/volume/image_renderlayer';
 import {trackableAlphaValue} from 'neuroglancer/trackable_alpha';
+import {trackableBlendModeValue} from 'neuroglancer/trackable_blend';
 import {mat4} from 'neuroglancer/util/geom';
 import {makeWatchableShaderError} from 'neuroglancer/webgl/dynamic_shader';
 import {RangeWidget} from 'neuroglancer/widget/range';
@@ -34,6 +35,7 @@ require('neuroglancer/maximize_button.css');
 export class ImageUserLayer extends UserLayer {
   volumePath: string;
   opacity = trackableAlphaValue(0.5);
+  blendMode = trackableBlendModeValue();
   fragmentMain = getTrackableFragmentMain();
   shaderError = makeWatchableShaderError();
   renderLayer: ImageRenderLayer;
@@ -45,6 +47,7 @@ export class ImageUserLayer extends UserLayer {
       throw new Error('Invalid image layer specification');
     }
     this.opacity.restoreState(x['opacity']);
+    this.blendMode.restoreState(x['blend']);
     this.fragmentMain.restoreState(x['shader']);
     this.transform.restoreState(x['transform']);
     this.registerDisposer(this.fragmentMain.changed.add(() => {
@@ -56,6 +59,7 @@ export class ImageUserLayer extends UserLayer {
           if (!this.wasDisposed) {
             let renderLayer = this.renderLayer = new ImageRenderLayer(volume, {
               opacity: this.opacity,
+              blendMode: this.blendMode,
               fragmentMain: this.fragmentMain,
               shaderError: this.shaderError,
               sourceOptions: {transform: mat4.clone(this.transform.transform)},
@@ -69,6 +73,7 @@ export class ImageUserLayer extends UserLayer {
     let x: any = {'type': 'image'};
     x['source'] = this.volumePath;
     x['opacity'] = this.opacity.toJSON();
+    x['blend'] = this.blendMode.toJSON();
     x['shader'] = this.fragmentMain.toJSON();
     x['transform'] = this.transform.toJSON();
     return x;

--- a/src/neuroglancer/sliceview/frontend.ts
+++ b/src/neuroglancer/sliceview/frontend.ts
@@ -226,11 +226,8 @@ export class SliceView extends Base {
           /*func=*/gl.GREATER,
           /*ref=*/1,
           /*mask=*/1);
-      if (renderLayerNum === 1) {
-        // Turn on blending after the first layer.
-        gl.enable(gl.BLEND);
-        gl.blendFunc(gl.SRC_ALPHA, gl.ONE_MINUS_SRC_ALPHA);
-      }
+
+      renderLayer.setGLBlendMode(gl, renderLayerNum);
       renderLayer.draw(this);
       ++renderLayerNum;
     }

--- a/src/neuroglancer/sliceview/renderlayer.ts
+++ b/src/neuroglancer/sliceview/renderlayer.ts
@@ -122,6 +122,14 @@ export abstract class RenderLayer extends GenericRenderLayer {
     return builder.build();
   }
 
+  setGLBlendMode(gl: WebGLRenderingContext, renderLayerNum: number): void {
+    // Default blend mode for non-blend-mode-aware layers
+    if (renderLayerNum > 0) {
+      gl.enable(gl.BLEND);
+      gl.blendFunc(gl.SRC_ALPHA, gl.ONE_MINUS_SRC_ALPHA);
+    }
+  }
+
   abstract defineShader(builder: ShaderBuilder): void;
   abstract beginSlice(_sliceView: SliceView): ShaderProgram;
   abstract endSlice(shader: ShaderProgram): void;

--- a/src/neuroglancer/trackable_blend.ts
+++ b/src/neuroglancer/trackable_blend.ts
@@ -1,0 +1,45 @@
+/**
+ * @license
+ * Copyright 2017 Google Inc.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {TrackableValue} from 'neuroglancer/trackable_value';
+import {verifyEnumString, verifyString} from 'neuroglancer/util/json';
+
+export enum BLEND_MODES {
+  DEFAULT = 0,
+  ADDITIVE = 1
+}
+
+export const BLEND_FUNCTIONS = new Map<BLEND_MODES, Function>();
+BLEND_FUNCTIONS.set(BLEND_MODES.DEFAULT, (gl: WebGLRenderingContext) => {
+  gl.blendFunc(gl.SRC_ALPHA, gl.ONE_MINUS_SRC_ALPHA);
+});
+BLEND_FUNCTIONS.set(BLEND_MODES.ADDITIVE, (gl: WebGLRenderingContext) => {
+  gl.blendFunc(gl.SRC_ALPHA, gl.ONE);
+});
+
+export type TrackableBlendModeValue = TrackableValue<string>;
+
+function blendModeValidator(obj: any): string {
+  if (verifyEnumString(obj, BLEND_MODES)) {
+    return verifyString(obj);
+  } else {
+    throw new Error();
+  }
+}
+
+export function trackableBlendModeValue(initialValue = 'default') {
+  return new TrackableValue<string>(initialValue, blendModeValidator);
+}


### PR DESCRIPTION
This commit adds a new `blend` property to each layer, allowing the user to change the blend function used on a per-layer basis. Currently, only `additive` blending is supported, but others modes could be added in the `trackable_blend` file. Note that `additive` blending is always enabled, whereas the `default` blend mode is only enabled after the first layer has been added. This mirrors existing behavior.

It might make sense to add `none` as an option, for layers that have blending totally disabled. It would seem like the default should continue to be `gl.blendFunc(gl.SRC_ALPHA, gl.ONE_MINUS_SRC_ALPHA);` for backwards compatibility. 