### PR TITLE
Quickfix of example project

### DIFF
--- a/examples/dependent-project/config/webpack.config.js
+++ b/examples/dependent-project/config/webpack.config.js
@@ -21,5 +21,5 @@ const webpack_helpers = require('./webpack_helpers');
 module.exports = env => {
   env = env || 'dev';
   return webpack_helpers.getViewerConfigFromEnv(
-      {outputPath: path.resolve(__dirname, '../dist/' + outputSuffix)}, env);
+      {outputPath: path.resolve(__dirname, '../dist/' + env)}, env);
 };

--- a/examples/dependent-project/config/webpack_helpers.js
+++ b/examples/dependent-project/config/webpack_helpers.js
@@ -40,6 +40,22 @@ function modifyViewerOptions(options) {
   return options;
 }
 
-exports.getViewerConfig = function(options) {
+function getViewerConfig(options) {
   return original_webpack_helpers.getViewerConfig(modifyViewerOptions(options));
 };
+
+function getViewerConfigFromEnv(options, env) {
+  env = env || 'dev';
+  const envParts = new Set(env.split('-'));
+  options = Object.assign({}, options);
+  if (envParts.has('min')) {
+    options.minify = true;
+  }
+  if (envParts.has('python')) {
+    options = makePythonClientOptions(options);
+  }
+  return getViewerConfig(options);
+}
+
+exports.getViewerConfig = getViewerConfig;
+exports.getViewerConfigFromEnv=getViewerConfigFromEnv;


### PR DESCRIPTION
Webpack of example project seemed to be broken (appaerntly for almost a
year?)
- reference to non-existing variable in webpack config, fixed
- reference to non-exisiting function in webpack config (fixed below)
- reintroduced missing function in webpack helper
- undone oversimplification (anonymous function) so reintroduced
function can work

Disclaimer: blind fixes. no interpretation of changes was done, just
cross-checking with 'config' in project root