### PR TITLE
[feature] Json link shortener

### DIFF
--- a/src/main_python.ts
+++ b/src/main_python.ts
@@ -119,7 +119,7 @@ window.addEventListener('DOMContentLoaded', () => {
   configState.add('screenshot', screenshotHandler.requestState);
 
   let sharedState: Trackable|undefined = viewer.state;
-
+  viewer.loadFromJsonUrl();
   if (window.location.hash) {
     const hashBinding = viewer.registerDisposer(new UrlHashBinding(viewer.state));
     hashBinding.updateFromUrlHash();
@@ -177,6 +177,4 @@ window.addEventListener('DOMContentLoaded', () => {
 
   bindDefaultCopyHandler(viewer);
   bindDefaultPasteHandler(viewer);
-
-
 });

--- a/src/main_python.ts
+++ b/src/main_python.ts
@@ -177,4 +177,6 @@ window.addEventListener('DOMContentLoaded', () => {
 
   bindDefaultCopyHandler(viewer);
   bindDefaultPasteHandler(viewer);
+
+
 });

--- a/src/neuroglancer/ui/default_viewer_setup.ts
+++ b/src/neuroglancer/ui/default_viewer_setup.ts
@@ -38,6 +38,8 @@ export function setupDefaultViewer() {
     hashBinding.parseError;
   }));
   hashBinding.updateFromUrlHash();
+  
+  viewer.loadFromJsonUrl();
 
   bindDefaultCopyHandler(viewer);
   bindDefaultPasteHandler(viewer);

--- a/src/neuroglancer/ui/url_hash_binding.ts
+++ b/src/neuroglancer/ui/url_hash_binding.ts
@@ -33,6 +33,10 @@ function encodeFragment(fragment: string) {
   });
 }
 
+export function removeParameterFromUrl(url: string, parameter: string) {
+  return url.replace(new RegExp('[?&]' + parameter + '=[^&#]*(#.*)?$'), '$1')
+      .replace(new RegExp('([?&])' + parameter + '=[^&]*&'), '$1');
+}
 /**
  * An instance of this class manages a binding between a Trackable value and the URL hash state.
  * The binding is initialized in the constructor, and is removed when dispose is called.
@@ -75,7 +79,7 @@ export class UrlHashBinding extends RefCounted {
         if (decodeURIComponent(stateString) === '{}') {
           history.replaceState(null, '', '#');
         } else {
-          history.replaceState(null, '', '#!' + stateString);
+          history.replaceState(null, '', removeParameterFromUrl(window.location.href, 'json_url')+'#!' + stateString);
         }
       }
     }

--- a/src/neuroglancer/viewer.ts
+++ b/src/neuroglancer/viewer.ts
@@ -604,7 +604,8 @@ export class Viewer extends RefCounted implements ViewerState {
             .replace(new RegExp('[?&]' + parameter + '=[^&#]*(#.*)?$'), '$1')
             .replace(new RegExp('([?&])' + parameter + '=[^&]*&'), '$1');
         }
-        RemoveParameterFromUrl(window.location.search, 'json_url');
+        
+        history.replaceState(null, '', RemoveParameterFromUrl(window.location.search, 'json_url'));
       }
       catch (HttpError){
         console.log('failed to load from: ' + json_url)

--- a/src/neuroglancer/viewer.ts
+++ b/src/neuroglancer/viewer.ts
@@ -458,7 +458,7 @@ export class Viewer extends RefCounted implements ViewerState {
       topRow.appendChild(button);
     }
     {
-      const button = makeTextIconButton('post', 'Post JSON to state server');
+      const button = makeTextIconButton('🔗', 'Post JSON to state server');
       this.registerEventListener(button, 'click', () => {
         this.postJsonState();
       });

--- a/src/neuroglancer/viewer.ts
+++ b/src/neuroglancer/viewer.ts
@@ -211,7 +211,6 @@ export class Viewer extends RefCounted implements ViewerState {
   layerSpecification: TopLevelLayerListSpecification;
   layout: RootLayoutContainer;
 
-  stateServer = new TrackableValue<string>('', validateStateServer);
   jsonStateServer = new TrackableValue<string>('', validateStateServer)
   state = new CompoundTrackable();
 
@@ -330,7 +329,6 @@ export class Viewer extends RefCounted implements ViewerState {
         'systemMemoryLimit', this.dataContext.chunkQueueManager.capacities.systemMemory.sizeLimit);
     state.add(
         'concurrentDownloads', this.dataContext.chunkQueueManager.capacities.download.itemLimit);
-    state.add('stateServer', this.stateServer);
     state.add('jsonStateServer', this.jsonStateServer);
     state.add('selectedLayer', this.selectedLayer);
     state.add('crossSectionBackgroundColor', this.crossSectionBackgroundColor);
@@ -623,7 +621,6 @@ export class Viewer extends RefCounted implements ViewerState {
                               console.log(response);
                               var short_url =window.location.origin+"/?json_url="+this.jsonStateServer.value.replace(/\/$/,"")+"/"+response;
                               alert(short_url);
-                              //="?json_url="+this.jsonStateServer.value+response;
                             })
 
   }

--- a/src/neuroglancer/viewer.ts
+++ b/src/neuroglancer/viewer.ts
@@ -64,7 +64,6 @@ export function validateStateServer(obj: any) {
   return obj;
 }
 
-
 export class DataManagementContext extends RefCounted {
   worker = new Worker('chunk_worker.bundle.js');
   chunkQueueManager = this.registerDisposer(new ChunkQueueManager(new RPC(this.worker), this.gl, {
@@ -332,7 +331,7 @@ export class Viewer extends RefCounted implements ViewerState {
     state.add('jsonStateServer', this.jsonStateServer);
     state.add('selectedLayer', this.selectedLayer);
     state.add('crossSectionBackgroundColor', this.crossSectionBackgroundColor);
-    
+
     this.registerDisposer(this.navigationState.changed.add(() => {
       this.handleNavigationStateChanged();
     }));
@@ -444,7 +443,6 @@ export class Viewer extends RefCounted implements ViewerState {
     topRow.appendChild(annotationToolStatus.element);
     this.registerDisposer(new ElementVisibilityFromTrackableBoolean(
         this.uiControlVisibility.showAnnotationToolStatus, annotationToolStatus.element));
-    
     
     {
       const button = makeTextIconButton('{}', 'Edit JSON state');


### PR DESCRIPTION
This adds a link shortener functionality to neuroglancer by implementing two things.  First, if the query_parameter json_url is passed to the neuroglancer page, it will go attempt to get a json from the specified URL, and use that to set the state, and remove that query parameter from the url.

Second, a button is added to the upper right that when pressed, posts the present viewer state to a url specified by a configurable jsonStateServer parameter in the json state.  The resulting response from that url should contain a URL where the json can be later retrieved.  For now there is a dialog that prompts the user to fill in the name of such a service, of which https://api.myjson.com/ is a free and available prototype, but others could be implemented. 