### PR TITLE
Bugfix: Make computeVertexNormals normalize the normal vectors correc…

### DIFF
--- a/src/neuroglancer/mesh/backend.ts
+++ b/src/neuroglancer/mesh/backend.ts
@@ -153,13 +153,7 @@ export function computeVertexNormals(positions: Float32Array, indices: Uint32Arr
   const v1v0 = vec3.create();
   const v2v1 = vec3.create();
   let vertexNormals = new Float32Array(positions.length);
-  let vertexFaceCount = new Float32Array(positions.length / 3);
   let numIndices = indices.length;
-  for (let i = 0; i < numIndices; i += 3) {
-    for (let j = 0; j < 3; ++j) {
-      vertexFaceCount[indices[i + j]] += 1;
-    }
-  }
   for (let i = 0; i < numIndices; i += 3) {
     let i0 = indices[i] * 3, i1 = indices[i + 1] * 3, i2 = indices[i + 2] * 3;
     for (let j = 0; j < 3; ++j) {
@@ -171,17 +165,16 @@ export function computeVertexNormals(positions: Float32Array, indices: Uint32Arr
 
     for (let k = 0; k < 3; ++k) {
       let index = indices[i + k];
-      let scalar = 1.0 / vertexFaceCount[index];
       let offset = index * 3;
       for (let j = 0; j < 3; ++j) {
-        vertexNormals[offset + j] += scalar * faceNormal[j];
+        vertexNormals[offset + j] += faceNormal[j];
       }
     }
   }
   // Normalize all vertex normals.
   let numVertices = vertexNormals.length;
   for (let i = 0; i < numVertices; i += 3) {
-    let vec = <vec3>vertexNormals.subarray(i, 3);
+    let vec = <vec3>vertexNormals.subarray(i, i + 3);
     vec3.normalize(vec, vec);
   }
   return vertexNormals;


### PR DESCRIPTION
…tly: Float32Array.subarray must be called with [begin, end) indices.

Visually, this fix will make neurons appear slightly brighter overall and remove artifacts where certain vertices were much too dark before.

Optimization: Removed vertexFaceCount: With normal vector normalization working correctly, dividing by the number of adjacent triangles has no effect and can be removed.