### PR TITLE
fix(datasource/render): Fix issue computing stack hierarchy for const…

### DIFF
--- a/src/neuroglancer/datasource/render/frontend.ts
+++ b/src/neuroglancer/datasource/render/frontend.ts
@@ -354,6 +354,10 @@ export function computeStackHierarchy(stackInfo: StackInfo, tileSize: number) {
                                               maxBound = maxBound;
   }
 
+  if (tileSize >= maxBound) {
+    return 1;
+  }
+
   let counter = 0;
   while (maxBound > tileSize) {
     maxBound = maxBound / 2;


### PR DESCRIPTION
…rained stacks

When the stack bounds are smaller than the render tilesize, computeStackHierarchy would return a stack hierarchy of size 0. Fixed to return hierarchy of size 1 if the stack bounds are smaller than the tile size. Fix google/neuroglancer#72