### PR TITLE
Layer order now preserved on refresh or on load from URL or JSON server

### DIFF
--- a/python/examples/example_action.py
+++ b/python/examples/example_action.py
@@ -6,7 +6,7 @@ import neuroglancer
 
 viewer = neuroglancer.Viewer()
 with viewer.txn() as s:
-    s.layers['image'] = neuroglancer.ImageUserLayer(
+    s.layers['image'] = neuroglancer.ImageLayer(
         source='brainmaps://1016859101264:janelia-flyem-cx:raw',
     )
 

--- a/python/neuroglancer/viewer_state.py
+++ b/python/neuroglancer/viewer_state.py
@@ -436,10 +436,11 @@ class Layers(object):
                 self._layers.append(ManagedLayer(k, v, _readonly=_readonly))
         else:
             # layers property can also be an array in JSON now. each layer has a name property
-            for layer in six.iteritems(json_data):
-                name = text_type(layer.name)
-                del layer[name]
-                self._layers.append(ManagedLayer(name, layer, _readonly=_readonly))
+            for layer in json_data:
+                if isinstance(layer, ManagedLayer):
+                    self._layers.append(ManagedLayer(layer.name, layer, _readonly=_readonly))
+                elif isinstance(layer, dict):
+                    self._layers.append(ManagedLayer(text_type(layer['name']), layer, _readonly=_readonly))
 
     def index(self, k):
         for i, u in enumerate(self._layers):
@@ -513,9 +514,9 @@ class Layers(object):
         return iter(self._layers)
 
     def to_json(self):
-        r = collections.OrderedDict()
+        r = []
         for x in self._layers:
-            r[x.name] = x.to_json()
+            r.append(x.to_json())
         return r
 
     def __repr__(self):

--- a/python/neuroglancer/viewer_state.py
+++ b/python/neuroglancer/viewer_state.py
@@ -412,6 +412,7 @@ class ManagedLayer(JsonObjectWrapper):
 
     def to_json(self):
         r = self.layer.to_json()
+        r['name'] = self.name
         visible = self.visible
         if visible is not None:
             r['visible'] = visible

--- a/python/neuroglancer/viewer_state.py
+++ b/python/neuroglancer/viewer_state.py
@@ -431,8 +431,15 @@ class Layers(object):
             json_data = collections.OrderedDict()
         self._layers = []
         self._readonly = _readonly
-        for k, v in six.iteritems(json_data):
-            self._layers.append(ManagedLayer(k, v, _readonly=_readonly))
+        if isinstance(json_data, collections.Mapping):
+            for k, v in six.iteritems(json_data):
+                self._layers.append(ManagedLayer(k, v, _readonly=_readonly))
+        else:
+            # layers property can also be an array in JSON now. each layer has a name property
+            for layer in six.iteritems(json_data):
+                name = text_type(layer.name)
+                del layer[name]
+                self._layers.append(ManagedLayer(name, layer, _readonly=_readonly))
 
     def index(self, k):
         for i, u in enumerate(self._layers):

--- a/python/neuroglancer/viewer_state.py
+++ b/python/neuroglancer/viewer_state.py
@@ -441,6 +441,8 @@ class Layers(object):
                     self._layers.append(ManagedLayer(layer.name, layer, _readonly=_readonly))
                 elif isinstance(layer, dict):
                     self._layers.append(ManagedLayer(text_type(layer['name']), layer, _readonly=_readonly))
+                else:
+                    raise TypeError
 
     def index(self, k):
         for i, u in enumerate(self._layers):

--- a/src/neuroglancer/layer_specification.ts
+++ b/src/neuroglancer/layer_specification.ts
@@ -134,8 +134,6 @@ export class TopLevelLayerListSpecification extends RefCounted implements LayerL
       for (const layerObj of x) {
         verifyObject(layerObj);
         const name = verifyObjectProperty(layerObj, 'name', verifyString);
-        // Delete name property so that layerObj specification object is identical to what it used to be
-        delete layerObj.name;
         this.layerManager.addManagedLayer(this.getLayer(name, layerObj));
       }
     } else {

--- a/src/neuroglancer/layer_specification.ts
+++ b/src/neuroglancer/layer_specification.ts
@@ -133,7 +133,7 @@ export class TopLevelLayerListSpecification extends RefCounted implements LayerL
       // If array, layers have an order
       for (const layerObj of x) {
         verifyObject(layerObj);
-        const name = verifyObjectProperty(layerObj, 'name', verifyString);
+        const name = this.layerManager.getUniqueLayerName(verifyObjectProperty(layerObj, 'name', verifyString));
         this.layerManager.addManagedLayer(this.getLayer(name, layerObj));
       }
     } else {

--- a/src/neuroglancer/layer_specification.ts
+++ b/src/neuroglancer/layer_specification.ts
@@ -133,7 +133,7 @@ export class TopLevelLayerListSpecification extends RefCounted implements LayerL
       // If array, layers have an order
       for (const layerObj of x) {
         verifyObject(layerObj);
-        const name = layerObj.name;
+        const name = verifyObjectProperty(layerObj, 'name', verifyString);
         // Delete name property so that layerObj specification object is identical to what it used to be
         delete layerObj.name;
         this.layerManager.addManagedLayer(this.getLayer(name, layerObj));

--- a/src/neuroglancer/layer_specification.ts
+++ b/src/neuroglancer/layer_specification.ts
@@ -56,6 +56,7 @@ export class ManagedUserLayerWithSpecification extends ManagedUserLayer {
       return this.initialSpecification;
     }
     let layerSpec = userLayer.toJSON();
+    layerSpec.name = this.name;
     if (!this.visible) {
       layerSpec['visible'] = false;
     }
@@ -127,10 +128,22 @@ export class TopLevelLayerListSpecification extends RefCounted implements LayerL
   }
 
   restoreState(x: any) {
-    verifyObject(x);
     this.layerManager.clear();
-    for (let key of Object.keys(x)) {
-      this.layerManager.addManagedLayer(this.getLayer(key, x[key]));
+    if (Array.isArray(x)) {
+      // If array, layers have an order
+      for (const layerObj of x) {
+        verifyObject(layerObj);
+        const name = layerObj.name;
+        // Delete name property so that layerObj specification object is identical to what it used to be
+        delete layerObj.name;
+        this.layerManager.addManagedLayer(this.getLayer(name, layerObj));
+      }
+    } else {
+      // Keep for backwards compatibility
+      verifyObject(x);
+      for (let key of Object.keys(x)) {
+        this.layerManager.addManagedLayer(this.getLayer(key, x[key]));
+      }
     }
   }
 
@@ -200,14 +213,14 @@ export class TopLevelLayerListSpecification extends RefCounted implements LayerL
   }
 
   toJSON() {
-    let result: any = {};
+    const result = [];
     let numResults = 0;
     for (let managedLayer of this.layerManager.managedLayers) {
       const layerJson = (<ManagedUserLayerWithSpecification>managedLayer).toJSON();
       // A `null` layer specification is used to indicate a transient drag target, and should not be
       // serialized.
       if (layerJson != null) {
-        result[managedLayer.name] = layerJson;
+        result.push(layerJson);
         ++numResults;
       }
     }


### PR DESCRIPTION
This PR changes the "layers" property in the JSON state from an object to an array to preserve the layer order (see https://github.com/seung-lab/neuroglancer/issues/228).