### PR TITLE
feat(annotation): Adjustable colors and sizes

### DIFF
--- a/src/neuroglancer/annotation/frontend.ts
+++ b/src/neuroglancer/annotation/frontend.ts
@@ -14,15 +14,20 @@
  * limitations under the License.
  */
 
+import {AnnotationPointColorList, DEFAULT_COLOR} from 'neuroglancer/annotation/point_color_list';
 import {AnnotationPointList} from 'neuroglancer/annotation/point_list';
+import {AnnotationPointSizeList, DEFAULT_SIZE} from 'neuroglancer/annotation/point_size_list';
 import {ChunkManager} from 'neuroglancer/chunk_manager/frontend';
 import {MouseSelectionState, RenderLayer} from 'neuroglancer/layer';
 import {VoxelSize} from 'neuroglancer/navigation_state';
 import {PerspectiveViewRenderContext, PerspectiveViewRenderLayer} from 'neuroglancer/perspective_view/render_layer';
 import {SliceViewPanelRenderContext, SliceViewPanelRenderLayer} from 'neuroglancer/sliceview/panel';
-import {WatchableValue} from 'neuroglancer/trackable_value';
+import {TrackableBoolean} from 'neuroglancer/trackable_boolean';
+import {TrackableValue, WatchableValue} from 'neuroglancer/trackable_value';
+import {TrackableVec3} from 'neuroglancer/trackable_vec3';
 import {RefCounted} from 'neuroglancer/util/disposable';
 import {mat4, vec3} from 'neuroglancer/util/geom';
+import {verifyFinitePositiveFloat} from 'neuroglancer/util/json';
 import {NullarySignal} from 'neuroglancer/util/signal';
 import {Uint64} from 'neuroglancer/util/uint64';
 import {Buffer} from 'neuroglancer/webgl/buffer';
