### PR TITLE
fix(viewer): save 'xy' layout to JSON state

### DIFF
--- a/src/neuroglancer/layer_group_viewer.ts
+++ b/src/neuroglancer/layer_group_viewer.ts
@@ -267,7 +267,7 @@ export class LayerGroupViewer extends RefCounted {
     element.classList.add('neuroglancer-layer-group-viewer');
     this.registerDisposer(new AutomaticallyFocusedElement(element));
 
-    this.layout = this.registerDisposer(new DataPanelLayoutContainer(this, 'xy'));
+    this.layout = this.registerDisposer(new DataPanelLayoutContainer(this, '4panel'));
     this.state.add('layout', this.layout);
     this.registerActionBindings();
     this.registerDisposer(this.layerManager.useDirectly());


### PR DESCRIPTION
Refreshing Neuroglancer while using the `xy` layout changes the view to `4panel` mode. This PR fixes it by unifying default values when calling `new DataPanelLayoutContainer(...)` in [layer_group_viewer.ts](https://github.com/seung-lab/neuroglancer/blob/38c8ed8c24e0b24ddc9f0ceaa401d46e274d45c2/src/neuroglancer/layer_group_viewer.ts#L270) and `new RootLayoutContainer(...)` in [viewer.ts](https://github.com/seung-lab/neuroglancer/blob/38c8ed8c24e0b24ddc9f0ceaa401d46e274d45c2/src/neuroglancer/viewer.ts#L478)

First bad commit: e2cfba0fb3c6ed4ff91f05847446b91aca73d6f0
Closes https://github.com/seung-lab/neuroglancer/issues/207