### PR TITLE
feat(webgl): Switch to WebGL2 and GLSL 300 ES

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ or within Neuroglancer, press `h` or click on the button labeled `?` in the uppe
 
 - Neuroglancer doesn't appear to load properly.
 
-  Neuroglancer requires WebGL (1.0) and the `WEBGL_draw_buffers`, `OES_texture_float`, and `OES_element_index_uint` extensions.
+  Neuroglancer requires WebGL (2.0) and the `EXT_color_buffer_float` extension.
   
   To troubleshoot, check the developer console, which is accessed by the keyboard shortcut `control-shift-i` in Firefox and Chrome.  If there is a message regarding failure to initialize WebGL, you can take the following steps:
   

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "@types/pako": "^1.0.0",
     "@types/sockjs-client": "^1.0.32",
     "@types/text-encoding": "0.0.31",
+    "@types/webgl2": "^0.0.4",
     "@types/webpack-env": "^1.13.2",
     "babel-core": "^6.26.0",
     "babel-loader": "^7.1.2",

--- a/src/neuroglancer/annotation/bounding_box.ts
+++ b/src/neuroglancer/annotation/bounding_box.ts
@@ -146,11 +146,11 @@ abstract class RenderHelper extends AnnotationRenderHelper {
           aUpper, /*components=*/3, /*attributeType=*/GL_FLOAT, /*normalized=*/false,
           /*stride=*/4 * 6, /*offset=*/context.bufferOffset + 4 * 3);
 
-      gl.ANGLE_instanced_arrays.vertexAttribDivisorANGLE(aLower, 1);
-      gl.ANGLE_instanced_arrays.vertexAttribDivisorANGLE(aUpper, 1);
+      gl.vertexAttribDivisor(aLower, 1);
+      gl.vertexAttribDivisor(aUpper, 1);
       callback();
-      gl.ANGLE_instanced_arrays.vertexAttribDivisorANGLE(aLower, 0);
-      gl.ANGLE_instanced_arrays.vertexAttribDivisorANGLE(aUpper, 0);
+      gl.vertexAttribDivisor(aLower, 0);
+      gl.vertexAttribDivisor(aUpper, 0);
       gl.disableVertexAttribArray(aLower);
       gl.disableVertexAttribArray(aUpper);
     });
@@ -337,7 +337,7 @@ emitAnnotation(vec4(vColor.rgb, uFillOpacity));
 
       if (fillOpacity) {
         gl.uniform1f(shader.uniform('uFillOpacity'), fillOpacity);
-        gl.ANGLE_instanced_arrays.drawArraysInstancedANGLE(GL_TRIANGLE_FAN, 0, 6, context.count);
+        gl.drawArraysInstanced(GL_TRIANGLE_FAN, 0, 6, context.count);
       } else {
         const lineWidth = context.renderContext.emitColor ? 1 : 5;
         this.lineShader.draw(shader, context.renderContext, lineWidth, 1.0, context.count);

--- a/src/neuroglancer/annotation/ellipsoid.ts
+++ b/src/neuroglancer/annotation/ellipsoid.ts
@@ -53,11 +53,11 @@ abstract class RenderHelper extends AnnotationRenderHelper {
       context.buffer.bindToVertexAttrib(
           aRadii, /*components=*/3, /*attributeType=*/GL_FLOAT, /*normalized=*/false,
           /*stride=*/4 * 6, /*offset=*/context.bufferOffset + 4 * 3);
-      gl.ANGLE_instanced_arrays.vertexAttribDivisorANGLE(aCenter, 1);
-      gl.ANGLE_instanced_arrays.vertexAttribDivisorANGLE(aRadii, 1);
+      gl.vertexAttribDivisor(aCenter, 1);
+      gl.vertexAttribDivisor(aRadii, 1);
       callback();
-      gl.ANGLE_instanced_arrays.vertexAttribDivisorANGLE(aCenter, 0);
-      gl.ANGLE_instanced_arrays.vertexAttribDivisorANGLE(aRadii, 0);
+      gl.vertexAttribDivisor(aCenter, 0);
+      gl.vertexAttribDivisor(aRadii, 0);
       gl.disableVertexAttribArray(aCenter);
       gl.disableVertexAttribArray(aRadii);
     });

--- a/src/neuroglancer/annotation/line.ts
+++ b/src/neuroglancer/annotation/line.ts
@@ -93,11 +93,11 @@ emitAnnotation(getCircleColor(vColor, borderColor));
           aUpper, /*components=*/3, /*attributeType=*/GL_FLOAT, /*normalized=*/false,
           /*stride=*/4 * 6, /*offset=*/context.bufferOffset + 4 * 3);
 
-      gl.ANGLE_instanced_arrays.vertexAttribDivisorANGLE(aLower, 1);
-      gl.ANGLE_instanced_arrays.vertexAttribDivisorANGLE(aUpper, 1);
+      gl.vertexAttribDivisor(aLower, 1);
+      gl.vertexAttribDivisor(aUpper, 1);
       callback();
-      gl.ANGLE_instanced_arrays.vertexAttribDivisorANGLE(aLower, 0);
-      gl.ANGLE_instanced_arrays.vertexAttribDivisorANGLE(aUpper, 0);
+      gl.vertexAttribDivisor(aLower, 0);
+      gl.vertexAttribDivisor(aUpper, 0);
       gl.disableVertexAttribArray(aLower);
       gl.disableVertexAttribArray(aUpper);
     });

--- a/src/neuroglancer/annotation/point.ts
+++ b/src/neuroglancer/annotation/point.ts
@@ -53,12 +53,12 @@ emitAnnotation(getCircleColor(vColor, borderColor));
       context.buffer.bindToVertexAttrib(
           aVertexPosition, /*components=*/3, /*attributeType=*/GL_FLOAT, /*normalized=*/false,
           /*stride=*/0, /*offset=*/context.bufferOffset);
-      gl.ANGLE_instanced_arrays.vertexAttribDivisorANGLE(aVertexPosition, 1);
+      gl.vertexAttribDivisor(aVertexPosition, 1);
       this.circleShader.draw(
           shader, context.renderContext,
           {interiorRadiusInPixels: 6, borderWidthInPixels: 2, featherWidthInPixels: 1},
           context.count);
-      gl.ANGLE_instanced_arrays.vertexAttribDivisorANGLE(aVertexPosition, 0);
+      gl.vertexAttribDivisor(aVertexPosition, 0);
       gl.disableVertexAttribArray(aVertexPosition);
     });
   }

