### PR TITLE
updates to DVID driver

### DIFF
--- a/src/neuroglancer/datasource/dvid/backend.ts
+++ b/src/neuroglancer/datasource/dvid/backend.ts
@@ -54,11 +54,15 @@ const TILE_CHUNK_DECODERS = new Map<TileEncoding, ChunkDecoder>([
       return `/api/node/${params['nodeKey']}/${params['dataInstanceKey']}/subvolblocks/` +
           `${chunkDataSize[0]}_${chunkDataSize[1]}_${chunkDataSize[2]}/` +
           `${chunkPosition[0]}_${chunkPosition[1]}_${chunkPosition[2]}`;
-    } else if (params.encoding === VolumeChunkEncoding.RAW)  { 
+    } else if (params.encoding === VolumeChunkEncoding.RAW) { 
       return `/api/node/${params['nodeKey']}/${params['dataInstanceKey']}/raw/0_1_2/` +
           `${chunkDataSize[0]}_${chunkDataSize[1]}_${chunkDataSize[2]}/` +
           `${chunkPosition[0]}_${chunkPosition[1]}_${chunkPosition[2]}/jpeg`;
-    } else {
+    } else if (params.encoding === VolumeChunkEncoding.COMPRESSED_SEGMENTATIONARRAY) {
+      return `/api/node/${params['nodeKey']}/${params['dataInstanceKey']}/raw/0_1_2/` +
+          `${chunkDataSize[0]}_${chunkDataSize[1]}_${chunkDataSize[2]}/` +
+          `${chunkPosition[0]}_${chunkPosition[1]}_${chunkPosition[2]}?compression=googlegzip&scale=${params['dataScale']}`;
+     } else {
       // encoding is COMPRESSED_SEGMENTATION
       return `/api/node/${params['nodeKey']}/${params['dataInstanceKey']}/raw/0_1_2/` +
           `${chunkDataSize[0]}_${chunkDataSize[1]}_${chunkDataSize[2]}/` +

--- a/src/neuroglancer/datasource/dvid/backend.ts
+++ b/src/neuroglancer/datasource/dvid/backend.ts
@@ -45,14 +45,15 @@ const TILE_CHUNK_DECODERS = new Map<TileEncoding, ChunkDecoder>([
     let decoder = this.getDecoder(params);
     return sendHttpRequest(
                openShardedHttpRequest(params.baseUrls, path), 'arraybuffer', cancellationToken)
-        .then(response => decoder(chunk, response));
+               .then(response => decoder(chunk, (params.encoding === VolumeChunkEncoding.JPEG) 
+                                                    ? response.slice(16) : response));
   }
   getPath(chunkPosition: Float32Array, chunkDataSize: Float32Array) {
     let params = this.parameters;
     if (params.encoding === VolumeChunkEncoding.JPEG) {
-      return `/api/node/${params['nodeKey']}/${params['dataInstanceKey']}/raw/0_1_2/` +
+    return `/api/node/${params['nodeKey']}/${params['dataInstanceKey']}/subvolblocks/` +
           `${chunkDataSize[0]}_${chunkDataSize[1]}_${chunkDataSize[2]}/` +
-          `${chunkPosition[0]}_${chunkPosition[1]}_${chunkPosition[2]}/jpeg`;
+          `${chunkPosition[0]}_${chunkPosition[1]}_${chunkPosition[2]}`;
     } else {
       // encoding is COMPRESSED_SEGMENTATION
       return `/api/node/${params['nodeKey']}/${params['dataInstanceKey']}/raw/0_1_2/` +

--- a/src/neuroglancer/datasource/dvid/backend.ts
+++ b/src/neuroglancer/datasource/dvid/backend.ts
@@ -51,9 +51,13 @@ const TILE_CHUNK_DECODERS = new Map<TileEncoding, ChunkDecoder>([
   getPath(chunkPosition: Float32Array, chunkDataSize: Float32Array) {
     let params = this.parameters;
     if (params.encoding === VolumeChunkEncoding.JPEG) {
-    return `/api/node/${params['nodeKey']}/${params['dataInstanceKey']}/subvolblocks/` +
+      return `/api/node/${params['nodeKey']}/${params['dataInstanceKey']}/subvolblocks/` +
           `${chunkDataSize[0]}_${chunkDataSize[1]}_${chunkDataSize[2]}/` +
           `${chunkPosition[0]}_${chunkPosition[1]}_${chunkPosition[2]}`;
+    } else if (params.encoding === VolumeChunkEncoding.RAW)  { 
+      return `/api/node/${params['nodeKey']}/${params['dataInstanceKey']}/raw/0_1_2/` +
+          `${chunkDataSize[0]}_${chunkDataSize[1]}_${chunkDataSize[2]}/` +
+          `${chunkPosition[0]}_${chunkPosition[1]}_${chunkPosition[2]}/jpeg`;
     } else {
       // encoding is COMPRESSED_SEGMENTATION
       return `/api/node/${params['nodeKey']}/${params['dataInstanceKey']}/raw/0_1_2/` +
@@ -62,7 +66,8 @@ const TILE_CHUNK_DECODERS = new Map<TileEncoding, ChunkDecoder>([
     }
   }
   getDecoder(params: any) {
-    if (params.encoding === VolumeChunkEncoding.JPEG) {
+    if ((params.encoding === VolumeChunkEncoding.JPEG) || 
+        (params.encoding === VolumeChunkEncoding.RAW)) {
       return decodeJpegChunk;
     } else {
       // encoding is COMPRESSED_SEGMENTATION

--- a/src/neuroglancer/datasource/dvid/base.ts
+++ b/src/neuroglancer/datasource/dvid/base.ts
@@ -33,6 +33,10 @@ export class VolumeChunkSourceParameters extends DVIDSourceParameters {
   static RPC_ID = 'dvid/VolumeChunkSource';
 }
 
+export class SkeletonSourceParameters extends DVIDSourceParameters {
+  static RPC_ID = 'dvid/SkeletonSource';
+}
+
 export enum TileEncoding {
   JPEG
 }

--- a/src/neuroglancer/datasource/dvid/base.ts
+++ b/src/neuroglancer/datasource/dvid/base.ts
@@ -16,6 +16,7 @@
 
 export enum VolumeChunkEncoding {
   JPEG,
+  RAW,
   COMPRESSED_SEGMENTATION
 }
 

--- a/src/neuroglancer/datasource/dvid/base.ts
+++ b/src/neuroglancer/datasource/dvid/base.ts
@@ -17,7 +17,8 @@
 export enum VolumeChunkEncoding {
   JPEG,
   RAW,
-  COMPRESSED_SEGMENTATION
+  COMPRESSED_SEGMENTATION,
+  COMPRESSED_SEGMENTATIONARRAY
 }
 
 export class DVIDSourceParameters {
@@ -27,6 +28,7 @@ export class DVIDSourceParameters {
 }
 
 export class VolumeChunkSourceParameters extends DVIDSourceParameters {
+  dataScale: string;
   encoding: VolumeChunkEncoding;
   static RPC_ID = 'dvid/VolumeChunkSource';
 }

--- a/src/neuroglancer/datasource/dvid/base.ts
+++ b/src/neuroglancer/datasource/dvid/base.ts
@@ -36,15 +36,3 @@ export class VolumeChunkSourceParameters extends DVIDSourceParameters {
 export class SkeletonSourceParameters extends DVIDSourceParameters {
   static RPC_ID = 'dvid/SkeletonSource';
 }
-
-export enum TileEncoding {
-  JPEG
-}
-
-export class TileChunkSourceParameters extends DVIDSourceParameters {
-  dims: string;
-  level: string;
-  encoding: TileEncoding;
-
-  static RPC_ID = 'dvid/TileChunkSource';
-}

--- a/src/neuroglancer/datasource/dvid/frontend.ts
+++ b/src/neuroglancer/datasource/dvid/frontend.ts
@@ -21,7 +21,7 @@
 
 import {ChunkManager, WithParameters} from 'neuroglancer/chunk_manager/frontend';
 import {CompletionResult, DataSource} from 'neuroglancer/datasource';
-import {DVIDSourceParameters, SkeletonSourceParameters, TileChunkSourceParameters, TileEncoding, VolumeChunkEncoding, VolumeChunkSourceParameters} from 'neuroglancer/datasource/dvid/base';
+import {DVIDSourceParameters, SkeletonSourceParameters, VolumeChunkEncoding, VolumeChunkSourceParameters} from 'neuroglancer/datasource/dvid/base';
 import {SkeletonSource} from 'neuroglancer/skeleton/frontend';
 import {DataType, VolumeChunkSpecification, VolumeSourceOptions, VolumeType} from 'neuroglancer/sliceview/volume/base';
 import {MultiscaleVolumeChunkSource as GenericMultiscaleVolumeChunkSource, VolumeChunkSource} from 'neuroglancer/sliceview/volume/frontend';
@@ -29,7 +29,7 @@ import {StatusMessage} from 'neuroglancer/status';
 import {applyCompletionOffset, getPrefixMatchesWithDescriptions} from 'neuroglancer/util/completion';
 import {mat4, vec3} from 'neuroglancer/util/geom';
 import {openShardedHttpRequest, sendHttpRequest} from 'neuroglancer/util/http_request';
-import {parseArray, parseFixedLengthArray, parseIntVec, verifyFinitePositiveFloat, verifyInt, verifyMapKey, verifyObject, verifyObjectAsMap, verifyObjectProperty, verifyPositiveInt, verifyString} from 'neuroglancer/util/json';
+import {parseArray, parseFixedLengthArray, parseIntVec, verifyFinitePositiveFloat, verifyMapKey, verifyObject, verifyObjectAsMap, verifyObjectProperty, verifyPositiveInt, verifyString} from 'neuroglancer/util/json';
 
 let serverDataTypes = new Map<string, DataType>();
 serverDataTypes.set('uint8', DataType.UINT8);
@@ -40,7 +40,7 @@ export class DataInstanceBaseInfo {
   get typeName(): string {
     return this.obj['TypeName'];
   }
-  
+
   get compressionName(): string {
     return this.obj['Compression'];
   }
@@ -86,7 +86,7 @@ export class VolumeDataInstanceInfo extends DataInstanceInfo {
     if (encoding === VolumeChunkEncoding.COMPRESSED_SEGMENTATIONARRAY) {
       // retrieve maximum downres level
       let maxdownreslevel = verifyObjectProperty(extended, 'MaxDownresLevel', verifyPositiveInt);
-      this.numLevels = maxdownreslevel + 1
+      this.numLevels = maxdownreslevel + 1;
     } else {
       // labelblk does not have explicit datatype support for multiscale but
       // by convention different levels are specified with unique
@@ -96,9 +96,9 @@ export class VolumeDataInstanceInfo extends DataInstanceInfo {
       }
     }
 
-    this.skeletonSrc = "";
-    if (instSet.has(name + "_skeletons")) {
-      this.skeletonSrc = name + "_skeletons";
+    this.skeletonSrc = '';
+    if (instSet.has(name + '_skeletons')) {
+      this.skeletonSrc = name + '_skeletons';
     }
 
     this.dataType =
@@ -111,9 +111,10 @@ export class VolumeDataInstanceInfo extends DataInstanceInfo {
 
   get volumeType() {
     return (
-      (this.encoding === VolumeChunkEncoding.COMPRESSED_SEGMENTATION ||
-       this.encoding === VolumeChunkEncoding.COMPRESSED_SEGMENTATIONARRAY) ? 
-            VolumeType.SEGMENTATION : VolumeType.IMAGE);
+        (this.encoding === VolumeChunkEncoding.COMPRESSED_SEGMENTATION ||
+         this.encoding === VolumeChunkEncoding.COMPRESSED_SEGMENTATIONARRAY) ?
+            VolumeType.SEGMENTATION :
+            VolumeType.IMAGE);
   }
 
   getSources(
@@ -123,21 +124,21 @@ export class VolumeDataInstanceInfo extends DataInstanceInfo {
     let sources: VolumeChunkSource[][] = [];
 
     // must be 64 block size to work with neuroglancer properly
-    let blocksize = 64; 
+    let blocksize = 64;
     for (let level = 0; level < this.numLevels; ++level) {
       let voxelSize = vec3.scale(vec3.create(), this.voxelSize, Math.pow(2, level));
       let lowerVoxelBound = vec3.create();
       let upperVoxelBound = vec3.create();
       for (let i = 0; i < 3; ++i) {
-        let lowerVoxelNotAligned = 
-          Math.floor(this.lowerVoxelBound[i] * (this.voxelSize[i] / voxelSize[i]));
+        let lowerVoxelNotAligned =
+            Math.floor(this.lowerVoxelBound[i] * (this.voxelSize[i] / voxelSize[i]));
         // adjust min to be a multiple of blocksize
         lowerVoxelBound[i] = lowerVoxelNotAligned - (lowerVoxelNotAligned % blocksize);
         let upperVoxelNotAligned =
-          Math.ceil((this.upperVoxelBound[i]+1) * (this.voxelSize[i] / voxelSize[i]));
+            Math.ceil((this.upperVoxelBound[i] + 1) * (this.voxelSize[i] / voxelSize[i]));
         upperVoxelBound[i] = upperVoxelNotAligned;
         // adjust max to be a multiple of blocksize
-        if ((upperVoxelNotAligned % blocksize) != 0) {
+        if ((upperVoxelNotAligned % blocksize) !== 0) {
           upperVoxelBound[i] += (blocksize - (upperVoxelNotAligned % blocksize));
         }
       }
@@ -169,8 +170,8 @@ export class VolumeDataInstanceInfo extends DataInstanceInfo {
                 volumeType: this.volumeType,
                 volumeSourceOptions,
                 compressedSegmentationBlockSize:
-                  ((encoding === VolumeChunkEncoding.COMPRESSED_SEGMENTATION || 
-                    encoding === VolumeChunkEncoding.COMPRESSED_SEGMENTATIONARRAY) ?
+                    ((encoding === VolumeChunkEncoding.COMPRESSED_SEGMENTATION ||
+                      encoding === VolumeChunkEncoding.COMPRESSED_SEGMENTATIONARRAY) ?
                          vec3.fromValues(8, 8, 8) :
                          undefined)
               })
@@ -182,170 +183,20 @@ export class VolumeDataInstanceInfo extends DataInstanceInfo {
     }
     return sources;
   }
-  
-  getSkeletonSource(
-      chunkManager: ChunkManager, parameters: DVIDSourceParameters) {
-    if (this.skeletonSrc !== "") {
-      alert(this.skeletonSrc);
-      return chunkManager.getChunkSource(
-        DVIDSkeletonSource, {parameters: {
+
+  getSkeletonSource(chunkManager: ChunkManager, parameters: DVIDSourceParameters) {
+    if (this.skeletonSrc !== '') {
+      return chunkManager.getChunkSource(DVIDSkeletonSource, {
+        parameters: {
           'baseUrls': parameters.baseUrls,
           'nodeKey': parameters.nodeKey,
-          'dataInstanceKey': this.skeletonSrc, 
-        }});
-    } else {
-      return null;
-    }
-  }
-}
-
-export class TileLevelInfo {
-  /**
-   * Resolution of the two downsampled dimensions in the tile plane.  The tile depth is equal to the
-   * base voxel size in that dimension.
-   */
-  resolution: vec3;
-  tileSize: vec3;
-
-  constructor(obj: any) {
-    verifyObject(obj);
-    this.resolution = verifyObjectProperty(
-        obj, 'Resolution', x => parseFixedLengthArray(vec3.create(), x, verifyFinitePositiveFloat));
-    this.tileSize = verifyObjectProperty(
-        obj, 'TileSize', x => parseFixedLengthArray(vec3.create(), x, verifyPositiveInt));
-  }
-}
-
-/**
- * Dimensions for which tiles are computed.
- *
- * DVID does not indicate which dimensions are available but it
- * provides blank tiles if the dimension asked for is not there.
- */
-const TILE_DIMS = [
-  [0, 1],
-  [0, 2],
-  [1, 2],
-];
-
-class TileChunkSource extends
-(WithParameters(VolumeChunkSource, TileChunkSourceParameters)) {}
-
-export class TileDataInstanceInfo extends DataInstanceInfo {
-  get dataType() {
-    return DataType.UINT8;
-  }
-  get volumeType() {
-    return VolumeType.IMAGE;
-  }
-  get numChannels() {
-    return 1;
-  }
-
-  encoding: TileEncoding;
-
-  /**
-   * Base voxel size (nm).
-   */
-  voxelSize: vec3;
-
-  skeletonSrc: string;
-  levels: Map<string, TileLevelInfo>;
-
-  lowerVoxelBound: vec3;
-  upperVoxelBound: vec3;
-
-  constructor(obj: any, name: string, base: DataInstanceBaseInfo) {
-    super(obj, name, base);
-    let extended = verifyObjectProperty(obj, 'Extended', verifyObject);
-    this.levels = verifyObjectProperty(
-        extended, 'Levels', x => verifyObjectAsMap(x, y => new TileLevelInfo(y)));
-    let baseLevel = this.levels.get('0');
-    if (baseLevel === undefined) {
-      throw new Error(`Level 0 is not defined.`);
-    }
-    // do not allow skeletons for tiles interface for now
-    this.skeletonSrc = "";
-
-    this.voxelSize = baseLevel.resolution;
-    let minTileCoord = verifyObjectProperty(
-        extended, 'MinTileCoord', x => parseFixedLengthArray(vec3.create(), x, verifyInt));
-    let maxTileCoord = verifyObjectProperty(
-        extended, 'MaxTileCoord', x => parseFixedLengthArray(vec3.create(), x, verifyInt));
-    this.lowerVoxelBound = vec3.multiply(vec3.create(), baseLevel.tileSize, minTileCoord);
-    this.upperVoxelBound = vec3.multiply(vec3.create(), baseLevel.tileSize, maxTileCoord);
-
-    let encodingNumber = verifyObjectProperty(extended, 'Encoding', x => x);
-    switch (encodingNumber) {
-      case 2:
-        this.encoding = TileEncoding.JPEG;
-        break;
-      default:
-        throw new Error(`Unsupported tile encoding: ${JSON.stringify(encodingNumber)}.`);
-    }
-  }
-
-  getSources(
-      chunkManager: ChunkManager, parameters: DVIDSourceParameters,
-      volumeSourceOptions: VolumeSourceOptions) {
-    let sources: VolumeChunkSource[][] = [];
-    let {numChannels, dataType, encoding} = this;
-    for (let [level, levelInfo] of this.levels) {
-      let alternatives = TILE_DIMS.map(dims => {
-        let voxelSize = vec3.clone(this.voxelSize);
-        let chunkDataSize = vec3.fromValues(1, 1, 1);
-        // tiles are always NxMx1
-        for (let i = 0; i < 2; ++i) {
-          voxelSize[dims[i]] = levelInfo.resolution[dims[i]];
-          chunkDataSize[dims[i]] = levelInfo.tileSize[dims[i]];
+          'dataInstanceKey': this.skeletonSrc,
         }
-        let lowerVoxelBound = vec3.create(), upperVoxelBound = vec3.create();
-        for (let i = 0; i < 3; ++i) {
-          lowerVoxelBound[i] =
-              Math.floor(this.lowerVoxelBound[i] * (this.voxelSize[i] / voxelSize[i]));
-          upperVoxelBound[i] =
-              Math.ceil(this.upperVoxelBound[i] * (this.voxelSize[i] / voxelSize[i]));
-        }
-        let spec = VolumeChunkSpecification.make({
-          voxelSize,
-          chunkDataSize,
-          numChannels: numChannels,
-          dataType: dataType,
-          lowerVoxelBound,
-          upperVoxelBound,
-          volumeSourceOptions,
-        });
-        return chunkManager.getChunkSource(TileChunkSource, {
-          spec,
-          parameters: {
-            'baseUrls': parameters.baseUrls,
-            'nodeKey': parameters.nodeKey,
-            'dataInstanceKey': parameters.dataInstanceKey,
-            'encoding': encoding,
-            'level': level,
-            'dims': `${dims[0]}_${dims[1]}`,
-          }
-        });
       });
-      sources.push(alternatives);
-    }
-    return sources;
-  }
-  
-  getSkeletonSource(
-      chunkManager: ChunkManager, parameters: DVIDSourceParameters) {
-    if (this.skeletonSrc !== "") {
-      return chunkManager.getChunkSource(
-      DVIDSkeletonSource, {parameters: {
-        'baseUrls': parameters.baseUrls,
-        'nodeKey': parameters.nodeKey,
-        'dataInstanceKey': this.skeletonSrc, 
-        }});
     } else {
       return null;
     }
   }
-
 }
 
 export function parseDataInstance(
@@ -355,11 +206,10 @@ export function parseDataInstance(
   switch (baseInfo.typeName) {
     case 'uint8blk':
     case 'grayscale8':
-      let isjpegcompress = baseInfo.compressionName.indexOf("jpeg") !== -1;
+      let isjpegcompress = baseInfo.compressionName.indexOf('jpeg') !== -1;
       return new VolumeDataInstanceInfo(
-          obj, name, baseInfo, (isjpegcompress ? VolumeChunkEncoding.JPEG : VolumeChunkEncoding.RAW), instanceNames);
-    case 'imagetile':
-      return new TileDataInstanceInfo(obj, name, baseInfo);
+          obj, name, baseInfo,
+          (isjpegcompress ? VolumeChunkEncoding.JPEG : VolumeChunkEncoding.RAW), instanceNames);
     case 'labels64':
     case 'labelblk':
       return new VolumeDataInstanceInfo(
@@ -479,8 +329,7 @@ export function getServerInfo(chunkManager: ChunkManager, baseUrls: string[]) {
  * this requires an extra api call
  */
 export function getDataInstanceDetails(
-    chunkManager: ChunkManager, baseUrls: string[], nodeKey: string,
-    info: VolumeDataInstanceInfo|TileDataInstanceInfo) {
+    chunkManager: ChunkManager, baseUrls: string[], nodeKey: string, info: VolumeDataInstanceInfo) {
   return chunkManager.memoize.getUncounted(
       {type: 'dvid:getInstanceDetails', baseUrls, nodeKey, name: info.name}, () => {
         let result = sendHttpRequest(
@@ -503,7 +352,6 @@ export function getDataInstanceDetails(
               verifyObjectProperty(extended, 'MaxPoint', x => parseIntVec(vec3.create(), x));
           return info;
         });
-
       });
 }
 
@@ -521,7 +369,7 @@ export class MultiscaleVolumeChunkSource implements GenericMultiscaleVolumeChunk
 
   constructor(
       public chunkManager: ChunkManager, public baseUrls: string[], public nodeKey: string,
-      public dataInstanceKey: string, public info: VolumeDataInstanceInfo|TileDataInstanceInfo) {}
+      public dataInstanceKey: string, public info: VolumeDataInstanceInfo) {}
 
   getSources(volumeSourceOptions: VolumeSourceOptions) {
     return this.info.getSources(
@@ -534,13 +382,11 @@ export class MultiscaleVolumeChunkSource implements GenericMultiscaleVolumeChunk
   }
 
   getMeshSource() {
-    alert(this.dataInstanceKey);
-    return this.info.getSkeletonSource(
-        this.chunkManager, {
-          'baseUrls': this.baseUrls,
-          'nodeKey': this.nodeKey,
-          'dataInstanceKey': this.dataInstanceKey,
-        });
+    return this.info.getSkeletonSource(this.chunkManager, {
+      'baseUrls': this.baseUrls,
+      'nodeKey': this.nodeKey,
+      'dataInstanceKey': this.dataInstanceKey,
+    });
   }
 }
 
@@ -553,14 +399,12 @@ export function getShardedVolume(
           throw new Error(`Invalid node: ${JSON.stringify(nodeKey)}.`);
         }
         const dataInstanceInfo = repositoryInfo.dataInstances.get(dataInstanceKey);
-        if (!(dataInstanceInfo instanceof VolumeDataInstanceInfo) &&
-            !(dataInstanceInfo instanceof TileDataInstanceInfo)) {
+        if (!(dataInstanceInfo instanceof VolumeDataInstanceInfo)) {
           throw new Error(`Invalid data instance ${dataInstanceKey}.`);
         }
         return getDataInstanceDetails(chunkManager, baseUrls, nodeKey, dataInstanceInfo);
       })
-      .then((info: VolumeDataInstanceInfo | TileDataInstanceInfo) => {
-
+      .then((info: VolumeDataInstanceInfo) => {
         return chunkManager.memoize.getUncounted(
             {
               type: 'dvid:MultiscaleVolumeChunkSource',
@@ -610,8 +454,8 @@ export function completeNodeAndInstance(serverInfo: ServerInfo, prefix: string):
     };
   }
   let nodeKey = match[1];
-  let repository = serverInfo.getNode(nodeKey);
-  return applyCompletionOffset(nodeKey.length + 1, completeInstanceName(repository, match[2]));
+  let repositoryInfo = serverInfo.getNode(nodeKey);
+  return applyCompletionOffset(nodeKey.length + 1, completeInstanceName(repositoryInfo, match[2]));
 }
 
 export function volumeCompleter(

--- a/src/neuroglancer/datasource/dvid/frontend.ts
+++ b/src/neuroglancer/datasource/dvid/frontend.ts
@@ -321,6 +321,7 @@ export function parseDataInstance(
       return new VolumeDataInstanceInfo(
           obj, name, baseInfo, VolumeChunkEncoding.COMPRESSED_SEGMENTATION, instanceNames);
     case 'labelarray':
+    case 'labelmap':
       return new VolumeDataInstanceInfo(
           obj, name, baseInfo, VolumeChunkEncoding.COMPRESSED_SEGMENTATIONARRAY, instanceNames);
     default:

--- a/src/neuroglancer/datasource/dvid/frontend.ts
+++ b/src/neuroglancer/datasource/dvid/frontend.ts
@@ -39,6 +39,10 @@ export class DataInstanceBaseInfo {
   get typeName(): string {
     return this.obj['TypeName'];
   }
+  
+  get compressionName(): string {
+    return this.obj['Compression'];
+  }
 
   constructor(public obj: any) {
     verifyObject(obj);
@@ -285,8 +289,9 @@ export function parseDataInstance(
   switch (baseInfo.typeName) {
     case 'uint8blk':
     case 'grayscale8':
+      let isjpegcompress = baseInfo.compressionName.indexOf("jpeg") !== -1;
       return new VolumeDataInstanceInfo(
-          obj, name, baseInfo, VolumeChunkEncoding.JPEG, instanceNames);
+          obj, name, baseInfo, (isjpegcompress ? VolumeChunkEncoding.JPEG : VolumeChunkEncoding.RAW), instanceNames);
     case 'imagetile':
       return new TileDataInstanceInfo(obj, name, baseInfo);
     case 'labels64':


### PR DESCRIPTION
All changes were made within the dvid datasource.

* Adds supported for faster, pre-computed JPEG grayscale blocks
* Adds support for new multi-scale segmentation datatype
* Adds support for showing skeletons stored in DVID
* Fixes a bug in the offset calculation
* Removes support for dvid image tiles since its use in DVID is mostly deprecated and a non-ideal fit for neuroglancer

tslint and clang-format were run on the files.