### PR TITLE
adds dvid simple key/value mesh support

### DIFF
--- a/src/neuroglancer/datasource/dvid/backend.ts
+++ b/src/neuroglancer/datasource/dvid/backend.ts
@@ -15,13 +15,15 @@
  */
 
 import {WithParameters} from 'neuroglancer/chunk_manager/backend';
-import {SkeletonSourceParameters, VolumeChunkEncoding, VolumeChunkSourceParameters} from 'neuroglancer/datasource/dvid/base';
+import {MeshSourceParameters, SkeletonSourceParameters, VolumeChunkEncoding, VolumeChunkSourceParameters} from 'neuroglancer/datasource/dvid/base';
+import {decodeTriangleVertexPositionsAndIndices, FragmentChunk, ManifestChunk, MeshSource} from 'neuroglancer/mesh/backend';
 import {SkeletonChunk, SkeletonSource} from 'neuroglancer/skeleton/backend';
 import {decodeSwcSkeletonChunk} from 'neuroglancer/skeleton/decode_swc_skeleton';
 import {decodeCompressedSegmentationChunk} from 'neuroglancer/sliceview/backend_chunk_decoders/compressed_segmentation';
 import {decodeJpegChunk} from 'neuroglancer/sliceview/backend_chunk_decoders/jpeg';
 import {VolumeChunk, VolumeChunkSource} from 'neuroglancer/sliceview/volume/backend';
 import {CancellationToken} from 'neuroglancer/util/cancellation';
+import {Endianness} from 'neuroglancer/util/endian';
 import {openShardedHttpRequest, sendHttpRequest} from 'neuroglancer/util/http_request';
 import {registerSharedObject} from 'neuroglancer/worker_rpc';
 
@@ -39,6 +41,38 @@ import {registerSharedObject} from 'neuroglancer/worker_rpc';
           let enc = new TextDecoder('utf-8');
           decodeSwcSkeletonChunk(chunk, enc.decode(response));
         });
+  }
+}
+
+export function decodeFragmentChunk(chunk: FragmentChunk, response: ArrayBuffer) {
+  let dv = new DataView(response);
+  let numVertices = dv.getUint32(0, true);
+  decodeTriangleVertexPositionsAndIndices(
+      chunk, response, Endianness.LITTLE, /*vertexByteOffset=*/4, numVertices);
+}
+
+@registerSharedObject() export class DVIDMeshSource extends
+(WithParameters(MeshSource, MeshSourceParameters)) {
+  download(chunk: ManifestChunk) {
+    // DVID does not currently store meshes chunked, the main
+    // use-case is for low-resolution 3D views.
+    // for now, fragmentId is the body id
+    return new Promise(function(resolve) {
+             resolve();
+           })
+        .then(() => {
+          chunk.fragmentIds = [`${chunk.objectId}`];
+        });
+  }
+
+  downloadFragment(chunk: FragmentChunk, cancellationToken: CancellationToken) {
+    const {parameters} = this;
+    const requestPath = `/api/node/${parameters['nodeKey']}/${parameters['dataInstanceKey']}/key/${
+        chunk.fragmentId}.ngmesh`;
+    return sendHttpRequest(
+               openShardedHttpRequest(parameters.baseUrls, requestPath), 'arraybuffer',
+               cancellationToken)
+        .then(response => decodeFragmentChunk(chunk, response));
   }
 }
 

--- a/src/neuroglancer/datasource/dvid/backend.ts
+++ b/src/neuroglancer/datasource/dvid/backend.ts
@@ -57,12 +57,8 @@ export function decodeFragmentChunk(chunk: FragmentChunk, response: ArrayBuffer)
     // DVID does not currently store meshes chunked, the main
     // use-case is for low-resolution 3D views.
     // for now, fragmentId is the body id
