### PR TITLE
Sort values during UInt64Set serialization.

### DIFF
--- a/src/neuroglancer/uint64_set.ts
+++ b/src/neuroglancer/uint64_set.ts
@@ -91,6 +91,8 @@ export class Uint64Set extends SharedObjectCounterpart {
     for (let id of this) {
       result.push(id.toString());
     }
+    // Need to sort entries, otherwise serialization changes every time.
+    result.sort();
     return result;
   }
 }


### PR DESCRIPTION
UInt64Sets were serialized and sorted according to their hashed value, not their value. This resulted in indeterminate order when serializing state.