### PR TITLE
Improved display of multi-channel layer values

### DIFF
--- a/src/neuroglancer/layer_panel.css
+++ b/src/neuroglancer/layer_panel.css
@@ -86,7 +86,7 @@
 .neuroglancer-layer-item-value {
   display: inline-block;
   min-width: 10ch;
-  max-width: 30ch;
+  max-width: 50ch;
   margin-left: 1ch;
   white-space: nowrap;
   overflow: hidden;

--- a/src/neuroglancer/layer_panel.ts
+++ b/src/neuroglancer/layer_panel.ts
@@ -25,6 +25,7 @@ import {animationFrameDebounce} from 'neuroglancer/util/animation_frame_debounce
 import {RefCounted, registerEventListener} from 'neuroglancer/util/disposable';
 import {removeFromParent} from 'neuroglancer/util/dom';
 import {getDropEffect, preventDrag, setDropEffect} from 'neuroglancer/util/drag_and_drop';
+import {float32ToString} from 'neuroglancer/util/float32_to_string';
 import {makeCloseButton} from 'neuroglancer/widget/close_button';
 import {PositionWidget} from 'neuroglancer/widget/position_widget';
 
@@ -358,7 +359,18 @@ export class LayerPanel extends RefCounted {
       if (userLayer !== null) {
         let value = values.get(userLayer);
         if (value !== undefined) {
-          text = '' + value;
+          value = Array().concat(value);
+          value = value.map((x: any) => {
+            if (x === null) {
+              return 'null';
+            } else if (Math.fround(x) === x) {
+              // FIXME: Verify actual layer data type
+              return float32ToString(x);
+            } else {
+              return x;
+            }
+          });
+          text += value.join(', ');
         }
       }
       widget.valueElement.textContent = text;

--- a/src/neuroglancer/util/color.ts
+++ b/src/neuroglancer/util/color.ts
@@ -19,7 +19,7 @@
  */
 
 import {WatchableValue} from 'neuroglancer/trackable_value';
-import {floatToMinimalString} from 'neuroglancer/util/float_to_minimal_string';
+import {float32ToString} from 'neuroglancer/util/float32_to_string';
 import {vec3, vec4} from 'neuroglancer/util/geom';
 import {hexEncodeByte} from 'neuroglancer/util/hex';
 
@@ -81,7 +81,7 @@ export function serializeColor(x: vec3|vec4) {
       }
       result += Math.min(255, Math.max(0, Math.round(x[i] * 255)));
     }
-    result += `, ${floatToMinimalString(x[3])})`;
+    result += `, ${float32ToString(x[3])})`;
     return result;
   }
 }

--- a/src/neuroglancer/util/float32_to_string.spec.ts
+++ b/src/neuroglancer/util/float32_to_string.spec.ts
@@ -1,0 +1,69 @@
+/**
+ * @license
+ * Copyright 2018 The Neuroglancer Authors
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {float32ToString} from 'neuroglancer/util/float32_to_string';
+
+describe('float32_to_minimal_string', () => {
+  it('valid_float_to_minimal_string', () => {
+    let val: string;
+
+    val = float32ToString(0.2999998927116394);
+    expect(val).toEqual('0.2999999');
+
+    val = float32ToString(0.2999999225139618);
+    expect(val).toEqual('0.29999992');
+
+    val = float32ToString(0.30000001192092896);
+    expect(val).toEqual('0.3');
+
+    val = float32ToString(0.30000004172325134);
+    expect(val).toEqual('0.30000004');
+
+    val = float32ToString(0.0005000000237487257);
+    expect(val).toEqual('0.0005');
+
+    val = float32ToString(0.0005000000819563866);
+    expect(val).toEqual('0.0005000001');
+
+    val = float32ToString(4.999999987376214e-7);
+    expect(val).toEqual('5e-7');
+
+    val = float32ToString(NaN);
+    expect(val).toEqual('NaN');
+
+    val = float32ToString(-Infinity);
+    expect(val).toEqual('-Infinity');
+  });
+
+  it('float32_to_minimal_string_roundtrip', () => {
+    const test_values = [
+      (0.2999998927116394),
+      (0.2999999225139618),
+      (0.30000001192092896),
+      (0.30000004172325134),
+      (0.0005000000237487257),
+      (0.0005000000819563866),
+      (4.999999987376214e-7),
+      (NaN),
+      (-Infinity)
+    ];
+
+    test_values.forEach(original => {
+      let roundtrip = parseFloat(float32ToString(original));
+      expect(Math.fround(roundtrip)).toEqual(original);
+    });
+  });
+});

--- a/src/neuroglancer/util/float32_to_string.ts
+++ b/src/neuroglancer/util/float32_to_string.ts
@@ -18,12 +18,18 @@
 const tempArray = new Float32Array(1);
 
 /**
- * Return a minimum-length string representation of `x` that round-trips.
+ * Converts `x` into its nearest single precision float representation and
+ * returns a minimal string representation, with as many digits as necessary
+ * to uniquely distinguish single precision `x` from its adjacent single
+ * precision values.
+ *
+ * E.g.: 0.299999999000000017179701217174d → 0.30000001192092896f → '0.3')
  */
-export function floatToMinimalString(x: number) {
-  x = (tempArray[0] = x);
-  for (let digits = 0; digits < 9; ++digits) {
-    let result = x.toFixed(digits);
+export function float32ToString(x: number) {
+  tempArray[0] = x;
+  x = tempArray[0];
+  for (let digits = 1; digits < 21; ++digits) {
+    let result = x.toPrecision(digits);
     tempArray[0] = parseFloat(result);
     if (tempArray[0] === x) {
       return result;

--- a/src/neuroglancer/widget/coordinate_transform.ts
+++ b/src/neuroglancer/widget/coordinate_transform.ts
@@ -21,8 +21,8 @@
 import './coordinate_transform.css';
 
 import {CoordinateTransform} from 'neuroglancer/coordinate_transform';
+import {float32ToString} from 'neuroglancer/util/float32_to_string';
 import {Tab} from 'neuroglancer/widget/tab_view';
-import { floatToMinimalString } from 'neuroglancer/util/float_to_minimal_string';
 
 export class CoordinateTransformTab extends Tab {
   private textArea = document.createElement('textarea');
@@ -67,7 +67,7 @@ export class CoordinateTransformTab extends Tab {
           if (j !== 0) {
             value += ' ';
           }
-          value += floatToMinimalString(x);
+          value += float32ToString(x);
         }
       }
       this.textArea.value = value;


### PR DESCRIPTION
* Reworked `float_to_minimal_string`
  * renamed to `float32_to_string`
  * extended explanation, removed round-trip remark (never hold true)
  * added unit tests + fixes
  * changed behavior to return exponential notation if values become too small.
* Use `float32_to_string` for layer panel values that are representable as float32
  * ideally, this should check for the actual datatype of the layer, but I couldn't find it anywhere...
* Increase field size for layer values from 30 to 50 chars
  * enough to display equivalence mapping for two UInt64 values
  * typically enough to display 3-dimensional Float32 values

Resolves https://github.com/seung-lab/neuroglancer/issues/217