### PR TITLE
Feat(datasource/precomputed): Support skeletons

### DIFF
--- a/src/neuroglancer/datasource/precomputed/backend.ts
+++ b/src/neuroglancer/datasource/precomputed/backend.ts
@@ -89,15 +89,7 @@ export function decodeFragmentChunk(chunk: FragmentChunk, response: ArrayBuffer)
 function decodeSkeletonChunk(chunk: SkeletonChunk, response: ArrayBuffer) {
   let dv = new DataView(response);
   let numVertices = dv.getUint32(0, true);
-  // let numVerticesHigh = dv.getUint32(4, true);
-  // if (numVerticesHigh !== 0) {
-  //   throw new Error(`The number of vertices should not exceed 2^32-1.`);
-  // }
   let numEdges = dv.getUint32(4, true);
-  // let numEdgesHigh = dv.getUint32(12, true);
-  // if (numEdgesHigh !== 0) {
-  //   throw new Error(`The number of edges should not exceed 2^32-1.`);
-  // }
   decodeSkeletonVertexPositionsAndIndices(
       chunk, response, Endianness.LITTLE, /*vertexByteOffset=*/8, numVertices,
       /*indexByteOffset=*/undefined, /*numEdges=*/numEdges);

--- a/src/neuroglancer/datasource/precomputed/backend.ts
+++ b/src/neuroglancer/datasource/precomputed/backend.ts
@@ -15,8 +15,9 @@
  */
 
 import {WithParameters} from 'neuroglancer/chunk_manager/backend';
-import {MeshSourceParameters, VolumeChunkEncoding, VolumeChunkSourceParameters} from 'neuroglancer/datasource/precomputed/base';
+import {MeshSourceParameters, SkeletonSourceParameters, VolumeChunkEncoding, VolumeChunkSourceParameters} from 'neuroglancer/datasource/precomputed/base';
 import {decodeJsonManifestChunk, decodeTriangleVertexPositionsAndIndices, FragmentChunk, ManifestChunk, MeshSource} from 'neuroglancer/mesh/backend';
+import {decodeSkeletonVertexPositionsAndIndices, SkeletonChunk, SkeletonSource} from 'neuroglancer/skeleton/backend';
 import {ChunkDecoder} from 'neuroglancer/sliceview/backend_chunk_decoders';
 import {decodeCompressedSegmentationChunk} from 'neuroglancer/sliceview/backend_chunk_decoders/compressed_segmentation';
 import {decodeJpegChunk} from 'neuroglancer/sliceview/backend_chunk_decoders/jpeg';
@@ -82,5 +83,33 @@ export function decodeFragmentChunk(chunk: FragmentChunk, response: ArrayBuffer)
                openShardedHttpRequest(parameters.baseUrls, requestPath), 'arraybuffer',
                cancellationToken)
         .then(response => decodeFragmentChunk(chunk, response));
+  }
+}
+
+function decodeSkeletonChunk(chunk: SkeletonChunk, response: ArrayBuffer) {
+  let dv = new DataView(response);
+  let numVertices = dv.getUint32(0, true);
+  // let numVerticesHigh = dv.getUint32(4, true);
+  // if (numVerticesHigh !== 0) {
+  //   throw new Error(`The number of vertices should not exceed 2^32-1.`);
+  // }
+  let numEdges = dv.getUint32(4, true);
+  // let numEdgesHigh = dv.getUint32(12, true);
+  // if (numEdgesHigh !== 0) {
+  //   throw new Error(`The number of edges should not exceed 2^32-1.`);
+  // }
+  decodeSkeletonVertexPositionsAndIndices(
+      chunk, response, Endianness.LITTLE, /*vertexByteOffset=*/8, numVertices,
+      /*indexByteOffset=*/undefined, /*numEdges=*/numEdges);
+}
+
+@registerSharedObject() export class PrecomputedSkeletonSource extends (WithParameters(SkeletonSource, SkeletonSourceParameters)) {
+  download(chunk: SkeletonChunk, cancellationToken: CancellationToken) {
+    const {parameters} = this;
+    let requestPath = `${parameters.path}/${chunk.objectId}`;
+    return sendHttpRequest(
+               openShardedHttpRequest(parameters.baseUrls, requestPath), 'arraybuffer',
+               cancellationToken)
+        .then(response => decodeSkeletonChunk(chunk, response));
   }
 }

--- a/src/neuroglancer/datasource/precomputed/base.ts
+++ b/src/neuroglancer/datasource/precomputed/base.ts
@@ -36,3 +36,11 @@ export class MeshSourceParameters {
 
   static RPC_ID = 'precomputed/MeshSource';
 }
+
+
+export class SkeletonSourceParameters {
+  baseUrls: string[];
+  path: string;
+
+  static RPC_ID = 'precomputed/SkeletonSource';
+}

--- a/src/neuroglancer/datasource/precomputed/frontend.ts
+++ b/src/neuroglancer/datasource/precomputed/frontend.ts
@@ -17,8 +17,9 @@
 import {AnnotationSource, makeDataBoundsBoundingBox} from 'neuroglancer/annotation';
 import {ChunkManager, WithParameters} from 'neuroglancer/chunk_manager/frontend';
 import {DataSource} from 'neuroglancer/datasource';