@@ -36,23 +41,52 @@ const tempMat = mat4.create();
 const tempPickID = new Float32Array(4);
 
 export class AnnotationPointListLayer extends RefCounted {
-  buffer: Buffer;
-  generation = -1;
+  posBuffer: Buffer;
+  colBuffer: Buffer;
+  sizeBuffer: Buffer;
+  posGeneration = -1;
+  colGeneration = -1;
+  sizeGeneration = -1;
+  usePerspective2D = new TrackableBoolean(false);
+  usePerspective3D = new TrackableBoolean(false);
+  defaultSize = new TrackableValue<number>(DEFAULT_SIZE, verifyFinitePositiveFloat);
+  defaultColor = new TrackableVec3(vec3.clone(DEFAULT_COLOR), DEFAULT_COLOR);
   redrawNeeded = new NullarySignal();
-  color = Float32Array.of(1.0, 1.0, 0.0, 1.0);
-  selectedColor = Float32Array.of(0.0, 1.0, 0.0, 1.0);
 
   constructor(
       public chunkManager: ChunkManager, public pointList: AnnotationPointList,
+      public colorList: AnnotationPointColorList, public sizeList: AnnotationPointSizeList,
       public voxelSizeObject: VoxelSize, public selectedIndex: WatchableValue<number|null>) {
     super();
-    this.buffer = new Buffer(chunkManager.gl);
+    this.posBuffer = new Buffer(chunkManager.gl);
+    this.colBuffer = new Buffer(chunkManager.gl);
+    this.sizeBuffer = new Buffer(chunkManager.gl);
     this.registerDisposer(pointList.changed.add(() => {
       // Clear selectedIndex, since the indices have changed.
       this.selectedIndex.value = null;
       this.redrawNeeded.dispatch();
     }));
+    this.registerDisposer(colorList.changed.add(() => {
+      this.redrawNeeded.dispatch();
+    }));
+    this.registerDisposer(sizeList.changed.add(() => {
+      this.redrawNeeded.dispatch();
+    }));
     this.registerDisposer(selectedIndex.changed.add(() => {
+      this.redrawNeeded.dispatch();
+    }));
+    this.registerDisposer(this.usePerspective2D.changed.add(() => {
+      this.redrawNeeded.dispatch();
+    }));
+    this.registerDisposer(this.usePerspective3D.changed.add(() => {
+      this.redrawNeeded.dispatch();
+    }));
+    this.registerDisposer(this.defaultSize.changed.add(() => {
+      ++this.sizeList.generation;
+      this.redrawNeeded.dispatch();
+    }));
+    this.registerDisposer(this.defaultColor.changed.add(() => {
+      ++this.colorList.generation;
       this.redrawNeeded.dispatch();
     }));
   }
@@ -62,11 +96,41 @@ export class AnnotationPointListLayer extends RefCounted {
   }
 
   updateBuffer() {
-    let {pointList} = this;
-    const newGeneration = pointList.generation;
-    if (this.generation !== newGeneration) {
-      this.generation = newGeneration;
-      this.buffer.setData(pointList.points.view);
+    let {pointList, colorList, sizeList} = this;
+    let newGeneration = pointList.generation;
+    let pointsChanged = false;
+    if (this.posGeneration !== newGeneration) {
+      pointsChanged = true;
+      this.posGeneration = newGeneration;
+      this.posBuffer.setData(pointList.points.view);
+    }
+
+    newGeneration = colorList.generation;
+    if (this.colGeneration !== newGeneration || pointsChanged) {
+      this.colGeneration = newGeneration;
+      if (colorList.colors.length < pointList.points.length) {
+        let tmp = new Float32Array(pointList.points.length);
+        tmp.set(colorList.colors.view);
+        for (let i = colorList.colors.length; i < pointList.points.length; i += 3) {
+          tmp.set(this.defaultColor.value, i);
+        }
+        this.colBuffer.setData(tmp);
+      } else {
+        this.colBuffer.setData(colorList.colors.view);
+      }
+    }
+
+    newGeneration = sizeList.generation;
+    if (this.sizeGeneration !== newGeneration || pointsChanged) {
+      this.sizeGeneration = newGeneration;
+      if (sizeList.sizes.length < pointList.points.length) {
+        let tmp = new Float32Array(pointList.points.length);
+        tmp.set(sizeList.sizes.view);
+        tmp.fill(this.defaultSize.value, sizeList.sizes.length, pointList.points.length);
+        this.sizeBuffer.setData(tmp);
+      } else {
+        this.sizeBuffer.setData(sizeList.sizes.view);
+      }
     }
   }
 
@@ -88,38 +152,68 @@ export class RenderHelper extends RefCounted {
     // Position of point in camera coordinates.
     builder.addAttribute('highp vec3', 'aVertexPosition');
 
+    // Color of point in RGB float [0..1]
+    builder.addAttribute('mediump vec3', 'aVertexColor');
+
+    // The radius of the point in world units (when using perspective scaling)
+    // For fixed size points, radius is simply 0.25 * world unit radius.
+    builder.addAttribute('mediump float', 'aVertexSize');
+
     // XY corners of square ranging from [-1, -1] to [1, 1].
     builder.addAttribute('highp vec2', 'aCornerOffset');
 
-    // The x and y radii of the point in normalized device coordinates.
-    builder.addUniform('highp vec2', 'uPointRadii');
+    // Whether points should be fixed size or obey perspective.
+    builder.addUniform('bool', 'uPerspective');
 
-    builder.addUniform('highp vec4', 'uColor');
-    builder.addUniform('highp vec4', 'uColorSelected');
     builder.addUniform('highp vec4', 'uSelectedIndex');
     builder.addVarying('highp vec4', 'vColor');
+    builder.addVarying('highp float', 'vDepth');
 
-    // Transform from camera to clip coordinates.
+    builder.addUniform('highp vec2', 'uViewport');
+    builder.addUniform('highp mat4', 'uModelView');
     builder.addUniform('highp mat4', 'uProjection');
+    builder.addUniform('highp mat4', 'uInvProjection');
     builder.addUniform('highp vec4', 'uPickID');
     builder.addVarying('highp vec4', 'vPickID');
     builder.addVarying('highp vec2', 'vPointCoord');
     builder.require(countingBufferShaderModule);
     builder.addVertexCode(glsl_addUint32);
     builder.setVertexMain(`
-gl_Position = uProjection * vec4(aVertexPosition, 1.0);
-gl_Position.xy += aCornerOffset * uPointRadii * gl_Position.w;
+#define SQRT2 1.41421356237
+
+vec4 worldPos = uModelView * vec4(aVertexPosition, 1.0);
+
+gl_Position = uProjection * worldPos;
+gl_Position /= gl_Position.w;
+vDepth = gl_Position.z;
+
+if (uPerspective) {
+  vec4 tmpProjCornerPos = gl_Position;
+  tmpProjCornerPos.xy += aCornerOffset / uViewport * uViewport.y;
+
+  vec4 worldCornerPos = uInvProjection * tmpProjCornerPos;
+  worldCornerPos /= worldCornerPos.w;
+  vec3 worldCornerOffset = SQRT2 * aVertexSize * normalize(worldCornerPos.xyz - worldPos.xyz);
+
+  worldCornerPos.xyz = worldPos.xyz + worldCornerOffset;
+  gl_Position = uProjection * worldCornerPos;
+  gl_Position /= gl_Position.w;
+} else {
+  gl_Position.xy += 0.25 * aVertexSize * aCornerOffset / uViewport;
+}
+
 vPointCoord = aCornerOffset;
 
 uint32_t primitiveIndex = getPrimitiveIndex();
 
 uint32_t pickID; pickID.value = uPickID;
 vPickID = add(pickID, primitiveIndex).value;
+vec4 vUserColor = vec4(aVertexColor, 1.0);
 
 if (uSelectedIndex == primitiveIndex.value) {
-  vColor = uColorSelected;
+  vColor = vec4(1.0) - vec4(vUserColor.gbr, 0.0);
 } else {
-  vColor = uColor;
+  vColor = vUserColor;
 }
 `);
     builder.setFragmentMain(`
@@ -152,28 +246,42 @@ emit(getColor(), vPickID);
     base.updateBuffer();
     const numPoints = base.pointList.length;
     const aVertexPosition = shader.attribute('aVertexPosition');
+    const aVertexSize = shader.attribute('aVertexSize');
     const aCornerOffset = shader.attribute('aCornerOffset');
-    base.buffer.bindToVertexAttrib(aVertexPosition, /*components=*/3);
+    base.posBuffer.bindToVertexAttrib(aVertexPosition, /*components=*/3);
     gl.ANGLE_instanced_arrays.vertexAttribDivisorANGLE(aVertexPosition, 1);
+    base.sizeBuffer.bindToVertexAttrib(aVertexSize, /*components=*/1);
+    gl.ANGLE_instanced_arrays.vertexAttribDivisorANGLE(aVertexSize, 1);
     this.squareCornersBuffer.bindToVertexAttrib(aCornerOffset, /*components=*/2);
     this.countingBuffer.ensure(numPoints).bind(shader, 1);
 
+    let aVertexColor = -1;
+    if (renderContext.emitColor) {
+      aVertexColor = shader.attribute('aVertexColor');
+      base.colBuffer.bindToVertexAttrib(aVertexColor, /*components=*/3);
+      gl.ANGLE_instanced_arrays.vertexAttribDivisorANGLE(aVertexColor, 1);
+    }
+
     let objectToDataMatrix = tempMat;
+    let invProjection = mat4.create();
+    mat4.invert(invProjection, renderContext.dataToDevice);
     mat4.identity(objectToDataMatrix);
     mat4.scale(objectToDataMatrix, objectToDataMatrix, base.voxelSizeObject.size);
-    mat4.multiply(tempMat, renderContext.dataToDevice, objectToDataMatrix);
-    gl.uniformMatrix4fv(shader.uniform('uProjection'), false, tempMat);
-    const pointRadius = 8;
+    gl.uniformMatrix4fv(shader.uniform('uModelView'), false, objectToDataMatrix);
+    gl.uniformMatrix4fv(shader.uniform('uProjection'), false, renderContext.dataToDevice);
+    gl.uniformMatrix4fv(shader.uniform('uInvProjection'), false, invProjection);
     gl.uniform2f(
-        shader.uniform('uPointRadii'), pointRadius / renderContext.viewportWidth,
-        pointRadius / renderContext.viewportHeight);
+        shader.uniform('uViewport'), renderContext.viewportWidth, renderContext.viewportHeight);
+    if (renderLayer instanceof SliceViewPanelRenderLayer) {
+      gl.uniform1i(shader.uniform('uPerspective'), base.usePerspective2D.value ? 1 : 0);
+    } else {  // instanceof PerspectiveViewPanelRenderLayer
+      gl.uniform1i(shader.uniform('uPerspective'), base.usePerspective3D.value ? 1 : 0);
+    }
     if (renderContext.emitPickID) {
       const pickID = renderContext.pickIDs.register(renderLayer, numPoints);
       gl.uniform4fv(shader.uniform('uPickID'), setVec4FromUint32(tempPickID, pickID));
     }
     if (renderContext.emitColor) {
-      gl.uniform4fv(shader.uniform('uColor'), base.color);
-      gl.uniform4fv(shader.uniform('uColorSelected'), base.selectedColor);
       let selectedIndex = base.selectedIndex.value;
       if (selectedIndex === null) {
         selectedIndex = 0xFFFFFFFF;
@@ -183,8 +291,15 @@ emit(getColor(), vPickID);
 
     gl.ANGLE_instanced_arrays.drawArraysInstancedANGLE(gl.TRIANGLE_FAN, 0, 4, numPoints);
     gl.ANGLE_instanced_arrays.vertexAttribDivisorANGLE(aVertexPosition, 0);
+    gl.ANGLE_instanced_arrays.vertexAttribDivisorANGLE(aVertexSize, 0);
     disableCountingBuffer(gl, shader, /*instanced=*/true);
     gl.disableVertexAttribArray(aVertexPosition);
+    gl.disableVertexAttribArray(aVertexSize);
+
+    if (renderContext.emitColor) {
+      gl.ANGLE_instanced_arrays.vertexAttribDivisorANGLE(aVertexColor, 0);
+      gl.disableVertexAttribArray(aVertexColor);
+    }
   }
 }
 
@@ -231,7 +346,7 @@ class SliceViewRenderHelper extends RenderHelper {
     super.defineShader(builder);
     builder.addFragmentCode(`
 vec4 getColor() {
-  float scalar = 1.0 - 2.0 * abs(0.5 - gl_FragCoord.z);
+  float scalar = 1.0 - abs(vDepth);
   return vec4(vColor.xyz, scalar * vColor.a);
 }
 `);

--- a/src/neuroglancer/annotation/point_color_list.ts
+++ b/src/neuroglancer/annotation/point_color_list.ts
@@ -1,0 +1,92 @@
+/**
+ * @license
+ * Copyright 2018 The Neuroglancer Authors
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @file
+ * Defines a trackable in-memory list of point colors.
+ */
+
+import {Float32ArrayBuilder} from 'neuroglancer/util/float32array_builder';
+import {vec3} from 'neuroglancer/util/geom';
+import {parseFixedLengthArray, verifyFiniteFloat} from 'neuroglancer/util/json';
+import {NullarySignal} from 'neuroglancer/util/signal';
+
+export const DEFAULT_COLOR = vec3.fromValues(1.0, 1.0, 0.0);
+
+export class AnnotationPointColorList {
+  colors = new Float32ArrayBuilder();
+  changed = new NullarySignal();
+  generation = 0;
+
+  get length() {
+    return this.colors.length / 3;
+  }
+
+  delete(index: number) {
+    this.colors.eraseRange(index * 3, index * 3 + 3);
+    ++this.generation;
+    this.changed.dispatch();
+  }
+
+  get(index: number): vec3 {
+    return <vec3>this.colors.data.subarray(index * 3, index * 3 + 3);
+  }
+
+  append(point: vec3) {
+    this.colors.appendArray(point.subarray(0, 3));
+    ++this.generation;
+    this.changed.dispatch();
+  }
+
+  reset() {
+    this.colors.clear();
+    ++this.generation;
+    this.changed.dispatch();
+  }
+
+  restoreState(obj: any) {
+    try {
+      if (Array.isArray(obj)) {
+        const numPoints = obj.length;
+        let {colors} = this;
+        colors.resize(numPoints * 3);
+        let {data} = colors;
+        for (let i = 0; i < numPoints; ++i) {
+          const j = i * 3;
+          parseFixedLengthArray<number, Float32Array>(
+              data.subarray(j, j + 3), obj[i], verifyFiniteFloat);
+        }
+        ++this.generation;
+        this.changed.dispatch();
+        return;
+      }
+    } catch (ignoredError) {
+      this.reset();
+    }
+  }
+
+  toJSON() {
+    let {colors} = this;
+    const numPoints = this.length;
+    let data = colors.data;
+    let result = new Array(numPoints);
+    for (let i = 0; i < numPoints; ++i) {
+      const j = i * 3;
+      result[i] = [data[j], data[j + 1], data[j + 2]];
+    }
+    return result;
+  }
+}

--- a/src/neuroglancer/annotation/point_size_list.ts
+++ b/src/neuroglancer/annotation/point_size_list.ts
@@ -1,0 +1,80 @@
+/**
+ * @license
+ * Copyright 2018 The Neuroglancer Authors
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @file
+ * Defines a trackable in-memory list of point sizes.
+ */
+
+import {Float32ArrayBuilder} from 'neuroglancer/util/float32array_builder';
+import {parseFixedLengthArray, verifyFiniteFloat} from 'neuroglancer/util/json';
+import {NullarySignal} from 'neuroglancer/util/signal';
+
+export const DEFAULT_SIZE = 32.0;
+
+export class AnnotationPointSizeList {
+  sizes = new Float32ArrayBuilder();
+  changed = new NullarySignal();
+  generation = 0;
+
+  get length() {
+    return this.sizes.length;
+  }
+
+  delete(index: number) {
+    this.sizes.eraseRange(index, index + 1);
+    ++this.generation;
+    this.changed.dispatch();
+  }
+
+  get(index: number): number {
+    return this.sizes.data[index];
+  }
+
+  append(point: number) {
+    this.sizes.appendArray([point]);
+    ++this.generation;
+    this.changed.dispatch();
+  }
+
+  reset() {
+    this.sizes.clear();
+    ++this.generation;
+    this.changed.dispatch();
+  }
+
+  restoreState(obj: any) {
+    try {
+      if (Array.isArray(obj)) {
+        const numPoints = obj.length;
+        let {sizes} = this;
+        sizes.resize(numPoints);
+        let {data} = sizes;
+        parseFixedLengthArray<number, Float32Array>(
+            data.subarray(0, numPoints), obj, verifyFiniteFloat);
+        ++this.generation;
+        this.changed.dispatch();
+        return;
+      }
+    } catch (ignoredError) {
+      this.reset();
+    }
+  }
+
+  toJSON() {
+    return Array.from(this.sizes.view);
+  }
+}

--- a/src/neuroglancer/annotation/user_layer.ts
+++ b/src/neuroglancer/annotation/user_layer.ts
@@ -15,7 +15,9 @@
  */
 
 import {AnnotationPointListLayer, PerspectiveViewAnnotationPointListLayer, SliceViewAnnotationPointListLayer} from 'neuroglancer/annotation/frontend';
+import {AnnotationPointColorList} from 'neuroglancer/annotation/point_color_list';
 import {AnnotationPointList} from 'neuroglancer/annotation/point_list';
+import {AnnotationPointSizeList} from 'neuroglancer/annotation/point_size_list';
 import {UserLayer, UserLayerDropdown} from 'neuroglancer/layer';
 import {LayerListSpecification, registerLayerType} from 'neuroglancer/layer_specification';
 import {WatchableValue} from 'neuroglancer/trackable_value';
@@ -29,12 +31,36 @@ const LAYER_TYPE = 'pointAnnotation';
 export class AnnotationPointListUserLayer extends UserLayer {
   selectedIndex = new WatchableValue<number|null>(null);
   layer = new AnnotationPointListLayer(
-      this.manager.chunkManager, new AnnotationPointList(), this.manager.voxelSize,
-      this.selectedIndex);
+      this.manager.chunkManager, new AnnotationPointList(), new AnnotationPointColorList(),
+      new AnnotationPointSizeList, this.manager.voxelSize, this.selectedIndex);
   constructor(public manager: LayerListSpecification, x: any) {
     super([]);
+    this.layer.usePerspective2D.restoreState(x['perspective2D']);
+    this.layer.usePerspective3D.restoreState(x['perspective3D']);
+    this.layer.defaultSize.restoreState(x['defaultSize']);
+    this.layer.defaultColor.restoreState(x['defaultColor']);
     this.layer.pointList.restoreState(x['points']);
+    this.layer.colorList.restoreState(x['colors']);
+    this.layer.sizeList.restoreState(x['sizes']);
+    this.registerDisposer(this.layer.usePerspective2D.changed.add(() => {
+      this.specificationChanged.dispatch();
+    }));
+    this.registerDisposer(this.layer.usePerspective3D.changed.add(() => {
+      this.specificationChanged.dispatch();
+    }));
+    this.registerDisposer(this.layer.defaultSize.changed.add(() => {
+      this.specificationChanged.dispatch();
+    }));
+    this.registerDisposer(this.layer.defaultColor.changed.add(() => {
+      this.specificationChanged.dispatch();
+    }));
     this.registerDisposer(this.layer.pointList.changed.add(() => {
+      this.specificationChanged.dispatch();
+    }));
+    this.registerDisposer(this.layer.colorList.changed.add(() => {
+      this.specificationChanged.dispatch();
+    }));
+    this.registerDisposer(this.layer.sizeList.changed.add(() => {
       this.specificationChanged.dispatch();
     }));
     this.addRenderLayer(new PerspectiveViewAnnotationPointListLayer(this.layer));
@@ -48,7 +74,13 @@ export class AnnotationPointListUserLayer extends UserLayer {
   }
   toJSON() {
     let x: any = {'type': LAYER_TYPE};
+    x['perspective2D'] = this.layer.usePerspective2D.toJSON();
+    x['perspective3D'] = this.layer.usePerspective3D.toJSON();
+    x['defaultSize'] = this.layer.defaultSize.toJSON();
+    x['defaultColor'] = this.layer.defaultColor.toJSON();
     x['points'] = this.layer.pointList.toJSON();
+    x['colors'] = this.layer.colorList.toJSON();
+    x['sizes'] = this.layer.sizeList.toJSON();
     return x;
   }
 
@@ -58,6 +90,12 @@ export class AnnotationPointListUserLayer extends UserLayer {
         let selectedValue = this.manager.layerSelectedValues.get(this);
         if (selectedValue !== undefined) {
           this.layer.pointList.delete(selectedValue);
+          if (selectedValue < this.layer.colorList.length) {
+            this.layer.colorList.delete(selectedValue);
+          }
+          if (selectedValue < this.layer.sizeList.length) {
+            this.layer.sizeList.delete(selectedValue);
+          }
         } else if (this.manager.layerSelectedValues.mouseState.active) {
           this.layer.pointList.append(this.manager.voxelSize.voxelFromSpatial(
               vec3.create(), this.manager.layerSelectedValues.mouseState.position));
@@ -73,8 +111,11 @@ export class AnnotationPointListUserLayer extends UserLayer {
 }
 
 class Dropdown extends UserLayerDropdown {
-  pointListWidget = this.registerDisposer(
-      new PointListWidget(this.layer.layer.pointList, this.layer.selectedIndex));
+  pointListWidget = this.registerDisposer(new PointListWidget(
+      this.layer.layer.pointList, this.layer.layer.colorList, this.layer.layer.sizeList,
+      this.layer.selectedIndex, this.layer.layer.usePerspective2D,
+      this.layer.layer.usePerspective3D, this.layer.layer.defaultSize,
+      this.layer.layer.defaultColor));
   constructor(public element: HTMLDivElement, public layer: AnnotationPointListUserLayer) {
     super();
     element.classList.add('neuroglancer-annotation-point-list-dropdown');

--- a/src/neuroglancer/trackable_vec3.ts
+++ b/src/neuroglancer/trackable_vec3.ts
@@ -38,7 +38,7 @@ export class TrackableVec3 implements Trackable {
   constructor(private value_: vec3, public defaultValue: vec3) {}
   toJSON() {
     let {value_} = this;
-    if (value_ === this.defaultValue) {
+    if (vec3.equals(value_, this.defaultValue)) {
       return undefined;
     }
     return this.value_.toString();
@@ -47,10 +47,10 @@ export class TrackableVec3 implements Trackable {
     try {
       this.value = verify3dVec(x.split(','));
     } catch (e) {
-      this.value = this.defaultValue;
+      this.value = vec3.clone(this.defaultValue);
     }
   }
   reset() {
-    this.value = this.defaultValue;
+    this.value = vec3.clone(this.defaultValue);
   }
 }

--- a/src/neuroglancer/widget/point_list_widget.css
+++ b/src/neuroglancer/widget/point_list_widget.css
@@ -53,3 +53,33 @@
   text-decoration: underline;
   cursor: pointer;
 }
+
+.neuroglancer-defaultsize-input-container {
+  line-height: 1.5em;
+  text-align: middle;
+}
+
+#neuroglancer-defaultsize-input {
+  padding: 1px;
+  height: 1em;
+  width: 5em;
+  margin: 2px;
+  float: right;
+}
+
+.neuroglancer-defaultcolor-input-container {
+  line-height: 1.5em;
+  text-align: middle;
+}
+
+#neuroglancer-defaultcolor-input {
+  padding: 1px;
+  height: 1em;
+  width: 1em;
+  margin: 2px;
+  float: right;
+}
+
+#neuroglancer-defaultcolor-input::-webkit-color-swatch-wrapper {
+  padding: 0px;
+}

--- a/src/neuroglancer/widget/point_list_widget.ts
+++ b/src/neuroglancer/widget/point_list_widget.ts
@@ -19,8 +19,13 @@
  * Defines a widget for displaying a list of point locations.
  */
 
+import {AnnotationPointColorList} from 'neuroglancer/annotation/point_color_list';
 import {AnnotationPointList} from 'neuroglancer/annotation/point_list';
-import {WatchableValue} from 'neuroglancer/trackable_value';
+import {AnnotationPointSizeList} from 'neuroglancer/annotation/point_size_list';
+import {TrackableBoolean, TrackableBooleanCheckbox} from 'neuroglancer/trackable_boolean';
+import {TrackableValue, WatchableValue} from 'neuroglancer/trackable_value';
+import {TrackableVec3} from 'neuroglancer/trackable_vec3';
+import {hexToRgb, rgbToHex} from 'neuroglancer/util/colorspace';
 import {RefCounted} from 'neuroglancer/util/disposable';
 import {removeChildren, removeFromParent} from 'neuroglancer/util/dom';
 import {Signal} from 'neuroglancer/util/signal';
@@ -31,23 +36,89 @@ require('./point_list_widget.css');
 export class PointListWidget extends RefCounted {
   element = document.createElement('div');
   private clearButton = document.createElement('button');
+  private defaultSizeInput = document.createElement('input');
+  private defaultColorInput = document.createElement('input');
   private itemContainer = document.createElement('div');
   generation = -1;
   pointSelected = new Signal<(index: number) => void>();
   private visible_ = false;
 
   constructor(
-      public pointList: AnnotationPointList, public selectionIndex: WatchableValue<number|null>) {
+      public pointList: AnnotationPointList, public colorList: AnnotationPointColorList,
+      public sizeList: AnnotationPointSizeList, public selectionIndex: WatchableValue<number|null>,
+      public usePerspective2D: TrackableBoolean, public usePerspective3D: TrackableBoolean,
+      public defaultSize: TrackableValue<number>, public defaultColor: TrackableVec3) {
     super();
-    let {element, clearButton, itemContainer} = this;
+    let {element, clearButton, itemContainer, defaultSizeInput, defaultColorInput} = this;
     element.className = 'neuroglancer-point-list-widget';
     clearButton.className = 'neuroglancer-clear-button';
     clearButton.textContent = 'Delete all points';
     this.registerEventListener(clearButton, 'click', () => {
       this.pointList.reset();
+      this.colorList.reset();
+      this.sizeList.reset();
     });
-    itemContainer.className = 'neuroglancer-item-container neuroglancer-select-text';
     element.appendChild(clearButton);
+    {
+      const checkbox = this.registerDisposer(new TrackableBooleanCheckbox(usePerspective2D));
+      checkbox.element.className = 'neuroglancer-perspective-checkbox';
+      const label = document.createElement('label');
+      label.className = 'neuroglancer-perspective-checkbox';
+      label.appendChild(document.createTextNode('Perspective Scaling (2D)'));
+      label.appendChild(checkbox.element);
+      element.appendChild(label);
+    }
+    {
+      const checkbox = this.registerDisposer(new TrackableBooleanCheckbox(usePerspective3D));
+      checkbox.element.className = 'neuroglancer-perspective-checkbox';
+      const label = document.createElement('label');
+      label.className = 'neuroglancer-perspective-checkbox';
+      label.appendChild(document.createTextNode('Perspective Scaling (3D)'));
+      label.appendChild(checkbox.element);
+      element.appendChild(label);
+    }
+    {
+      defaultSizeInput.type = 'number';
+      defaultSizeInput.min = '1';
+      this.registerDisposer(defaultSize.changed.add(() => {
+        this.updateSizeInput();
+      }));
+      this.updateSizeInput();
+      this.registerEventListener(defaultSizeInput, 'input', () => {
+        defaultSize.value = parseFloat(defaultSizeInput.value);
+        defaultSize.changed.dispatch();
+      });
+      const div = document.createElement('div');
+      div.className = 'neuroglancer-defaultsize-input-container';
+      const label = document.createElement('label');
+      label.appendChild(document.createTextNode('Default Size'));
+      label.htmlFor = 'neuroglancer-defaultsize-input';
+      defaultSizeInput.id = 'neuroglancer-defaultsize-input';
+      div.appendChild(label);
+      div.appendChild(defaultSizeInput);
+      element.appendChild(div);
+    }
+    {
+      defaultColorInput.type = 'color';
+      this.registerDisposer(defaultColor.changed.add(() => {
+        this.updateColorInput();
+      }));
+      this.updateColorInput();
+      this.registerEventListener(defaultColorInput, 'input', () => {
+        hexToRgb(defaultColor.value, defaultColorInput.value);
+        defaultColor.changed.dispatch();
+      });
+      const div = document.createElement('div');
+      div.className = 'neuroglancer-defaultcolor-input-container';
+      const label = document.createElement('label');
+      label.appendChild(document.createTextNode('Default Color'));
+      label.htmlFor = 'neuroglancer-defaultcolor-input';
+      defaultColorInput.id = 'neuroglancer-defaultcolor-input';
+      div.appendChild(label);
+      div.appendChild(defaultColorInput);
+      element.appendChild(div);
+    }
+    itemContainer.className = 'neuroglancer-item-container neuroglancer-select-text';
     element.appendChild(itemContainer);
     this.registerDisposer(pointList.changed.add(() => {
       this.maybeUpdate();
@@ -64,6 +135,15 @@ export class PointListWidget extends RefCounted {
         this.maybeUpdate();
       }
     }
+  }
+
+  updateSizeInput() {
+    this.defaultSizeInput.value = this.defaultSize.value.toString();
+  }
+
+  updateColorInput() {
+    let col = rgbToHex(this.defaultColor.value);
+    this.defaultColorInput.value = col ? col : '#000000';
   }
 
   maybeUpdate() {
@@ -104,6 +184,8 @@ export class PointListWidget extends RefCounted {
     this.element = <any>undefined;
     this.itemContainer = <any>undefined;
     this.clearButton = <any>undefined;
+    this.defaultSizeInput = <any>undefined;
+    this.defaultColorInput = <any>undefined;
     super.disposed();
   }
 }


### PR DESCRIPTION
Lab asked for more control over color and size of all points, and being able to switch between the current orthogonal/fixed size view and a perspective projection for points.
Thought that might be a useful feature for other teams as well.

Visible to user:
* Adjustable color and size for points (only by modifying URL)
* Adjustable default color and size for points (right click on point annotation layer)
* Optional perspective scaling for 2D and/or 3D view. (right click on point annotation layer) Point sizes in this case are interpreted as physical units.

Invisible to user:
* Added `RgbToHex` and `HexToRgb` function in `utils/colorspace.ts`
* fixed unintended behavior (I think?) in `trackable_vec3.ts` -- wanted to verify with @alexbaden 

All changes should be backward compatible. A working demo can be found here: https://goo.gl/WSCPV7