### PR TITLE
Json state server

### DIFF
--- a/src/main_python.ts
+++ b/src/main_python.ts
@@ -119,7 +119,7 @@ window.addEventListener('DOMContentLoaded', () => {
   configState.add('screenshot', screenshotHandler.requestState);
 
   let sharedState: Trackable|undefined = viewer.state;
-
+  viewer.loadFromJsonUrl();
   if (window.location.hash) {
     const hashBinding = viewer.registerDisposer(new UrlHashBinding(viewer.state));
     hashBinding.updateFromUrlHash();
@@ -177,6 +177,4 @@ window.addEventListener('DOMContentLoaded', () => {
 
   bindDefaultCopyHandler(viewer);
   bindDefaultPasteHandler(viewer);
-
-
 });

--- a/src/main_python.ts
+++ b/src/main_python.ts
@@ -177,4 +177,6 @@ window.addEventListener('DOMContentLoaded', () => {
 
   bindDefaultCopyHandler(viewer);
   bindDefaultPasteHandler(viewer);
+
+
 });

--- a/src/neuroglancer/ui/default_viewer_setup.ts
+++ b/src/neuroglancer/ui/default_viewer_setup.ts
@@ -38,6 +38,8 @@ export function setupDefaultViewer() {
     hashBinding.parseError;
   }));
   hashBinding.updateFromUrlHash();
+  
+  viewer.loadFromJsonUrl();
 
   bindDefaultCopyHandler(viewer);
   bindDefaultPasteHandler(viewer);

--- a/src/neuroglancer/viewer.ts
+++ b/src/neuroglancer/viewer.ts
@@ -458,7 +458,7 @@ export class Viewer extends RefCounted implements ViewerState {
       topRow.appendChild(button);
     }
     {
-      const button = makeTextIconButton('post', 'Post JSON to state server');
+      const button = makeTextIconButton('🔗', 'Post JSON to state server');
       this.registerEventListener(button, 'click', () => {
         this.postJsonState();
       });

--- a/src/neuroglancer/viewer.ts
+++ b/src/neuroglancer/viewer.ts
@@ -211,7 +211,6 @@ export class Viewer extends RefCounted implements ViewerState {
   layerSpecification: TopLevelLayerListSpecification;
   layout: RootLayoutContainer;
 
-  stateServer = new TrackableValue<string>('', validateStateServer);
   jsonStateServer = new TrackableValue<string>('', validateStateServer)
   state = new CompoundTrackable();
 
@@ -330,7 +329,6 @@ export class Viewer extends RefCounted implements ViewerState {
         'systemMemoryLimit', this.dataContext.chunkQueueManager.capacities.systemMemory.sizeLimit);
     state.add(
         'concurrentDownloads', this.dataContext.chunkQueueManager.capacities.download.itemLimit);
-    state.add('stateServer', this.stateServer);
     state.add('jsonStateServer', this.jsonStateServer);
     state.add('selectedLayer', this.selectedLayer);
     state.add('crossSectionBackgroundColor', this.crossSectionBackgroundColor);
@@ -623,7 +621,6 @@ export class Viewer extends RefCounted implements ViewerState {
                               console.log(response);
                               var short_url =window.location.origin+"/?json_url="+this.jsonStateServer.value.replace(/\/$/,"")+"/"+response;
                               alert(short_url);
-                              //="?json_url="+this.jsonStateServer.value+response;
                             })
 
   }

--- a/src/neuroglancer/viewer.ts
+++ b/src/neuroglancer/viewer.ts
@@ -64,7 +64,6 @@ export function validateStateServer(obj: any) {
   return obj;
 }
 
-
 export class DataManagementContext extends RefCounted {
   worker = new Worker('chunk_worker.bundle.js');
   chunkQueueManager = this.registerDisposer(new ChunkQueueManager(new RPC(this.worker), this.gl, {
@@ -332,7 +331,7 @@ export class Viewer extends RefCounted implements ViewerState {
     state.add('jsonStateServer', this.jsonStateServer);
     state.add('selectedLayer', this.selectedLayer);
     state.add('crossSectionBackgroundColor', this.crossSectionBackgroundColor);
-    
+
     this.registerDisposer(this.navigationState.changed.add(() => {
       this.handleNavigationStateChanged();
     }));
@@ -444,7 +443,6 @@ export class Viewer extends RefCounted implements ViewerState {
     topRow.appendChild(annotationToolStatus.element);
     this.registerDisposer(new ElementVisibilityFromTrackableBoolean(
         this.uiControlVisibility.showAnnotationToolStatus, annotationToolStatus.element));
-    
     
     {
       const button = makeTextIconButton('{}', 'Edit JSON state');


### PR DESCRIPTION
One problem that we have run into often is that as we start using the annotation tools for visualizing complex datasets, the URL state starts to become larger than can be accommodated by the limits on the browser. However, we still like the idea of sharing these links with all their state.  In addition, sometimes the long links with the url encoded special characters don't paste well into some chat/email or other electronic communication methods.  Both of these problems are addressed by this PR, which adds a feature to enable users to 1) load state from a query parameter that specifies a URL to download a json object from.  and 2) a button to issue a POST request with the present json configurable state to a configurable jsonStateServer URL, which is expected to respond with what should be appended to to the original URL in order to retrieve that json state in the future.  This is then displayed as a link in an alert to the user who may copy and paste it into an email/chat etc.  It's essentially a neuroglancer link shortener that circumvents the built in browser limits.  We have implemented a simple web service with a key/value store to support the backend of this feature... it's a fairly trivial service that could be implemented in several ways.

Would be happy to hear feedback on making these requests more secure/robust, ways that seem reasonable to deploy a version that is preset with a particular jsonStateServer preconfigured as a default, or thoughts on this as a feature. 