-import {MeshSourceParameters, VolumeChunkEncoding, VolumeChunkSourceParameters} from 'neuroglancer/datasource/precomputed/base';
+import {MeshSourceParameters, SkeletonSourceParameters, VolumeChunkEncoding, VolumeChunkSourceParameters} from 'neuroglancer/datasource/precomputed/base';
 import {MeshSource} from 'neuroglancer/mesh/frontend';
+import {SkeletonSource} from 'neuroglancer/skeleton/frontend';
 import {DataType, VolumeChunkSpecification, VolumeSourceOptions, VolumeType} from 'neuroglancer/sliceview/volume/base';
 import {MultiscaleVolumeChunkSource as GenericMultiscaleVolumeChunkSource, VolumeChunkSource} from 'neuroglancer/sliceview/volume/frontend';
 import {mat4, vec3} from 'neuroglancer/util/geom';
@@ -30,6 +31,9 @@ class PrecomputedVolumeChunkSource extends
 
 class PrecomputedMeshSource extends
 (WithParameters(MeshSource, MeshSourceParameters)) {}
+
+class PrecomputedSkeletonSource extends
+(WithParameters(SkeletonSource, SkeletonSourceParameters)) {}
 
 class ScaleInfo {
   key: string;
@@ -69,9 +73,15 @@ export class MultiscaleVolumeChunkSource implements GenericMultiscaleVolumeChunk
   numChannels: number;
   volumeType: VolumeType;
   mesh: string|undefined;
+  skeleton: string|undefined;
   scales: ScaleInfo[];
 
   getMeshSource() {
+    let {skeleton} = this;
+    if (skeleton !== undefined) {
+      return getShardedSkeletonSource(
+        this.chunkManager, {baseUrls: this.baseUrls, path: `${this.path}/${skeleton}`});
+    }
     let {mesh} = this;
     if (mesh === undefined) {
       return null;
@@ -87,6 +97,7 @@ export class MultiscaleVolumeChunkSource implements GenericMultiscaleVolumeChunk
     this.numChannels = verifyObjectProperty(obj, 'num_channels', verifyPositiveInt);
     this.volumeType = verifyObjectProperty(obj, 'type', x => verifyEnumString(x, VolumeType));
     this.mesh = verifyObjectProperty(obj, 'mesh', verifyOptionalString);
+    this.skeleton = verifyObjectProperty(obj, 'skeleton', verifyOptionalString);
     this.scales = verifyObjectProperty(obj, 'scales', x => parseArray(x, y => new ScaleInfo(y)));
   }
 
@@ -133,6 +144,16 @@ export function getShardedMeshSource(chunkManager: ChunkManager, parameters: Mes
   return chunkManager.getChunkSource(PrecomputedMeshSource, {parameters});
 }
 
+export function getShardedSkeletonSource(
+    chunkManager: ChunkManager, parameters: SkeletonSourceParameters) {
+  return chunkManager.getChunkSource(PrecomputedSkeletonSource, {parameters});
+}
+
+export function getSkeletonSource(chunkManager: ChunkManager, url: string) {
+  const [baseUrls, path] = parseSpecialUrl(url);
+  return getShardedSkeletonSource(chunkManager, {baseUrls, path});
+}
+
 export function getShardedVolume(chunkManager: ChunkManager, baseUrls: string[], path: string) {
   return chunkManager.memoize.getUncounted(
       {'type': 'precomputed:MultiscaleVolumeChunkSource', baseUrls, path},
@@ -161,5 +182,8 @@ export class PrecomputedDataSource extends DataSource {
   }
   getMeshSource(chunkManager: ChunkManager, url: string) {
     return getMeshSource(chunkManager, url);
+  }
+  getSkeletonSource(chunkManager: ChunkManager, url: string) {
+    return getSkeletonSource(chunkManager, url);
   }
 }

--- a/src/neuroglancer/datasource/precomputed/register_default.ts
+++ b/src/neuroglancer/datasource/precomputed/register_default.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {PrecomputedDataSource} from 'neuroglancer/datasource/precomputed/frontend';
 import {registerProvider} from 'neuroglancer/datasource/default_provider';
+import {PrecomputedDataSource} from 'neuroglancer/datasource/precomputed/frontend';
 
 registerProvider('precomputed', () => new PrecomputedDataSource());

--- a/src/neuroglancer/datasource/precomputed/register_default.ts
+++ b/src/neuroglancer/datasource/precomputed/register_default.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {registerProvider} from 'neuroglancer/datasource/default_provider';
 import {PrecomputedDataSource} from 'neuroglancer/datasource/precomputed/frontend';
+import {registerProvider} from 'neuroglancer/datasource/default_provider';
 
 registerProvider('precomputed', () => new PrecomputedDataSource());


### PR DESCRIPTION
This adds support for precomputed skeletons compatible with the neuroglancer python format.  

This is really only a small continuation of the original PR that @alexbaden made here: https://github.com/google/neuroglancer/pull/60

There is currently a constraint in that within the precomputed `info` file you can only have either a mesh or a skeleton folder, not both.  I think this is as intended, as otherwise the segments IDs would be linked and that doesn't make sense.  To get meshes AND skeletons in the same view we load two separate info files as separate layers.