-    return new Promise(function(resolve) {
-             resolve();
-           })
-        .then(() => {
-          chunk.fragmentIds = [`${chunk.objectId}`];
-        });
+    chunk.fragmentIds = [`${chunk.objectId}`];
+    return Promise.resolve(undefined);
   }
 
   downloadFragment(chunk: FragmentChunk, cancellationToken: CancellationToken) {

--- a/src/neuroglancer/datasource/dvid/base.ts
+++ b/src/neuroglancer/datasource/dvid/base.ts
@@ -36,3 +36,7 @@ export class VolumeChunkSourceParameters extends DVIDSourceParameters {
 export class SkeletonSourceParameters extends DVIDSourceParameters {
   static RPC_ID = 'dvid/SkeletonSource';
 }
+
+export class MeshSourceParameters extends DVIDSourceParameters {
+  static RPC_ID = 'dvid/MeshSource';
+}

--- a/src/neuroglancer/datasource/dvid/frontend.ts
+++ b/src/neuroglancer/datasource/dvid/frontend.ts
@@ -21,7 +21,8 @@
 
 import {ChunkManager, WithParameters} from 'neuroglancer/chunk_manager/frontend';
 import {CompletionResult, DataSource} from 'neuroglancer/datasource';
-import {DVIDSourceParameters, SkeletonSourceParameters, VolumeChunkEncoding, VolumeChunkSourceParameters} from 'neuroglancer/datasource/dvid/base';
+import {DVIDSourceParameters, MeshSourceParameters, SkeletonSourceParameters, VolumeChunkEncoding, VolumeChunkSourceParameters} from 'neuroglancer/datasource/dvid/base';
+import {MeshSource} from 'neuroglancer/mesh/frontend';
 import {SkeletonSource} from 'neuroglancer/skeleton/frontend';
 import {DataType, VolumeChunkSpecification, VolumeSourceOptions, VolumeType} from 'neuroglancer/sliceview/volume/base';
 import {MultiscaleVolumeChunkSource as GenericMultiscaleVolumeChunkSource, VolumeChunkSource} from 'neuroglancer/sliceview/volume/frontend';
@@ -61,6 +62,9 @@ class DVIDVolumeChunkSource extends
 class DVIDSkeletonSource extends
 (WithParameters(SkeletonSource, SkeletonSourceParameters)) {}
 
+class DVIDMeshSource extends
+(WithParameters(MeshSource, MeshSourceParameters)) {}
+
 export class VolumeDataInstanceInfo extends DataInstanceInfo {
   dataType: DataType;
   lowerVoxelBound: vec3;
@@ -68,6 +72,7 @@ export class VolumeDataInstanceInfo extends DataInstanceInfo {
   voxelSize: vec3;
   numChannels: number;
   numLevels: number;
+  meshSrc: string;
   skeletonSrc: string;
 
   constructor(
@@ -96,10 +101,19 @@ export class VolumeDataInstanceInfo extends DataInstanceInfo {
       }
     }
 
-    this.skeletonSrc = '';
-    if (instSet.has(name + '_skeletons')) {
-      this.skeletonSrc = name + '_skeletons';
+    // only allow mesh or skeletons as sources but not both
+    this.meshSrc = '';
+    if (instSet.has(name + '_meshes')) {
+      this.meshSrc = name + '_meshes';
     }
+
+    this.skeletonSrc = '';
+    if (this.meshSrc !== '') {
+      if (instSet.has(name + '_skeletons')) {
+        this.skeletonSrc = name + '_skeletons';
+      }
+    }
+
 
     this.dataType =
         verifyObjectProperty(extendedValues[0], 'DataType', x => verifyMapKey(x, serverDataTypes));
@@ -182,6 +196,20 @@ export class VolumeDataInstanceInfo extends DataInstanceInfo {
       sources.push(alternatives);
     }
     return sources;
+  }
+
+  getMeshSource(chunkManager: ChunkManager, parameters: DVIDSourceParameters) {
+    if (this.meshSrc !== '') {
+      return chunkManager.getChunkSource(DVIDMeshSource, {
+        parameters: {
+          'baseUrls': parameters.baseUrls,
+          'nodeKey': parameters.nodeKey,
+          'dataInstanceKey': this.meshSrc,
+        }
+      });
+    } else {
+      return null;
+    }
   }
 
   getSkeletonSource(chunkManager: ChunkManager, parameters: DVIDSourceParameters) {
@@ -382,11 +410,19 @@ export class MultiscaleVolumeChunkSource implements GenericMultiscaleVolumeChunk
   }
 
   getMeshSource() {
-    return this.info.getSkeletonSource(this.chunkManager, {
+    let meshSource = this.info.getMeshSource(this.chunkManager, {
       'baseUrls': this.baseUrls,
       'nodeKey': this.nodeKey,
       'dataInstanceKey': this.dataInstanceKey,
     });
+    if (meshSource === null) {
+      return this.info.getSkeletonSource(this.chunkManager, {
+        'baseUrls': this.baseUrls,
+        'nodeKey': this.nodeKey,
+        'dataInstanceKey': this.dataInstanceKey,
+      });
+    }
+    return meshSource;
   }
 }
 


### PR DESCRIPTION
This commit adds support for meshes with the DVID backend using the pre-computed mesh format specified by neuroglancer.  The current implementation assumes a single chunk representation for the mesh as the intended use case, for now, is for quick (low-res if needed) browsing.  I otherwise tried to closely conform to the interface used in the precomputed instance in case we want to support mesh chunking in the future.

tslint and clang-format were run on the files.