### PR TITLE
Added a cubehelix colormap

### DIFF
--- a/src/neuroglancer/webgl/colormaps.glsl
+++ b/src/neuroglancer/webgl/colormaps.glsl
@@ -21,3 +21,21 @@ vec3 colormapJet(float x) {
   result.b = x < 0.34 ? (0.5 + x * 0.5 / 0.11) : (1.0 - (x - 0.34) / 0.31);
   return clamp(result, 0.0, 1.0);
 }
+
+/*
+ * Adapted from http://www.mrao.cam.ac.uk/~dag/CUBEHELIX/CubeHelix.m
+ * which is licensed under http://unlicense.org/
+ */
+vec3 colormapCubehelix(float x) {
+    float xclamp = clamp(x, 0.0, 1.0);
+    float angle = 2.0 * 3.1415926 * (4.0 / 3.0 + xclamp);
+    float amp = xclamp * (1.0 - xclamp) / 2.0;
+    vec3 result;
+    float cosangle = cos(angle);
+    float sinangle = sin(angle);
+    result.r = -0.14861 * cosangle + 1.78277 * sinangle;
+    result.g = -0.29227 * cosangle + -0.90649 * sinangle;
+    result.b = 1.97294 * cosangle;
+    result = clamp(xclamp + amp * result, 0.0, 1.0);
+    emitRGB(result);
+}


### PR DESCRIPTION
Hey all,
I just implemented Dave Green's cubehelix here. It looks absolutely fantastic, so I thought I should share. If you want a quick preview, just paste this as your shader (substitute your chosen amplitude for "40.0" below):

```
void main() {
    float x = clamp(toNormalized(getDataValue()) * 40.0, 0.0, 1.0);
    float angle = 2.0 * 3.1415926 * (4.0 / 3.0 +  x);
    float amp = x * (1.0 - x) / 2.0;
    vec3 result;
    float cosangle = cos(angle);
    float sinangle = sin(angle);
    result.r = -0.14861 * cosangle + 1.78277 * sinangle;
    result.g = -0.29227 * cosangle + -0.90649 * sinangle;
    result.b = 1.97294 * cosangle;
    result = clamp(x + amp * result, 0.0, 1.0);
    emitRGB(result);
}
```
I have used defaults for some of his parameters (hue, starting color, # of rotations), because I was hesitant about adding them as parameters to the function, not sure exactly how to *use* jet as anything but a shader example.

Original code is published with an unlicense, so I think it is unencumbered.
@jmswaney