### PR TITLE
feat: add configurable cursor size

### DIFF
--- a/src/neuroglancer/perspective_view/panel.ts
+++ b/src/neuroglancer/perspective_view/panel.ts
@@ -365,7 +365,7 @@ export class PerspectivePanel extends RenderedDataPanel {
 
     const field_width = ReceptiveField.width;
     const field_height = ReceptiveField.height;
-    const pixels = field_width * field_height;
+    const pixels = RFSpiral.length;
 
     offscreenFramebuffer.readPixels(
       OffscreenTextures.Z, glWindowX, glWindowY,

--- a/src/neuroglancer/perspective_view/panel.ts
+++ b/src/neuroglancer/perspective_view/panel.ts
@@ -125,6 +125,15 @@ v4f_fragColor = vec4(accum.rgb / accum.a, revealage);
 const PerspectiveViewStateBase = withSharedVisibility(SharedObject);
 class PerspectiveViewState extends PerspectiveViewStateBase {}
 
+// The following three variables are for cursor state.
+const ReceptiveField = { 
+  width: 23, // must pick odd numbers so a center pixel exists
+  height: 23,
+};
+const RFSpiral = spiralSequence(ReceptiveField.width, ReceptiveField.height);
+const zData = new Uint8Array(ReceptiveField.width * ReceptiveField.height * 4);
+
+
 export class PerspectivePanel extends RenderedDataPanel {
   viewer: PerspectiveViewerState;
 
@@ -349,11 +358,41 @@ export class PerspectivePanel extends RenderedDataPanel {
     }
     let glWindowX = this.mouseX;
     let glWindowY = height - this.mouseY;
-    let zData = offscreenFramebuffer.readPixel(OffscreenTextures.Z, glWindowX, glWindowY);
-    let glWindowZ = 1.0 - unpackFloat01FromFixedPoint(zData);
+
+    if (isNaN(glWindowX) || isNaN(glWindowY)) {
+      return false;
+    }
+
+    const field_width = ReceptiveField.width;
+    const field_height = ReceptiveField.height;
+    const pixels = field_width * field_height;
+
+    offscreenFramebuffer.readPixels(
+      OffscreenTextures.Z, glWindowX, glWindowY,
+      field_width, field_height, zData
+    );
+
+    let zDatum = 0;
+    let rfindex = 0;
+    for (let i = 0; i < pixels; i++) {
+      rfindex = RFSpiral[i];
+      zDatum = unpackFloat01FromFixedPoint(
+        zData.slice(rfindex * 4, (rfindex + 1) * 4)
+      );
+
+      if (zDatum) {
+        break;
+      }
+    }
+
+    let glWindowZ = 1.0 - zDatum;
     if (glWindowZ === 1.0) {
       return false;
     }
+
+    glWindowX += (rfindex % field_width) - (field_width >> 1);
+    glWindowY += Math.floor(rfindex / field_height) - (field_height >> 1);
+
     out[0] = 2.0 * glWindowX / width - 1.0;
     out[1] = 2.0 * glWindowY / height - 1.0;
     out[2] = 2.0 * glWindowZ - 1.0;
@@ -648,4 +687,87 @@ export class PerspectivePanel extends RenderedDataPanel {
   zoomByMouse(factor: number) {
     this.navigationState.zoomBy(factor);
   }
+}
+
+/*  Generate a clockwise spiral around a 2D rectangular grid.
+    Outputs Vec3s, but only x and y are used. Used for spiraling
+    out of the center of the cursor to look for objects within the
+    receptive field.
+
+      3x3 pattern    3x3 unraveled array
+      | 8, 7, 6 |    | 0, 1, 2 |
+      | 1, 0, 5 |    | 3, 4, 5 |
+      | 2, 3, 4 |    | 6, 7, 8 |
+
+    Renders as [4,3,6,7,8,5,2,1,0] to show how to access the
+    right hand side array in a spiral pattern.
+
+    width: width of array in pixels
+    height: height of array in pixels
+
+    Note: width and height must be odd numbers
+
+    We also apply a circularizing operator to filter out elements of
+    the spiral that are outside a given radius from the center,
+    otherwise the cursor will be more sensitive along diagonals.
+*/
+function spiralSequence(width: number, height: number) : Uint32Array {
+  const pixels = width * height;
+  let sequence = new Uint32Array(pixels);
+
+  if (width === 0 || height === 0) {
+    return sequence;
+  }
+  else if (width === 1) {
+    for (let i = 0; i < height; i++) {
+      sequence[i] = i * width;
+    }
+    return sequence;
+  }
+  else if (height === 1) {
+    for (let i = 0; i < width; i++) {
+      sequence[i] = i;
+    }
+    return sequence;
+  }
+
+  function clockwise_spiral(sequence: Uint32Array) {
+    let bounds = [ width, height - 1 ];
+    let direction = [ 1, 0 ];
+    let pt = [ 0, 0 ];
+    let bound_idx = 0;
+    let steps = 1;
+
+    for (let covered = 0; covered < pixels; covered++) {
+      sequence[covered] = pt[0] + width * pt[1];
+
+      pt[0] += direction[0];
+      pt[1] += direction[1];
+      steps += 1;
+
+      if (steps === bounds[bound_idx]) {
+        steps = 0;
+        bounds[bound_idx] -= 1;
+        bound_idx = (bound_idx + 1) % 2;
+        direction = [ -direction[1], direction[0] ];
+      }
+    }
+
+    return sequence;
+  }
+
+  sequence = clockwise_spiral(sequence).reverse();
+
+  // Circularize
+  let r2 = Math.min(width, height) / 2;
+  r2 *= r2;
+
+  return sequence.filter( (idx) => {
+    let x = (idx % width) - (width >> 1);
+    let y = Math.floor(idx / height) - (height >> 1);
+
+    let dist2 = x*x + y*y;
+
+    return dist2 <= r2;
+  });
 }

--- a/src/neuroglancer/webgl/offscreen.ts
+++ b/src/neuroglancer/webgl/offscreen.ts
@@ -227,6 +227,57 @@ export class FramebufferConfiguration<ColorBuffer extends TextureBuffer|Renderbu
     return tempPixel;
   }
 
+  readPixels(
+    textureIndex: number, glWindowX: number, glWindowY: number,
+    width: number, height: number, buffer?: Uint8Array
+  ) : Uint8Array {
+
+    let {gl} = this;
+
+    if (!buffer) {
+      buffer = new Uint8Array(width * height * 4);
+    }
+
+    // WebGL supports reading pixels off the
+    // edge of the texture though the values are undefined.
+    let left = glWindowX - (width >> 1);
+    let bottom = glWindowY - (height >> 1);
+
+    try {
+      this.bindSingle(textureIndex);
+      gl.readPixels(left, bottom, width, height, gl.RGBA, gl.UNSIGNED_BYTE, buffer);
+    } finally {
+      this.framebuffer.unbind();
+    }
+
+    if (glWindowX >= 0 
+        && glWindowX < gl.drawingBufferWidth
+        && glWindowY >= 0
+        && glWindowY < gl.drawingBufferHeight) {
+
+      return buffer;
+    }
+
+    // According to the WebGL spec, if we are reading outside of the 
+    // texture, those values are undefined so let's zero them out.
+    // https://www.khronos.org/registry/OpenGL-Refpages/es2.0/xhtml/glReadPixels.xml
+    // "Values for pixels that lie outside the window connected to the current GL context are undefined."
+
+    let buff32 = new Uint32Array(buffer.buffer);
+
+    let i = 0;
+    for (let y = glWindowY; y < glWindowY + height; y++) {
+      for (let x = glWindowX; x < glWindowX + width; x++) {
+        if (x < 0 || y < 0 || x >= gl.drawingBufferWidth || y >= gl.drawingBufferHeight) {
+          buff32[i] = 0;
+        }
+        i++;
+      }
+    }
+
+    return buffer;
+  }
+
   /**
    * Calls readPixel, but interprets the RGBA result as a little-endian uint32 value.
    */


### PR DESCRIPTION
The current neuroglancer cursor is only sensitive around its central pixel. However, when interacting with thin objects, a few more pixels can help. This PR works by increasing the receptive field of the cursor from 1px to 23px in diameter.

This is done by creating a spiral search pattern out from the central pixel towards the extremities. Thus, the central pixel will always be selected first, but anything up to radius 11px away will be selected if it is within range and nothing else is in the way. 

We have tested this and it appears to work without imposing significant CPU costs.