--- a/src/neuroglancer/annotation/type_handler.ts
+++ b/src/neuroglancer/annotation/type_handler.ts
@@ -64,7 +64,7 @@ ${partIndexExpressions.map((_, i) => `uint32_t pickOffset${i} = add(pickBaseOffs
     s += `
   vPickID = add(pickID, pickOffset0).value;
   uint32_t selectedIndex; selectedIndex.value = uSelectedIndex;
-if (equal(selectedIndex, pickBaseOffset)${partIndexExpressions.map((_, i) => ` || equal(selectedIndex, pickOffset${i})`).join('')}) {
+if (equals(selectedIndex, pickBaseOffset)${partIndexExpressions.map((_, i) => ` || equals(selectedIndex, pickOffset${i})`).join('')}) {
     vColor = uColorSelected;
   } else {
     vColor = uColor;
@@ -103,7 +103,7 @@ uint32_t getPickBaseOffset() { return getPrimitiveIndex(); }
     } else {
       builder.addVertexCode(glsl_multiplyUint32);
       builder.addVertexCode(`
-uint32_t getPickBaseOffset() {       
+uint32_t getPickBaseOffset() {
   return multiply(getPrimitiveIndex(), ${this.pickIdsPerInstance.toFixed(1)});
 }
 `);

--- a/src/neuroglancer/gpu_hash/shader.ts
+++ b/src/neuroglancer/gpu_hash/shader.ts
@@ -105,12 +105,13 @@ export class GPUHashTable<HashTable extends HashTableBase> extends RefCounted {
     gl.pixelStorei(gl.UNPACK_ALIGNMENT, 1);
     setRawTextureParameters(gl);
 
+    const internalFormat = gl.RGBA8;
     const format = gl.RGBA;
 
     hashTable.tableWithMungedEmptyKey(table => {
       gl.texImage2D(
           gl.TEXTURE_2D,
-          /*level=*/0, format,
+          /*level=*/0, internalFormat,
           /*width=*/width * hashTable.entryStride,
           /*height=*/height,
           /*border=*/0, format, gl.UNSIGNED_BYTE, new Uint8Array(table.buffer));
@@ -180,8 +181,8 @@ bool ${this.hasFunctionName}(uint64_t x) {
       s += `
   {
     vec2 v = ${this.prefix}_computeHash_${alt}(x);
-    vec4 lowResult = texture2D(${samplerName}, v);
-    vec4 highResult = texture2D(${samplerName}, vec2(v.x + highOffset, v.y));
+    vec4 lowResult = texture(${samplerName}, v);
+    vec4 highResult = texture(${samplerName}, vec2(v.x + highOffset, v.y));
     if (lowResult == x.low && highResult == x.high) {
       return true;
     }
@@ -228,11 +229,11 @@ bool ${this.getFunctionName}(uint64_t x, out uint64_t value) {
       s += `
   {
     vec2 v = ${this.prefix}_computeHash_${alt}(x);
-    vec4 lowResult = texture2D(${samplerName}, v);
-    vec4 highResult = texture2D(${samplerName}, vec2(v.x + highOffset, v.y));
+    vec4 lowResult = texture(${samplerName}, v);
+    vec4 highResult = texture(${samplerName}, vec2(v.x + highOffset, v.y));
     if (lowResult == x.low && highResult == x.high) {
-      value.low = texture2D(${samplerName}, vec2(v.x + 2.0 * highOffset, v.y));
-      value.high = texture2D(${samplerName}, vec2(v.x + 3.0 * highOffset, v.y));
+      value.low = texture(${samplerName}, vec2(v.x + 2.0 * highOffset, v.y));
+      value.high = texture(${samplerName}, vec2(v.x + 3.0 * highOffset, v.y));
       return true;
     }
   }

--- a/src/neuroglancer/segment_color.spec.ts
+++ b/src/neuroglancer/segment_color.spec.ts
@@ -27,15 +27,18 @@ describe('segment_color', () => {
       shaderManager.defineShader(builder);
       builder.addUniform('highp vec4', 'inputValue', 2);
       const colorHash = SegmentColorHash.getDefault();
+      builder.addOutputBuffer('vec4', 'v4f_fragData0', 0);
+      builder.addOutputBuffer('vec4', 'v4f_fragData1', 1);
+      builder.addOutputBuffer('vec4', 'v4f_fragData2', 2);
       builder.setFragmentMain(`
 uint64_t x;
 x.low = inputValue[0];
 x.high = inputValue[1];
 
 highp vec3 color = getColor(x);
-gl_FragData[0] = packFloatIntoVec4(color.x);
-gl_FragData[1] = packFloatIntoVec4(color.y);
-gl_FragData[2] = packFloatIntoVec4(color.z);
+v4f_fragData0 = packFloatIntoVec4(color.x);
+v4f_fragData1 = packFloatIntoVec4(color.y);
+v4f_fragData2 = packFloatIntoVec4(color.z);
 `);
       tester.build();
       let {shader} = tester;

--- a/src/neuroglancer/single_mesh/frontend.spec.ts
+++ b/src/neuroglancer/single_mesh/frontend.spec.ts
@@ -49,16 +49,23 @@ describe('single_mesh/frontend', () => {
   vVertexPosition = vertexPosition;
   vVertexNormal = vertexNormal;
 `);
+      builder.addOutputBuffer('vec4', 'v4f_fragData0', 0);
+      builder.addOutputBuffer('vec4', 'v4f_fragData1', 1);
+      builder.addOutputBuffer('vec4', 'v4f_fragData2', 2);
+      builder.addOutputBuffer('vec4', 'v4f_fragData3', 3);
+      builder.addOutputBuffer('vec4', 'v4f_fragData4', 4);
+      builder.addOutputBuffer('vec4', 'v4f_fragData5', 5);
       builder.setFragmentMain(`
-  gl_FragData[0] = packFloatIntoVec4(vVertexPosition.x);
-  gl_FragData[1] = packFloatIntoVec4(vVertexPosition.y);
-  gl_FragData[2] = packFloatIntoVec4(vVertexPosition.z);
-  gl_FragData[3] = packFloatIntoVec4(vVertexNormal.x);
-  gl_FragData[4] = packFloatIntoVec4(vVertexNormal.y);
-  gl_FragData[5] = packFloatIntoVec4(vVertexNormal.z);
+  v4f_fragData0 = packFloatIntoVec4(vVertexPosition.x);
+  v4f_fragData1 = packFloatIntoVec4(vVertexPosition.y);
+  v4f_fragData2 = packFloatIntoVec4(vVertexPosition.z);
+  v4f_fragData3 = packFloatIntoVec4(vVertexNormal.x);
+  v4f_fragData4 = packFloatIntoVec4(vVertexNormal.y);
+  v4f_fragData5 = packFloatIntoVec4(vVertexNormal.z);
 `);
       vertexData.copyToGPU(gl, attributeFormats);
       tester.build();
+      //debugger;
       let {shader} = tester;
       shader.bind();
 

--- a/src/neuroglancer/sliceview/chunk_format_testing.ts
+++ b/src/neuroglancer/sliceview/chunk_format_testing.ts
@@ -48,32 +48,38 @@ export function chunkFormatTest<TextureLayout extends Disposable>(
            for (let channel = 0; channel < numChannels; ++channel) {
              switch (dataType) {
                case DataType.UINT64:
+                 builder.addOutputBuffer('vec4', `v4f_fragData${outputChannel}`, outputChannel);
+                 builder.addOutputBuffer('vec4', `v4f_fragData${outputChannel + 1}`, outputChannel + 1);
                  fragmentMain += `
 {
   uint64_t value = getDataValue(${channel});
-  gl_FragData[${outputChannel++}] = value.low;
-  gl_FragData[${outputChannel++}] = value.high;
+  v4f_fragData${outputChannel++} = value.low;
+  v4f_fragData${outputChannel++} = value.high;
 }
 `;
                  break;
                case DataType.UINT8:
+                 builder.addOutputBuffer('vec4', `v4f_fragData${outputChannel}`, outputChannel);
                  fragmentMain += `
-gl_FragData[${outputChannel++}] = vec4(getDataValue(${channel}).value, 0, 0, 0);
+v4f_fragData${outputChannel++} = vec4(getDataValue(${channel}).value, 0, 0, 0);
 `;
                  break;
                case DataType.FLOAT32:
+                 builder.addOutputBuffer('vec4', `v4f_fragData${outputChannel}`, outputChannel);
                  fragmentMain += `
-gl_FragData[${outputChannel++}] = packFloatIntoVec4(getDataValue(${channel}));
+v4f_fragData${outputChannel++} = packFloatIntoVec4(getDataValue(${channel}));
 `;
                  break;
                case DataType.UINT16:
+                 builder.addOutputBuffer('vec4', `v4f_fragData${outputChannel}`, outputChannel);
                  fragmentMain += `
-gl_FragData[${outputChannel++}] = vec4(getDataValue(${channel}).value, 0, 0);
+v4f_fragData${outputChannel++} = vec4(getDataValue(${channel}).value, 0, 0);
 `;
                  break;
                case DataType.UINT32:
+                 builder.addOutputBuffer('vec4', `v4f_fragData${outputChannel}`, outputChannel);
                  fragmentMain += `
-gl_FragData[${outputChannel++}] = getDataValue(${channel}).value;
+v4f_fragData${outputChannel++} = getDataValue(${channel}).value;
 `;
                  break;
              }

--- a/src/neuroglancer/sliceview/frontend.ts
+++ b/src/neuroglancer/sliceview/frontend.ts
@@ -394,7 +394,7 @@ export class SliceViewRenderHelper extends RefCounted {
     builder.addUniform('vec4', 'uTextureCoordinateAdjustment');
     builder.require(emitter);
     builder.setFragmentMain(`
-vec4 sampledColor = texture2D(uSampler, vTexCoord);
+vec4 sampledColor = texture(uSampler, vTexCoord);
 if (sampledColor.a == 0.0) {
   sampledColor = uBackgroundColor;
 }

--- a/src/neuroglancer/sliceview/panel.ts
+++ b/src/neuroglancer/sliceview/panel.ts
@@ -43,17 +43,19 @@ export enum OffscreenTextures {
 }
 
 function sliceViewPanelEmitColor(builder: ShaderBuilder) {
+  builder.addOutputBuffer('vec4', 'v4f_fragColor', null);
   builder.addFragmentCode(`
 void emit(vec4 color, vec4 pickId) {
-  gl_FragColor = color;
+  v4f_fragColor = color;
 }
 `);
 }
 
 function sliceViewPanelEmitPickID(builder: ShaderBuilder) {
+  builder.addOutputBuffer('vec4', 'v4f_fragColor', null);
   builder.addFragmentCode(`
 void emit(vec4 color, vec4 pickId) {
-  gl_FragColor = pickId;
+  v4f_fragColor = pickId;
 }
 `);
 }

--- a/src/neuroglancer/sliceview/renderlayer.ts
+++ b/src/neuroglancer/sliceview/renderlayer.ts
@@ -75,7 +75,7 @@ export abstract class RenderLayer extends GenericRenderLayer {
     return this.chunkManager.chunkQueueManager.gl;
   }
 
-  setGLBlendMode(gl: WebGLRenderingContext, renderLayerNum: number): void {
+  setGLBlendMode(gl: WebGL2RenderingContext, renderLayerNum: number): void {
     // Default blend mode for non-blend-mode-aware layers
     if (renderLayerNum > 0) {
       gl.enable(gl.BLEND);

--- a/src/neuroglancer/sliceview/single_texture_chunk_format.ts
+++ b/src/neuroglancer/sliceview/single_texture_chunk_format.ts
@@ -27,6 +27,7 @@ const textureLayoutSymbol = Symbol('SingleTextureVolumeChunk.textureLayout');
 export abstract class SingleTextureChunkFormat<TextureLayout extends Disposable> extends RefCounted
     implements ChunkFormat {
   arrayElementsPerTexel: number;
+  textureInternalFormat: number;
   texelType: number;
   textureFormat: number;
 

--- a/src/neuroglancer/sliceview/uncompressed_chunk_format.ts
+++ b/src/neuroglancer/sliceview/uncompressed_chunk_format.ts
@@ -52,6 +52,7 @@ class TextureLayout extends RefCounted {
 
 export class ChunkFormat extends SingleTextureChunkFormat<TextureLayout> {
   texelsPerElement: number;
+  textureInternalFormat: number;
   textureFormat: number;
   texelType: number;
   arrayElementsPerTexel: number;

--- a/src/neuroglancer/sliceview/vector_graphics/frontend.ts
+++ b/src/neuroglancer/sliceview/vector_graphics/frontend.ts
@@ -44,7 +44,7 @@ export abstract class RenderLayer extends GenericSliceViewRenderLayer {
   defineShader(builder: ShaderBuilder) {
     builder.addFragmentCode(`
 void emit(vec4 color) {
-  gl_FragColor = color;
+  v4f_fragColor = color;
 }
 void emitRGBA(vec4 rgba) {
   emit(vec4(rgba.rgb, rgba.a * uOpacity));

--- a/src/neuroglancer/sliceview/vector_graphics/vector_graphics_line_renderlayer.ts
+++ b/src/neuroglancer/sliceview/vector_graphics/vector_graphics_line_renderlayer.ts
@@ -202,7 +202,7 @@ gl_Position = uProjection * (pos + delta);
               /*normalized=*/false,
               /*stride=*/6 * 4,
               /*offset=*/0);
-          gl.ANGLE_instanced_arrays.vertexAttribDivisorANGLE(aVertexFirst, 1);
+          gl.vertexAttribDivisor(aVertexFirst, 1);
 
           const aVertexSecond = shader.attribute('aVertexSecond');
           chunk.vertexBuffer.bindToVertexAttrib(
@@ -212,12 +212,12 @@ gl_Position = uProjection * (pos + delta);
               /*normalized=*/false,
               /*stride=*/6 * 4,
               /*offset=*/3 * 4);
-          gl.ANGLE_instanced_arrays.vertexAttribDivisorANGLE(aVertexSecond, 1);
+          gl.vertexAttribDivisor(aVertexSecond, 1);
 
-          gl.ANGLE_instanced_arrays.drawArraysInstancedANGLE(gl.TRIANGLE_STRIP, 0, 4, numInstances);
+          gl.drawArraysInstanced(gl.TRIANGLE_STRIP, 0, 4, numInstances);
 
-          gl.ANGLE_instanced_arrays.vertexAttribDivisorANGLE(aVertexFirst, 0);
-          gl.ANGLE_instanced_arrays.vertexAttribDivisorANGLE(aVertexSecond, 0);
+          gl.vertexAttribDivisor(aVertexFirst, 0);
+          gl.vertexAttribDivisor(aVertexSecond, 0);
         }
       }
     }

--- a/src/neuroglancer/sliceview/volume/image_renderlayer.ts
+++ b/src/neuroglancer/sliceview/volume/image_renderlayer.ts
@@ -102,7 +102,7 @@ void emitTransparent() {
     return shader;
   }
 
-  setGLBlendMode(gl: WebGLRenderingContext, renderLayerNum: number) {
+  setGLBlendMode(gl: WebGL2RenderingContext, renderLayerNum: number) {
     let blendModeValue = verifyEnumString(this.blendMode.value, BLEND_MODES);
     if (blendModeValue === BLEND_MODES.ADDITIVE || renderLayerNum > 0) {
       gl.enable(gl.BLEND);

--- a/src/neuroglancer/sliceview/volume/renderlayer.ts
+++ b/src/neuroglancer/sliceview/volume/renderlayer.ts
@@ -250,9 +250,10 @@ export class RenderLayer extends SliceViewRenderLayer {
 
   protected defineShader(builder: ShaderBuilder) {
     this.vertexComputationManager.defineShader(builder);
+    builder.addOutputBuffer('vec4', 'v4f_fragData0', 0);
     builder.addFragmentCode(`
 void emit(vec4 color) {
-  gl_FragData[0] = color;
+  v4f_fragData0 = color;
 }
 `);
     this.chunkFormat.defineShader(builder);

--- a/src/neuroglancer/trackable_blend.ts
+++ b/src/neuroglancer/trackable_blend.ts
@@ -23,10 +23,10 @@ export enum BLEND_MODES {
 }
 
 export const BLEND_FUNCTIONS = new Map<BLEND_MODES, Function>();
-BLEND_FUNCTIONS.set(BLEND_MODES.DEFAULT, (gl: WebGLRenderingContext) => {
+BLEND_FUNCTIONS.set(BLEND_MODES.DEFAULT, (gl: WebGL2RenderingContext) => {
   gl.blendFunc(gl.SRC_ALPHA, gl.ONE_MINUS_SRC_ALPHA);
 });
-BLEND_FUNCTIONS.set(BLEND_MODES.ADDITIVE, (gl: WebGLRenderingContext) => {
+BLEND_FUNCTIONS.set(BLEND_MODES.ADDITIVE, (gl: WebGL2RenderingContext) => {
   gl.blendFunc(gl.SRC_ALPHA, gl.ONE);
 });
 

--- a/src/neuroglancer/webgl/buffer.ts
+++ b/src/neuroglancer/webgl/buffer.ts
@@ -26,7 +26,7 @@ export type WebGLDataType = number;
 export type WebGLBufferUsage = number;
 export class Buffer implements Disposable {
   buffer: WebGLBuffer|null;
-  constructor(public gl: WebGLRenderingContext, public bufferType: BufferType = GL_ARRAY_BUFFER) {
+  constructor(public gl: WebGL2RenderingContext, public bufferType: BufferType = GL_ARRAY_BUFFER) {
     this.gl = gl;
     // This should never return null.
     this.buffer = gl.createBuffer();
@@ -58,7 +58,7 @@ export class Buffer implements Disposable {
   }
 
   static fromData(
-      gl: WebGLRenderingContext, data: ArrayBufferView, bufferType?: BufferType,
+      gl: WebGL2RenderingContext, data: ArrayBufferView, bufferType?: BufferType,
       usage?: WebGLBufferUsage) {
     let buffer = new Buffer(gl, bufferType);
     buffer.setData(data, usage);

--- a/src/neuroglancer/webgl/context.ts
+++ b/src/neuroglancer/webgl/context.ts
@@ -17,10 +17,8 @@
 import {RefCounted} from 'neuroglancer/util/disposable';
 import {Memoize} from 'neuroglancer/util/memoize';
 
-export interface GL extends WebGLRenderingContext {
+export interface GL extends WebGL2RenderingContext {
   memoize: Memoize<any, RefCounted>;
-  WEBGL_draw_buffers: any;
-  ANGLE_instanced_arrays: any;
   maxTextureSize: number;
   maxTextureImageUnits: number;
   tempTextureUnit: number;
@@ -38,7 +36,7 @@ export function initializeWebGL(canvas: HTMLCanvasElement) {
     options['preserveDrawingBuffer'] = true;
   }
   let gl =
-      <GL>(canvas.getContext('webgl', options) || canvas.getContext('experimental-webgl', options));
+      <GL>canvas.getContext('webgl2', options);
   if (gl == null) {
     throw new Error('WebGL not supported.');
   }
@@ -51,21 +49,10 @@ export function initializeWebGL(canvas: HTMLCanvasElement) {
   // var contextAttributes = gl.getContextAttributes();
   // var haveStencilBuffer = contextAttributes.stencil;
 
-  gl.WEBGL_draw_buffers = gl.getExtension('WEBGL_draw_buffers');
-  if (!gl.WEBGL_draw_buffers) {
-    throw new Error('WEBGL_draw_buffers extension not available');
-  }
-
-  gl.ANGLE_instanced_arrays = gl.getExtension('ANGLE_instanced_arrays');
-  if (!gl.ANGLE_instanced_arrays) {
-    throw new Error('ANGLE_instanced_ararys extension not available');
-  }
-
-  for (let extension of ['OES_texture_float', 'OES_element_index_uint']) {
+  for (let extension of ['EXT_color_buffer_float']) {
     if (!gl.getExtension(extension)) {
       throw new Error(`${extension} extension not available`);
     }
   }
-
   return gl;
 }

--- a/src/neuroglancer/webgl/index_emulation.spec.ts
+++ b/src/neuroglancer/webgl/index_emulation.spec.ts
@@ -25,7 +25,8 @@ describe('webgl/index_emulation', () => {
       helper.defineShader(builder);
       builder.addVarying('highp float', 'vVertexIndex');
       builder.addVertexMain(`vVertexIndex = getVertexIndex();`);
-      builder.setFragmentMain(`gl_FragData[0] = packFloatIntoVec4(vVertexIndex);`);
+      builder.addOutputBuffer('vec4', 'v4f_fragData0', 0);
+      builder.setFragmentMain(`v4f_fragData0 = packFloatIntoVec4(vVertexIndex);`);
 
       tester.build();
       let {shader} = tester;

--- a/src/neuroglancer/webgl/index_emulation.ts
+++ b/src/neuroglancer/webgl/index_emulation.ts
@@ -86,7 +86,7 @@ export class CountingBuffer extends RefCounted {
     if (location >= 0) {
       this.bindToVertexAttrib(location);
       if (divisor !== 0) {
-        this.gl.ANGLE_instanced_arrays.vertexAttribDivisorANGLE(location, divisor);
+        this.gl.vertexAttribDivisor(location, divisor);
       }
     }
   }
@@ -96,7 +96,7 @@ export function disableCountingBuffer(gl: GL, shader: ShaderProgram, instanced =
   const location = shader.attribute('aIndexRaw');
   if (location >= 0) {
     if (instanced) {
-      gl.ANGLE_instanced_arrays.vertexAttribDivisorANGLE(location, 0);
+      gl.vertexAttribDivisor(location, 0);
     }
     gl.disableVertexAttribArray(location);
   }
@@ -147,7 +147,7 @@ float ${this.getterName} () {
   }
 }
 
-export function makeIndexBuffer(gl: WebGLRenderingContext, data: Uint32Array) {
+export function makeIndexBuffer(gl: WebGL2RenderingContext, data: Uint32Array) {
   return Buffer.fromData(
       gl, new Uint8Array(data.buffer, data.byteOffset, data.byteLength), GL_ARRAY_BUFFER,
       GL_STATIC_DRAW);

--- a/src/neuroglancer/webgl/offscreen.ts
+++ b/src/neuroglancer/webgl/offscreen.ts
@@ -109,13 +109,13 @@ export class Framebuffer extends RefCounted {
 export class TextureBuffer extends SizeManaged {
   texture: WebGLTexture|null;
 
-  constructor(public gl: GL, public format: number, public dataType: number) {
+  constructor(public gl: GL, public internalFormat: number, public format: number, public dataType: number) {
     super();
     this.texture = gl.createTexture();
   }
 
   protected performResize() {
-    resizeTexture(this.gl, this.texture, this.width, this.height, this.format, this.dataType);
+    resizeTexture(this.gl, this.texture, this.width, this.height, this.internalFormat, this.format, this.dataType);
   }
 
   disposed() {
@@ -129,10 +129,10 @@ export class TextureBuffer extends SizeManaged {
 }
 
 export function makeTextureBuffers(
-    gl: GL, count: number, format: number = gl.RGBA, dataType: number = gl.UNSIGNED_BYTE) {
+    gl: GL, count: number, internalFormat: number = gl.RGBA8, format: number = gl.RGBA, dataType: number = gl.UNSIGNED_BYTE) {
   let result = new Array<TextureBuffer>();
   for (let i = 0; i < count; ++i) {
-    result[i] = new TextureBuffer(gl, format, dataType);
+    result[i] = new TextureBuffer(gl, internalFormat, format, dataType);
   }
   return result;
 }
@@ -187,7 +187,7 @@ export class FramebufferConfiguration<ColorBuffer extends TextureBuffer|Renderbu
       buffer.resize(width, height);
       buffer.attachToFramebuffer(gl.COLOR_ATTACHMENT0 + i);
     });
-    gl.WEBGL_draw_buffers.drawBuffersWEBGL(this.fullAttachmentList);
+    gl.drawBuffers(this.fullAttachmentList);
     this.verifyAttachment();
     gl.viewport(0, 0, width, height);
   }
@@ -206,7 +206,7 @@ export class FramebufferConfiguration<ColorBuffer extends TextureBuffer|Renderbu
 
     gl.bindTexture(gl.TEXTURE_2D, null);
     this.colorBuffers[textureIndex].attachToFramebuffer(gl.COLOR_ATTACHMENT0);
-    gl.WEBGL_draw_buffers.drawBuffersWEBGL(this.singleAttachmentList);
+    gl.drawBuffers(this.singleAttachmentList);
   }
 
   unbind() {

--- a/src/neuroglancer/webgl/one_dimensional_texture_access.spec.ts
+++ b/src/neuroglancer/webgl/one_dimensional_texture_access.spec.ts
@@ -48,15 +48,21 @@ function testTextureAccess(
         accessHelper.getAccessor('readValue', 'uSampler', dataType, numComponents));
     builder.addFragmentCode(glsl_unnormalizeUint8);
     builder.addFragmentCode(glsl_uintleToFloat);
+    builder.addOutputBuffer('vec4', 'v4f_fragData0', 0);
+    builder.addOutputBuffer('vec4', 'v4f_fragData1', 1);
+    builder.addOutputBuffer('vec4', 'v4f_fragData2', 2);
+    builder.addOutputBuffer('vec4', 'v4f_fragData3', 3);
+    builder.addOutputBuffer('vec4', 'v4f_fragData4', 4);
+    builder.addOutputBuffer('vec4', 'v4f_fragData5', 5);
     builder.setFragmentMain(`
 uint32_t value = readValue(uOffset);
-gl_FragData[4] = packFloatIntoVec4(uintleToFloat(value.value.xyz));
-gl_FragData[5] = packFloatIntoVec4(all(equal(value.value, uExpected)) ? 1.0 : 0.0);
+v4f_fragData4 = packFloatIntoVec4(uintleToFloat(value.value.xyz));
+v4f_fragData5 = packFloatIntoVec4(all(equal(value.value, uExpected)) ? 1.0 : 0.0);
 value.value = unnormalizeUint8(value.value);
-gl_FragData[0] = packFloatIntoVec4(value.value.x);
-gl_FragData[1] = packFloatIntoVec4(value.value.y);
-gl_FragData[2] = packFloatIntoVec4(value.value.z);
-gl_FragData[3] = packFloatIntoVec4(value.value.w);
+v4f_fragData0 = packFloatIntoVec4(value.value.x);
+v4f_fragData1 = packFloatIntoVec4(value.value.y);
+v4f_fragData2 = packFloatIntoVec4(value.value.z);
+v4f_fragData3 = packFloatIntoVec4(value.value.w);
 `);
 
     tester.build();

--- a/src/neuroglancer/webgl/quad.ts
+++ b/src/neuroglancer/webgl/quad.ts
@@ -59,10 +59,10 @@ export class QuadRenderHelper extends RefCounted {
 
   draw(gl: GL, numInstances: number) {
     if (this.quadsPerInstance === 1) {
-      gl.ANGLE_instanced_arrays.drawArraysInstancedANGLE(GL_TRIANGLE_FAN, 0, 4, numInstances);
+      gl.drawArraysInstanced(GL_TRIANGLE_FAN, 0, 4, numInstances);
     } else {
       this.quadIndexBuffer.bind();
-      gl.ANGLE_instanced_arrays.drawElementsInstancedANGLE(
+      gl.drawElementsInstanced(
           GL_TRIANGLES, INDICES_PER_QUAD * this.quadsPerInstance, GL_UNSIGNED_SHORT, /*offset=*/0,
           numInstances);
     }

--- a/src/neuroglancer/webgl/shader_lib.spec.ts
+++ b/src/neuroglancer/webgl/shader_lib.spec.ts
@@ -37,9 +37,10 @@ describe('webgl/shader_lib', () => {
       builder.addFragmentCode(glsl_addUint32);
       builder.addUniform('highp vec4', 'uValue1');
       builder.addUniform('highp vec4', 'uValue2');
+      builder.addOutputBuffer('vec4', 'v4f_fragData0', 0);
       builder.setFragmentMain(`
 uint32_t a, b; a.value = uValue1; b.value = uValue2;
-gl_FragData[0] = add(a, b).value;
+v4f_fragData0 = add(a, b).value;
 `);
 
       tester.build();
@@ -74,9 +75,10 @@ gl_FragData[0] = add(a, b).value;
       builder.addFragmentCode(glsl_addUint32);
       builder.addUniform('highp vec4', 'uValue1');
       builder.addUniform('highp float', 'uValue2');
+      builder.addOutputBuffer('vec4', 'v4f_fragData0', 0);
       builder.setFragmentMain(`
 uint32_t a; a.value = uValue1;
-gl_FragData[0] = add(a, uValue2).value;
+v4f_fragData0 = add(a, uValue2).value;
 `);
 
       tester.build();
@@ -114,13 +116,15 @@ gl_FragData[0] = add(a, uValue2).value;
       builder.addUniform('highp vec4', 'uValue1');
       builder.addUniform('highp float', 'uValue2');
       builder.addUniform('highp vec4', 'uResult');
+      builder.addOutputBuffer('vec4', 'v4f_fragData0', 0);
+      builder.addOutputBuffer('vec4', 'v4f_fragData1', 1);
       builder.setFragmentMain(`
 uint32_t a; a.value = uValue1;
 uint32_t result = multiply(a, uValue2);
 uint32_t expected; expected.value = uResult;
-gl_FragData[0] = result.value;
-float areEqual = equal(result, expected) ? 1.0 : 0.0;
-gl_FragData[1] = vec4(areEqual, areEqual, areEqual, areEqual);
+v4f_fragData0 = result.value;
+float areEqual = equals(result, expected) ? 1.0 : 0.0;
+v4f_fragData1 = vec4(areEqual, areEqual, areEqual, areEqual);
 `);
 
       tester.build();
@@ -161,11 +165,13 @@ gl_FragData[1] = vec4(areEqual, areEqual, areEqual, areEqual);
       builder.addFragmentCode(glsl_divmodUint32);
       builder.addUniform('highp vec4', 'uDividend');
       builder.addUniform('highp float', 'uDivisor');
+      builder.addOutputBuffer('vec4', 'v4f_fragData0', 0);
+      builder.addOutputBuffer('vec4', 'v4f_fragData1', 1);
       builder.setFragmentMain(`
 uint32_t a; a.value = uDividend;
 uint32_t quotient;
-gl_FragData[0] = packFloatIntoVec4(divmod(a, uDivisor, quotient));
-gl_FragData[1] = quotient.value;
+v4f_fragData0 = packFloatIntoVec4(divmod(a, uDivisor, quotient));
+v4f_fragData1 = quotient.value;
 `);
 
       tester.build();

--- a/src/neuroglancer/webgl/shader_lib.ts
+++ b/src/neuroglancer/webgl/shader_lib.ts
@@ -279,13 +279,13 @@ export function exp2(x: number) {
  */
 export var glsl_packFloat = `
 vec4 packFloatIntoVec4(float f) {
-  float magnitude = abs(f); 
+  float magnitude = abs(f);
   if (magnitude == 0.0) {
      return vec4(0,0,0,0);
   }
   float sign =  step(0.0, -f);
-  float exponent = floor(log2(magnitude)); 
-  float mantissa = magnitude / exp2(exponent); 
+  float exponent = floor(log2(magnitude));
+  float mantissa = magnitude / exp2(exponent);
   // Denormalized values if all exponent bits are zero
   if (mantissa < 1.0) {
      exponent -= 1.0;
@@ -367,7 +367,7 @@ export function getShaderType(dataType: DataType, numComponents: number = 1) {
 
 export const glsl_equalUint32 = [
   glsl_uint32, `
-bool equal(uint32_t a, uint32_t b) {
+bool equals(uint32_t a, uint32_t b) {
   return all(lessThan(abs(a.value - b.value), vec4(1.0 / 256.0, 1.0 / 256.0, 1.0 / 256.0, 1.0 / 256.0)));
 }
 `
@@ -488,7 +488,7 @@ export const glsl_floatToUint32 = [
 uint32_t floatToUint32(float x) {
   uint32_t result;
   float v;
-  
+
   v = mod(x, 256.0);
   result.x = v / 255.0;
   x = (x - v) / 256.0;
@@ -500,7 +500,7 @@ uint32_t floatToUint32(float x) {
   v = mod(x, 256.0);
   result.z = v / 255.0;
   result.w = 0.0;
-  
+
   return result;
 }
 `

--- a/src/neuroglancer/webgl/shader_testing.spec.ts
+++ b/src/neuroglancer/webgl/shader_testing.spec.ts
@@ -23,7 +23,8 @@ describe('FragmentShaderTester', () => {
     fragmentShaderTest(1, tester => {
       let {gl, builder} = tester;
       builder.addUniform('vec4', 'inputValue');
-      builder.setFragmentMain(`gl_FragData[0] = inputValue;`);
+      builder.addOutputBuffer('vec4', 'v4f_fragData0', 0);
+      builder.setFragmentMain(`v4f_fragData0 = inputValue;`);
       tester.build();
       let {shader} = tester;
       let inputValue = vec4.fromValues(0, 64 / 255, 128 / 255, 192 / 255);
@@ -40,7 +41,8 @@ describe('FragmentShaderTester', () => {
       let {gl, builder} = tester;
       builder.addUniform('highp float', 'inputValue');
       builder.addFragmentCode(glsl_packFloat);
-      builder.setFragmentMain(`gl_FragData[0] = packFloatIntoVec4(inputValue);`);
+      builder.addOutputBuffer('vec4', 'v4f_fragData0', 0);
+      builder.setFragmentMain(`v4f_fragData0 = packFloatIntoVec4(inputValue);`);
       tester.build();
       function generateRandomNumber() {
         let buf = new Uint32Array(1);
@@ -74,9 +76,11 @@ describe('FragmentShaderTester', () => {
       builder.addUniform('highp float', 'inputValue1');
       builder.addUniform('highp float', 'inputValue2');
       builder.addFragmentCode(glsl_packFloat);
+      builder.addOutputBuffer('vec4', 'v4f_fragData0', 0);
+      builder.addOutputBuffer('vec4', 'v4f_fragData1', 1);
       builder.setFragmentMain(`
-  gl_FragData[0] = packFloatIntoVec4(inputValue1);
-  gl_FragData[1] = packFloatIntoVec4(inputValue2);
+  v4f_fragData0 = packFloatIntoVec4(inputValue1);
+  v4f_fragData1 = packFloatIntoVec4(inputValue2);
 `);
       tester.build();
       function generateRandomNumber() {
@@ -114,7 +118,8 @@ describe('FragmentShaderTester', () => {
       let {gl, builder} = tester;
       builder.addUniform('highp float', 'inputValue');
       builder.addFragmentCode(glsl_packFloat01ToFixedPoint);
-      builder.setFragmentMain(`gl_FragData[0] = packFloat01ToFixedPoint(inputValue);`);
+      builder.addOutputBuffer('vec4', 'v4f_fragData0', 0);
+      builder.setFragmentMain(`v4f_fragData0 = packFloat01ToFixedPoint(inputValue);`);
       tester.build();
       function generateRandomNumber() {
         let buf = new Uint32Array(1);

--- a/src/neuroglancer/webgl/shader_testing.ts
+++ b/src/neuroglancer/webgl/shader_testing.ts
@@ -33,7 +33,6 @@ export class FragmentShaderTester extends RefCounted {
     super();
     let {builder} = this;
     this.offscreenFramebuffer = new FramebufferConfiguration(this.gl, {colorBuffers});
-    builder.addFragmentExtension('GL_EXT_draw_buffers');
     builder.addAttribute('vec4', 'shader_testing_aVertexPosition');
     builder.setVertexMain(`gl_Position = shader_testing_aVertexPosition;`);
     builder.addFragmentCode(glsl_debugFunctions);

--- a/src/neuroglancer/webgl/spheres.ts
+++ b/src/neuroglancer/webgl/spheres.ts
@@ -106,7 +106,7 @@ void emitSphere(mat4 projectionMatrix, mat4 normalTransformMatrix, vec3 centerPo
     this.vertexBuffer.bindToVertexAttrib(
         aSphereVertex, /*components=*/3, /*attributeType=*/GL_FLOAT, /*normalized=*/false);
     this.indexBuffer.bind();
-    shader.gl.ANGLE_instanced_arrays.drawElementsInstancedANGLE(
+    shader.gl.drawElementsInstanced(
         GL_TRIANGLES, this.numIndices, GL_UNSIGNED_SHORT, /*offset=*/0, numInstances);
     shader.gl.disableVertexAttribArray(aSphereVertex);
   }

--- a/src/neuroglancer/webgl/texture.ts
+++ b/src/neuroglancer/webgl/texture.ts
@@ -14,58 +14,58 @@
  * limitations under the License.
  */
 
-import {GL_CLAMP_TO_EDGE, GL_LINEAR, GL_NEAREST, GL_RGBA, GL_TEXTURE0, GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_TEXTURE_MIN_FILTER, GL_TEXTURE_WRAP_S, GL_TEXTURE_WRAP_T, GL_UNPACK_ALIGNMENT, GL_UNPACK_FLIP_Y_WEBGL, GL_UNSIGNED_BYTE} from 'neuroglancer/webgl/constants';
 import {GL} from 'neuroglancer/webgl/context';
 
 /**
  * Sets parameters to make a texture suitable for use as a raw array: NEAREST
  * filtering, clamping.
  */
-export function setRawTextureParameters(gl: WebGLRenderingContext) {
-  gl.texParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
-  gl.texParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
+export function setRawTextureParameters(gl: WebGL2RenderingContext) {
+  gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.NEAREST);
+  gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.NEAREST);
   // Prevents s-coordinate wrapping (repeating).  Repeating not
   // permitted for non-power-of-2 textures.
-  gl.texParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+  gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
   // Prevents t-coordinate wrapping (repeating).  Repeating not
   // permitted for non-power-of-2 textures.
-  gl.texParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+  gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
 }
 
 export function resizeTexture(
-    gl: GL, texture: WebGLTexture|null, width: number, height: number, format: number = GL_RGBA,
-    dataType: number = GL_UNSIGNED_BYTE) {
-  gl.activeTexture(GL_TEXTURE0 + gl.tempTextureUnit);
-  gl.bindTexture(GL_TEXTURE_2D, texture);
+    gl: GL, texture: WebGLTexture|null, width: number, height: number,
+    internalFormat: number = gl.RGBA8, format: number = gl.RGBA,
+    dataType: number = gl.UNSIGNED_BYTE) {
+  gl.activeTexture(gl.TEXTURE0 + gl.tempTextureUnit);
+  gl.bindTexture(gl.TEXTURE_2D, texture);
   setRawTextureParameters(gl);
   gl.texImage2D(
-      GL_TEXTURE_2D, 0,
-      /*internalformat=*/format,
+      gl.TEXTURE_2D, 0,
+      /*internalformat=*/internalFormat,
       /*width=*/width,
       /*height=*/height,
       /*border=*/0,
       /*format=*/format, dataType, <any>null);
-  gl.bindTexture(GL_TEXTURE_2D, null);
+  gl.bindTexture(gl.TEXTURE_2D, null);
 }
 
 export function setTextureFromCanvas(
     gl: GL, texture: WebGLTexture|null, canvas: HTMLCanvasElement) {
-  gl.activeTexture(GL_TEXTURE0 + gl.tempTextureUnit);
-  gl.bindTexture(GL_TEXTURE_2D, texture);
-  gl.texParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
-  gl.texParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+  gl.activeTexture(gl.TEXTURE0 + gl.tempTextureUnit);
+  gl.bindTexture(gl.TEXTURE_2D, texture);
+  gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.LINEAR);
+  gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.LINEAR);
   // Prevents s-coordinate wrapping (repeating).  Repeating not
   // permitted for non-power-of-2 textures.
-  gl.texParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+  gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
   // Prevents t-coordinate wrapping (repeating).  Repeating not
   // permitted for non-power-of-2 textures.
-  gl.texParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
-  gl.pixelStorei(GL_UNPACK_FLIP_Y_WEBGL, true);
-  gl.pixelStorei(GL_UNPACK_ALIGNMENT, 4);
+  gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
+  gl.pixelStorei(gl.UNPACK_FLIP_Y_WEBGL, true);
+  gl.pixelStorei(gl.UNPACK_ALIGNMENT, 4);
   gl.texImage2D(
-      GL_TEXTURE_2D, /*level=*/0,
-      /*internalformat=*/GL_RGBA,
-      /*format=*/GL_RGBA, GL_UNSIGNED_BYTE, canvas);
-  gl.pixelStorei(GL_UNPACK_FLIP_Y_WEBGL, false);
-  gl.bindTexture(GL_TEXTURE_2D, null);
+      gl.TEXTURE_2D, /*level=*/0,
+      /*internalformat=*/gl.RGBA8,
+      /*format=*/gl.RGBA, gl.UNSIGNED_BYTE, canvas);
+  gl.pixelStorei(gl.UNPACK_FLIP_Y_WEBGL, false);
+  gl.bindTexture(gl.TEXTURE_2D, null);
 }

--- a/src/neuroglancer/webgl/trivial_shaders.ts
+++ b/src/neuroglancer/webgl/trivial_shaders.ts
@@ -19,7 +19,8 @@ import {GL} from 'neuroglancer/webgl/context';
 import {ShaderBuilder, ShaderModule, ShaderProgram} from 'neuroglancer/webgl/shader';
 
 export function defineCopyFragmentShader(builder: ShaderBuilder) {
-  builder.setFragmentMain('gl_FragColor = getValue0();');
+  builder.addOutputBuffer('vec4', 'v4f_fragColor', null);
+  builder.setFragmentMain('v4f_fragColor = getValue0();');
 }
 
 export function elementWiseTextureShader(
@@ -40,7 +41,7 @@ export function elementWiseTextureShader(
         for (let i = 0; i < numTextures; ++i) {
           builder.addFragmentCode(`
 vec4 getValue${i}() {
-  return texture2D(uSampler[${i}], vTexCoord);
+  return texture(uSampler[${i}], vTexCoord);
 }
 `);
         }
@@ -62,7 +63,8 @@ export function trivialColorShader(gl: GL): ShaderProgram {
   return gl.memoize.get('trivialColorShader', () => {
     let builder = new ShaderBuilder(gl);
     builder.addVarying('vec4', 'vColor');
-    builder.setFragmentMain('gl_FragColor = vColor;');
+    builder.addOutputBuffer('vec4', 'v4f_fragColor', null);
+    builder.setFragmentMain('v4f_fragColor = vColor;');
     builder.addAttribute('vec4', 'aVertexPosition');
     builder.addAttribute('vec4', 'aColor');
     builder.addUniform('mat4', 'uProjectionMatrix');
@@ -77,7 +79,8 @@ export function trivialUniformColorShader(gl: GL): ShaderProgram {
     builder.addUniform('mat4', 'uProjectionMatrix');
     builder.addAttribute('vec4', 'aVertexPosition');
     builder.addUniform('vec4', 'uColor');
-    builder.setFragmentMain('gl_FragColor = uColor;');
+    builder.addOutputBuffer('vec4', 'v4f_fragColor', null);
+    builder.setFragmentMain('v4f_fragColor = uColor;');
     builder.setVertexMain('gl_Position = uProjectionMatrix * aVertexPosition;');
     return builder.build();
   });

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -3,4 +3,5 @@
 /// <reference path="nifti-reader-js.d.ts" />
 /// <reference path="../node_modules/@types/jasmine/index.d.ts" />
 /// <reference path="../node_modules/@types/text-encoding/index.d.ts" />
+/// <reference path="../node_modules/@types/webgl2/index.d.ts" />
 /// <reference path="../node_modules/@types/webpack-env/index.d.ts" />


### PR DESCRIPTION
Supersedes https://github.com/google/neuroglancer/pull/16

What this PR does:
* Switching over from WebGLRenderingContext to WebGL**2**RenderingContext
* Upgrade shader code to version GLSL 300 ES

What this PR **not** does:
* Use any of the new cool features of WebGL/GLSL other than required for maintaining current Neuroglancer behavior and passing the tests.
* try to be backward compatible: No IE/Edge support [in the foreseeable future](https://caniuse.com/#search=WebGL)

WebGL changes in more detail:
* Using the DefinitelyTyped definitions for WebGL2
* `WEBGL_draw_buffers`, `OES_texture_float`, `OES_element_index_uint` are standard in WebGL2 - no need to check
* WebGL2 offers many new combinations of `internalFormat`, `format` and `type` for textures, but doesn't support *unsized* internal formats when using `GL_FLOAT` types --> had to separate `internalFormat` and `format`.

GLSL changes in more detail:
* `#version 300 es` string at beginning of shader
* `attribute`  in VS --> `in`
* `varying` in VS --> `out`
* `varying` in FS --> `in`
* No predefined `gl_FragColor` or `gl_FragData[x]` outputs anymore; user has to specify outputs using new function `addBufferOutput(typename, name, location)`. I used `v4f_fragColor`/`v4f_fragData[x]` to replicate old behavior.
* `texture2D` --> `texture`
* Overloading built-in functions does not seem to work anymore; had to rename `equal(uint32_t a, uint32_t b)` to `equals`.

One thing:
` neuroglancer/webgl/constants` still only contains the WebGL (1.0) constants - not sure if I should add the 2.0 ones or if I can remove it.