### PR TITLE
add blend mode for python binding

### DIFF
--- a/python/neuroglancer/viewer_state.py
+++ b/python/neuroglancer/viewer_state.py
@@ -185,6 +185,7 @@ class ImageLayer(Layer, _AnnotationLayerOptions):
     source = wrapped_property('source', volume_source)
     shader = wrapped_property('shader', text_type)
     opacity = wrapped_property('opacity', optional(float, 0.5))
+    blend = wrapped_property('blend', optional(str))
 
     @staticmethod
     def interpolate(a, b, t):


### PR DESCRIPTION
the blend mode option seems to be missing in the python bindings

this commit just adds it as an option for `ImageLayer`