### PR TITLE
Add offsets to label volume in Python example

### DIFF
--- a/python/examples/example.py
+++ b/python/examples/example.py
@@ -34,6 +34,7 @@ void main() {
     s.layers.append(
         name='b', layer=neuroglancer.LocalVolume(
             data=b,
+            offset=(200, 300, 150),
             voxel_size=s.voxel_size,
         ))
 print(viewer)


### PR DESCRIPTION
Without this, the example looks weird, with one volume offset from the other.

Let me know if the missing offsets were intentional...