### PR TITLE
fix(karma): "extract-text-webpack-plugin" loader is used without the corresponding plugin

### DIFF
--- a/config/karma.conf.js
+++ b/config/karma.conf.js
@@ -19,6 +19,7 @@
 let webpackHelpers = require('./webpack_helpers');
 const path = require('path');
 const webpack = require('webpack');
+const ExtractTextPlugin = require('extract-text-webpack-plugin');
 const minimist = require('minimist');
 
 module.exports = function(config) {
@@ -42,6 +43,7 @@ module.exports = function(config) {
             result.regExp = newRegExp;
           }
         }),
+    new ExtractTextPlugin({filename: 'styles.css', allChunks: true}),
   ];
 
   config.set({


### PR DESCRIPTION
Something introduced in 9c8a392391452b55b99ce597a7e5b94bef5620a3 causes `npm run test` to fail, complaining about missing plugin `extract-text-webpack-plugin`. Not sure what, or why it worked before...