### PR TITLE
Allow user to limit data downloads to specific MIP levels

### DIFF
--- a/src/neuroglancer/image_user_layer.ts
+++ b/src/neuroglancer/image_user_layer.ts
@@ -67,7 +67,9 @@ export class ImageUserLayer extends Base {
           fragmentMain: this.fragmentMain,
           shaderError: this.shaderError,
           transform: this.transform,
+          mipLevelConstraints: this.mipLevelConstraints
         });
+        this.setupVoxelSelectionWidget(renderLayer);
         this.addRenderLayer(renderLayer);
         this.shaderError.changed.dispatch();
         this.isReady = true;
@@ -138,6 +140,8 @@ class RenderingOptionsTab extends Tab {
         this.codeWidget.textEditor.refresh();
       }
     });
+
+    element.appendChild(layer.voxelSizeSelectionWidget.element);
   }
 }
 

--- a/src/neuroglancer/segmentation_user_layer.ts
+++ b/src/neuroglancer/segmentation_user_layer.ts
@@ -80,6 +80,7 @@ export class SegmentationUserLayer extends Base {
         objectToDataTransform: this.transform,
         fragmentMain: getTrackableFragmentMain(),
         shaderError: makeWatchableShaderError(),
+        mipLevelConstraints: this.mipLevelConstraints
       };
 
   /**
@@ -198,7 +199,9 @@ export class SegmentationUserLayer extends Base {
       ++remaining;
       multiscaleSource.then(volume => {
         if (!this.wasDisposed) {
-          this.addRenderLayer(new SegmentationRenderLayer(volume, this.displayState));
+          const segmentationRenderLayer = new SegmentationRenderLayer(volume, this.displayState);
+          this.setupVoxelSelectionWidget(segmentationRenderLayer);
+          this.addRenderLayer(segmentationRenderLayer);
           if (meshPath === undefined && skeletonsPath === undefined) {
             ++remaining;
             Promise.resolve(volume.getMeshSource()).then(objectSource => {
@@ -451,6 +454,8 @@ class DisplayOptionsTab extends Tab {
         }
       }
     });
+
+    element.appendChild(layer.voxelSizeSelectionWidget.element);
   }
 }
 

--- a/src/neuroglancer/sliceview/backend.ts
+++ b/src/neuroglancer/sliceview/backend.ts
@@ -16,12 +16,13 @@
 
 import {Chunk, ChunkConstructor, ChunkSource, withChunkManager} from 'neuroglancer/chunk_manager/backend';
 import {CoordinateTransform} from 'neuroglancer/coordinate_transform';
-import {RenderLayer as RenderLayerInterface, SLICEVIEW_ADD_VISIBLE_LAYER_RPC_ID, SLICEVIEW_REMOVE_VISIBLE_LAYER_RPC_ID, SLICEVIEW_RENDERLAYER_RPC_ID, SLICEVIEW_RENDERLAYER_UPDATE_TRANSFORM_RPC_ID, SLICEVIEW_RPC_ID, SLICEVIEW_UPDATE_VIEW_RPC_ID, SliceViewBase, SliceViewChunkSource as SliceViewChunkSourceInterface, SliceViewChunkSpecification} from 'neuroglancer/sliceview/base';
+import {RenderLayer as RenderLayerInterface, SLICEVIEW_ADD_VISIBLE_LAYER_RPC_ID, SLICEVIEW_REMOVE_VISIBLE_LAYER_RPC_ID, SLICEVIEW_RENDERLAYER_RPC_ID, SLICEVIEW_RENDERLAYER_UPDATE_TRANSFORM_RPC_ID, SLICEVIEW_RPC_ID, SLICEVIEW_UPDATE_VIEW_RPC_ID, SLICEVIEW_RENDERLAYER_UPDATE_MIP_LEVEL_CONSTRAINTS_RPC_ID, SliceViewBase, SliceViewChunkSource as SliceViewChunkSourceInterface, SliceViewChunkSpecification} from 'neuroglancer/sliceview/base';
 import {ChunkLayout} from 'neuroglancer/sliceview/chunk_layout';
 import {mat4, vec3, vec3Key} from 'neuroglancer/util/geom';
 import {NullarySignal} from 'neuroglancer/util/signal';
 import {getBasePriority, getPriorityTier, withSharedVisibility} from 'neuroglancer/visibility_priority/backend';
 import {registerRPC, registerSharedObject, RPC, SharedObjectCounterpart} from 'neuroglancer/worker_rpc';
+import {TrackableMIPLevelConstraints} from 'neuroglancer/trackable_mip_level_constraints';
 
 const BASE_PRIORITY = -1e12;
 const SCALE_PRIORITY_MULTIPLIER = 1e9;
@@ -98,6 +99,7 @@ export class SliceView extends SliceViewIntermediateBase {
     this.visibleLayers.delete(layer);
     layer.layerChanged.remove(this.handleLayerChanged);
     layer.transform.changed.remove(this.invalidateVisibleSources);
+    layer.mipLevelConstraints.changed.remove(this.invalidateVisibleSources);
     this.invalidateVisibleSources();
   }
 
@@ -105,6 +107,7 @@ export class SliceView extends SliceViewIntermediateBase {
     this.visibleLayers.set(layer, []);
     layer.layerChanged.add(this.handleLayerChanged);
     layer.transform.changed.add(this.invalidateVisibleSources);
+    layer.mipLevelConstraints.changed.add(this.invalidateVisibleSources);
     this.invalidateVisibleSources();
   }
 
@@ -208,6 +211,7 @@ export class RenderLayer extends SharedObjectCounterpart implements RenderLayerI
   transform = new CoordinateTransform();
   transformedSources: {source: SliceViewChunkSource, chunkLayout: ChunkLayout}[][];
   transformedSourcesGeneration = -1;
+  mipLevelConstraints: TrackableMIPLevelConstraints;
 
   constructor(rpc: RPC, options: any) {
     super(rpc, options);
@@ -223,6 +227,7 @@ export class RenderLayer extends SharedObjectCounterpart implements RenderLayerI
     }
     mat4.copy(this.transform.transform, options['transform']);
     this.transform.changed.add(this.layerChanged.dispatch);
+    this.mipLevelConstraints = new TrackableMIPLevelConstraints(options['minMIPLevel'], options['maxMIPLevel'], options['numberOfMIPLevels']);
   }
 }
 registerRPC(SLICEVIEW_RENDERLAYER_UPDATE_TRANSFORM_RPC_ID, function(x) {
@@ -233,4 +238,10 @@ registerRPC(SLICEVIEW_RENDERLAYER_UPDATE_TRANSFORM_RPC_ID, function(x) {
     mat4.copy(oldValue, newValue);
     layer.transform.changed.dispatch();
   }
+});
+registerRPC(SLICEVIEW_RENDERLAYER_UPDATE_MIP_LEVEL_CONSTRAINTS_RPC_ID, function(x) {
+  const layer = <RenderLayer>this.get(x.id);
+  const newMinMIPLevelValue: number|undefined = x.minMIPLevel;
+  const newMaxMIPLevelValue: number|undefined = x.maxMIPLevel;
+  layer.mipLevelConstraints.restoreState(newMinMIPLevelValue, newMaxMIPLevelValue);
 });

--- a/src/neuroglancer/sliceview/base.ts
+++ b/src/neuroglancer/sliceview/base.ts
@@ -21,6 +21,8 @@ import {approxEqual} from 'neuroglancer/util/compare';
 import {DATA_TYPE_BYTES, DataType} from 'neuroglancer/util/data_type';
 import {effectiveScalingFactorFromMat4, identityMat4, kAxes, kInfinityVec, kZeroVec, mat4, rectifyTransformMatrixIfAxisAligned, transformVectorByMat4, vec3} from 'neuroglancer/util/geom';
 import {SharedObject} from 'neuroglancer/worker_rpc';
+import {TrackableMIPLevelConstraints} from 'neuroglancer/trackable_mip_level_constraints';
+import {TrackableValue} from 'neuroglancer/trackable_value';
 
 export {DATA_TYPE_BYTES, DataType};
 
@@ -124,8 +126,10 @@ interface TransformedSource {
 export interface RenderLayer {
   sources: SliceViewChunkSource[][];
   transform: CoordinateTransform;
-  transformedSources: TransformedSource[][] | undefined;
+  transformedSources: TransformedSource[][]|undefined;
   transformedSourcesGeneration: number;
+  mipLevelConstraints: TrackableMIPLevelConstraints;
+  activeMinMIPLevel?: TrackableValue<number|undefined>; // not needed for backend
 }
 
 export function getTransformedSources(renderLayer: RenderLayer) {
@@ -304,7 +308,7 @@ export class SliceViewBase extends SharedObject {
 
   /**
    * Computes the list of sources to use for each visible layer, based on the
-   * current pixelSize.
+   * current pixelSize, and the user specified integers minMIPLevel and maxMIPLevel.
    */
   updateVisibleSources() {
     if (!this.visibleSourcesStale) {
@@ -312,23 +316,29 @@ export class SliceViewBase extends SharedObject {
     }
     this.visibleSourcesStale = false;
     // Increase pixel size by a small margin.
-    let pixelSize = this.pixelSize * 1.1;
+    const pixelSize = this.pixelSize * 1.1;
     // console.log("pixelSize", pixelSize);
 
-    let visibleChunkLayouts = this.visibleChunkLayouts;
+    const visibleChunkLayouts = this.visibleChunkLayouts;
     const zAxis = this.viewportAxes[2];
 
-    let visibleLayers = this.visibleLayers;
+    const visibleLayers = this.visibleLayers;
     visibleChunkLayouts.clear();
-    for (let [renderLayer, visibleSources] of visibleLayers) {
+    for (const [renderLayer, visibleSources] of visibleLayers) {
       visibleSources.length = 0;
-      let transformedSources = getTransformedSources(renderLayer);
-      let numSources = transformedSources.length;
+      const transformedSources = getTransformedSources(renderLayer);
+      const numSources = transformedSources.length;
+      const {mipLevelConstraints} = renderLayer;
+      const { minScaleIndex, maxScaleIndex } = (mipLevelConstraints.numberLevels === undefined) ?
+        { minScaleIndex: 0, maxScaleIndex: numSources - 1 } : {
+          minScaleIndex: mipLevelConstraints.getDeFactoMinMIPLevel(),
+          maxScaleIndex: mipLevelConstraints.getDeFactoMaxMIPLevel()
+        };
       let scaleIndex: number;
 
       // At the smallest scale, all alternative sources must have the same voxel size, which is
       // considered to be the base voxel size.
-      let smallestVoxelSize = transformedSources[0][0].source.spec.voxelSize;
+      const smallestVoxelSize = transformedSources[0][0].source.spec.voxelSize;
 
       /**
        * Determines whether we should continue to look for a finer-resolution source *after* one
@@ -346,6 +356,8 @@ export class SliceViewBase extends SharedObject {
         return false;
       };
 
+      let highestResolutionIndex;
+
       /**
        * Registers a source as being visible.  This should be called with consecutively decreasing
        * values of scaleIndex.
@@ -360,17 +372,31 @@ export class SliceViewBase extends SharedObject {
           visibleChunkLayouts.set(chunkLayout, existingSources);
         }
         existingSources.set(source, sourceScaleIndex);
+        highestResolutionIndex = scaleIndex;
       };
 
-      scaleIndex = numSources - 1;
-      while (true) {
+      // Here we start iterating from numSources - 1, instead of from the user
+      // specified maxMIPRendered, just in case the maxMIPRendered resolution
+      // is wasteful. In this case we only retrieve the min MIP level that is not
+      // wasteful. Otherwise we retrieve all the useful/not wasteful levels between
+      // minMIPLevel and maxMIPLevel.
+      for (scaleIndex = numSources - 1; scaleIndex >= minScaleIndex; --scaleIndex) {
         const transformedSource = pickBestAlternativeSource(zAxis, transformedSources[scaleIndex]);
-        addVisibleSource(transformedSource, scaleIndex);
-        if (scaleIndex === 0 || !canImproveOnVoxelSize(transformedSource.source.spec.voxelSize)) {
+        if (scaleIndex <= maxScaleIndex) {
+          addVisibleSource(transformedSource, (scaleIndex + 1) / numSources);
+        }
+        if (!canImproveOnVoxelSize(transformedSource.source.spec.voxelSize)) {
+          if (scaleIndex > maxScaleIndex) {
+            addVisibleSource(transformedSource, (scaleIndex + 1) / numSources);
+          }
           break;
         }
-        --scaleIndex;
       }
+
+      if (renderLayer.activeMinMIPLevel) {
+        renderLayer.activeMinMIPLevel.value = highestResolutionIndex;
+      }
+
       // Reverse visibleSources list since we added sources from coarsest to finest resolution, but
       // we want them ordered from finest to coarsest.
       visibleSources.reverse();
@@ -422,9 +448,8 @@ export class SliceViewBase extends SharedObject {
       computeSourcesChunkBounds(
           sourcesLowerChunkBound, sourcesUpperChunkBound, visibleSources.keys());
       if (DEBUG_CHUNK_INTERSECTIONS) {
-        console.log(`Initial sources chunk bounds: ${
-                                                     vec3.str(sourcesLowerChunkBound)
-                                                   }, ${vec3.str(sourcesUpperChunkBound)}`);
+        console.log(`Initial sources chunk bounds: ${vec3.str(sourcesLowerChunkBound)}, ${
+            vec3.str(sourcesUpperChunkBound)}`);
       }
 
       vec3.set(
@@ -866,8 +891,7 @@ export abstract class SliceViewChunkSpecification {
       upperChunkBound,
     } = options;
     this.voxelSize = voxelSize;
-    this.chunkLayout =
-        ChunkLayout.get(chunkSize, transform);
+    this.chunkLayout = ChunkLayout.get(chunkSize, transform);
 
     this.lowerChunkBound = lowerChunkBound;
     this.upperChunkBound = upperChunkBound;
@@ -908,7 +932,9 @@ export interface SliceViewChunkSpecificationOptions extends SliceViewChunkSpecif
 }
 
 
-export interface SliceViewChunkSource { spec: SliceViewChunkSpecification; }
+export interface SliceViewChunkSource {
+  spec: SliceViewChunkSpecification;
+}
 
 export const SLICEVIEW_RPC_ID = 'SliceView';
 export const SLICEVIEW_RENDERLAYER_RPC_ID = 'sliceview/RenderLayer';
@@ -916,3 +942,5 @@ export const SLICEVIEW_ADD_VISIBLE_LAYER_RPC_ID = 'SliceView.addVisibleLayer';
 export const SLICEVIEW_REMOVE_VISIBLE_LAYER_RPC_ID = 'SliceView.removeVisibleLayer';
 export const SLICEVIEW_UPDATE_VIEW_RPC_ID = 'SliceView.updateView';
 export const SLICEVIEW_RENDERLAYER_UPDATE_TRANSFORM_RPC_ID = 'SliceView.updateTransform';
+export const SLICEVIEW_RENDERLAYER_UPDATE_MIP_LEVEL_CONSTRAINTS_RPC_ID =
+  'SliceView.updateMIPLevelConstraints';

--- a/src/neuroglancer/sliceview/frontend.ts
+++ b/src/neuroglancer/sliceview/frontend.ts
@@ -149,11 +149,13 @@ export class SliceView extends Base {
   private bindVisibleRenderLayer(renderLayer: RenderLayer) {
     renderLayer.redrawNeeded.add(this.viewChanged.dispatch);
     renderLayer.transform.changed.add(this.invalidateVisibleSources);
+    renderLayer.mipLevelConstraints.changed.add(this.invalidateVisibleSources);
   }
 
   private unbindVisibleRenderLayer(renderLayer: RenderLayer) {
     renderLayer.redrawNeeded.remove(this.viewChanged.dispatch);
     renderLayer.transform.changed.remove(this.invalidateVisibleSources);
+    renderLayer.mipLevelConstraints.changed.remove(this.invalidateVisibleSources);
   }
 
   private updateVisibleLayersNow() {

--- a/src/neuroglancer/sliceview/volume/segmentation_renderlayer.ts
+++ b/src/neuroglancer/sliceview/volume/segmentation_renderlayer.ts
@@ -24,6 +24,7 @@ import {VolumeSourceOptions} from 'neuroglancer/sliceview/volume/base';
 import {MultiscaleVolumeChunkSource} from 'neuroglancer/sliceview/volume/frontend';
 import {RenderLayer} from 'neuroglancer/sliceview/volume/renderlayer';
 import {TrackableAlphaValue} from 'neuroglancer/trackable_alpha';
+import {TrackableMIPLevelConstraints} from 'neuroglancer/trackable_mip_level_constraints';
 import {TrackableBoolean} from 'neuroglancer/trackable_boolean';
 import {DisjointUint64Sets} from 'neuroglancer/util/disjoint_sets';
 import {ShaderBuilder, ShaderProgram} from 'neuroglancer/webgl/shader';
@@ -50,6 +51,7 @@ export interface SliceViewSegmentationDisplayState extends SegmentationDisplaySt
   selectedAlpha: TrackableAlphaValue;
   notSelectedAlpha: TrackableAlphaValue;
   volumeSourceOptions?: VolumeSourceOptions;
+  mipLevelConstraints: TrackableMIPLevelConstraints;
   hideSegmentZero: TrackableBoolean;
   objectToDataTransform: CoordinateTransform;
 }
@@ -72,7 +74,8 @@ export class SegmentationRenderLayer extends RenderLayer {
       public displayState: SliceViewSegmentationDisplayState) {
     super(multiscaleSource, {
       sourceOptions: displayState.volumeSourceOptions,
-      transform: displayState.objectToDataTransform
+      transform: displayState.objectToDataTransform,
+      mipLevelConstraints: displayState.mipLevelConstraints
     });
     registerRedrawWhenSegmentationDisplayStateChanged(displayState, this);
     this.registerDisposer(displayState.selectedAlpha.changed.add(() => {

--- a/src/neuroglancer/trackable_mip_level_constraints.spec.ts
+++ b/src/neuroglancer/trackable_mip_level_constraints.spec.ts
@@ -1,0 +1,35 @@
+import {TrackableMIPLevelConstraints} from 'neuroglancer/trackable_mip_level_constraints';
+
+describe('mipLevelConstraints', () => {
+    it('invalid constraints throw an error', () => {
+        expect(() => new TrackableMIPLevelConstraints(3, 1)).toThrow(new Error('Specified minMIPLevel cannot be greater than specified maxMIPLevel'));
+        expect(() => new TrackableMIPLevelConstraints(1, 4, 3)).toThrow(new Error('Specified maxMIPLevel cannot be greater than the number of levels'));
+        expect(() => new TrackableMIPLevelConstraints(-1, 3)).toThrow(new Error('MIPLevels must be nonnegative'));
+        const trackableMIPLevelConstraints = new TrackableMIPLevelConstraints();
+        expect(() => trackableMIPLevelConstraints.restoreState(4, 0)).toThrow(new Error('Specified minMIPLevel cannot be greater than specified maxMIPLevel'));
+        expect(() => trackableMIPLevelConstraints.setNumberLevels(-1)).toThrow();
+        trackableMIPLevelConstraints.setNumberLevels(3);
+        expect(() => trackableMIPLevelConstraints.restoreState(0, 4)).toThrow(new Error('Specified maxMIPLevel cannot be greater than the number of levels'));
+        expect(() => trackableMIPLevelConstraints.restoreState(-1, 4)).toThrow(new Error('MIPLevels must be nonnegative'));
+        expect(() => trackableMIPLevelConstraints.setNumberLevels(4)).toThrow();
+    });
+    it('min/max may change if other is changed', () => {
+        const trackableMIPLevelConstraints = new TrackableMIPLevelConstraints(1, 5);
+        spyOn(trackableMIPLevelConstraints.minMIPLevel.changed, 'dispatch').and.callThrough();
+        spyOn(trackableMIPLevelConstraints.maxMIPLevel.changed, 'dispatch').and.callThrough();
+        spyOn(trackableMIPLevelConstraints.changed, 'dispatch').and.callThrough();
+        trackableMIPLevelConstraints.maxMIPLevel.value = 3;
+        expect(trackableMIPLevelConstraints.minMIPLevel.value).toBe(1);
+        expect(trackableMIPLevelConstraints.changed.dispatch).toHaveBeenCalledTimes(1);
+        trackableMIPLevelConstraints.maxMIPLevel.value = 0;
+        expect(trackableMIPLevelConstraints.minMIPLevel.value).toBe(0);
+        expect(trackableMIPLevelConstraints.changed.dispatch).toHaveBeenCalledTimes(2);
+        trackableMIPLevelConstraints.minMIPLevel.value = 4;
+        expect(trackableMIPLevelConstraints.maxMIPLevel.value).toBe(4);
+        expect(trackableMIPLevelConstraints.changed.dispatch).toHaveBeenCalledTimes(3);
+        trackableMIPLevelConstraints.restoreState(1, 2);
+        expect(trackableMIPLevelConstraints.changed.dispatch).toHaveBeenCalledTimes(4);
+        expect(trackableMIPLevelConstraints.minMIPLevel.changed.dispatch).toHaveBeenCalledTimes(3);
+        expect(trackableMIPLevelConstraints.maxMIPLevel.changed.dispatch).toHaveBeenCalledTimes(4);
+    });
+});

--- a/src/neuroglancer/trackable_mip_level_constraints.ts
+++ b/src/neuroglancer/trackable_mip_level_constraints.ts
@@ -1,0 +1,121 @@
+import {TrackableValue} from 'neuroglancer/trackable_value';
+import {RefCounted} from 'neuroglancer/util/disposable';
+import {verifyNonnegativeInt, verifyOptionalNonnegativeInt} from 'neuroglancer/util/json';
+import {NullarySignal} from 'neuroglancer/util/signal';
+
+export type TrackableMIPLevel = TrackableValue<number|undefined>;
+
+export class TrackableMIPLevelConstraints extends RefCounted {
+  minMIPLevel: TrackableMIPLevel;
+  maxMIPLevel: TrackableMIPLevel;
+  changed = new NullarySignal();
+  private _numberLevels: number|undefined;
+  private dispatchEnabled = true;
+
+  constructor(
+      initialMinMIPLevel: number|undefined = undefined,
+      initialMaxMIPLevel: number|undefined = undefined,
+      numberLevels: number|undefined = undefined) {
+    super();
+    this.setNumberLevels(numberLevels);
+    this.verifyValidConstraints(initialMinMIPLevel, initialMaxMIPLevel);
+    this.minMIPLevel = new TrackableValue(initialMinMIPLevel, verifyOptionalNonnegativeInt);
+    this.maxMIPLevel = new TrackableValue(initialMaxMIPLevel, verifyOptionalNonnegativeInt);
+    this.registerDisposer(this.minMIPLevel.changed.add(() => {
+      this.handleMIPLevelChanged(true);
+    }));
+    this.registerDisposer(this.maxMIPLevel.changed.add(() => {
+      this.handleMIPLevelChanged(false);
+    }));
+  }
+
+  public restoreState(
+      newMinMIPLevel: number|undefined = undefined, newMaxMIPLevel: number|undefined = undefined, fireDispatch: boolean = true) {
+    if (this.minMIPLevel.value !== newMinMIPLevel || this.maxMIPLevel.value !== newMaxMIPLevel) {
+      this.verifyValidConstraints(newMinMIPLevel, newMaxMIPLevel);
+      // Turn off default behavior to always fire this.changed.dispatch exactly once
+      this.dispatchEnabled = false;
+      this.minMIPLevel.restoreState(newMinMIPLevel);
+      this.maxMIPLevel.restoreState(newMaxMIPLevel);
+      this.dispatchEnabled = true;
+      if (fireDispatch) {
+        this.changed.dispatch();
+      }
+    }
+  }
+
+  private handleMIPLevelChanged(minLevelWasChanged: boolean) {
+    if (this.dispatchEnabled) {
+      // If maybeAdjustConstraints returns true, then the other constraint
+      // will be changed, and handleMIPLevelChanged will fire again.
+      // Either way, this.changed.dispatch will fire exactly once.
+      if (!this.maybeAdjustConstraints(minLevelWasChanged)) {
+        this.verifyValidConstraints(this.minMIPLevel.value, this.maxMIPLevel.value);
+        this.changed.dispatch();
+      }
+    }
+  }
+
+  get numberLevels() {
+    return this._numberLevels;
+  }
+
+  // De facto min MIP level is 0 if not specified
+  public getDeFactoMinMIPLevel =
+      () => {
+        const {minMIPLevel: {value}, _numberLevels} = this;
+        verifyNonnegativeInt(_numberLevels);
+        return (value !== undefined) ? value : 0;
+      }
+
+  // De facto max MIP level is numberLevels - 1 if not specified
+  public getDeFactoMaxMIPLevel =
+      () => {
+        const {maxMIPLevel: {value}, _numberLevels} = this;
+        verifyNonnegativeInt(_numberLevels);
+        return (value !== undefined) ? value : _numberLevels! - 1;
+      }
+
+  // Only set the number of levels once either in constructor or after the renderLayer has been
+  // initialized and sources have been retrieved.
+  public setNumberLevels(numberLevels: number|undefined) {
+    if (this.numberLevels !== undefined) {
+      throw new Error('Cannot set number of MIP Levels more than once.');
+    }
+    verifyOptionalNonnegativeInt(numberLevels);
+    this._numberLevels = numberLevels;
+  }
+
+  private verifyValidConstraints(
+      minMIPLevelValue: number|undefined, maxMIPLevelValue: number|undefined) {
+    if (minMIPLevelValue !== undefined && maxMIPLevelValue !== undefined) {
+      // Should never happen
+      if (minMIPLevelValue < 0) {
+        throw new Error('MIPLevels must be nonnegative');
+      }
+      if (minMIPLevelValue > maxMIPLevelValue) {
+        throw new Error('Specified minMIPLevel cannot be greater than specified maxMIPLevel');
+      }
+      if (this.numberLevels !== undefined && maxMIPLevelValue > this.numberLevels) {
+        throw new Error('Specified maxMIPLevel cannot be greater than the number of levels');
+      }
+    }
+  }
+
+  // Ensure that minMIPLevel<= maxMIPLevelwhen one is adjusted by widget. Return
+  // true/false to tell handleMIPLevelChange to kick off changed dispatch exactly once when levels
+  // are adjusted.
+  private maybeAdjustConstraints(minLevelWasChanged: boolean): boolean {
+    if (this.minMIPLevel.value !== undefined && this.maxMIPLevel.value !== undefined &&
+        this.minMIPLevel.value > this.maxMIPLevel.value) {
+      // Invalid levels so adjust
+      if (minLevelWasChanged) {
+        this.maxMIPLevel.value = this.minMIPLevel.value;
+      } else {
+        this.minMIPLevel.value = this.maxMIPLevel.value;
+      }
+      return true;
+    }
+    return false;
+  }
+}

--- a/src/neuroglancer/util/json.ts
+++ b/src/neuroglancer/util/json.ts
@@ -388,9 +388,17 @@ export function verifyInt(obj: any) {
 }
 
 export function verifyPositiveInt(obj: any) {
-  let result = verifyInt(obj);
+  const result = verifyInt(obj);
   if (result <= 0) {
     throw new Error(`Expected positive integer, but received: ${result}.`);
+  }
+  return result;
+}
+
+export function verifyNonnegativeInt(obj: any) {
+  const result = verifyInt(obj);
+  if (result < 0) {
+    throw new Error(`Expected non-negative integer, but received: ${result}.`);
   }
   return result;
 }
@@ -424,6 +432,20 @@ export function verifyOptionalInt(obj: any): number|undefined {
     return undefined;
   }
   return verifyInt(obj);
+}
+
+export function verifyOptionalNonnegativeInt(obj: any): number|undefined {
+  if (obj === undefined) {
+    return undefined;
+  }
+  return verifyNonnegativeInt(obj);
+}
+
+export function verifyOptionalPositiveInt(obj: any): number|undefined {
+  if (obj === undefined) {
+    return undefined;
+  }
+  return verifyPositiveInt(obj);
 }
 
 export function verifyOptionalBoolean(obj: any): boolean|undefined {

--- a/src/neuroglancer/widget/voxel_size_selection_widget.css
+++ b/src/neuroglancer/widget/voxel_size_selection_widget.css
@@ -1,0 +1,33 @@
+.voxel-size-selection {
+    margin-bottom: 0.15em;
+}
+
+.voxel-selection-dropdown {
+    height: 1.3em;
+    font-size: 12px;
+}
+
+#minVoxelSizeLabel {
+    margin-right: 3px;
+}
+
+#activeLevelsTextbox {
+    font-size: 11px;
+    width: 70%;
+    height: 10%;
+    resize: none;
+}
+
+#activeLevelsHeader {
+    margin-top: 14px;
+    margin-bottom: 4px;
+}
+
+#voxelLimitsHeader {
+    margin-top: 5px;
+    margin-bottom: 3px;
+}
+
+.voxel-size-label {
+    vertical-align: bottom;
+}

--- a/src/neuroglancer/widget/voxel_size_selection_widget.ts
+++ b/src/neuroglancer/widget/voxel_size_selection_widget.ts
@@ -1,0 +1,165 @@
+import './voxel_size_selection_widget.css';
+
+import {TrackableMIPLevelConstraints} from 'neuroglancer/trackable_mip_level_constraints';
+import {TrackableValue} from 'neuroglancer/trackable_value';
+import {RefCounted} from 'neuroglancer/util/disposable';
+import {removeFromParent} from 'neuroglancer/util/dom';
+import {vec3} from 'neuroglancer/util/geom';
+import {verifyInt} from 'neuroglancer/util/json';
+import {StatusMessage} from 'neuroglancer/status';
+
+export class VoxelSizeSelectionWidget extends RefCounted {
+  element = document.createElement('div');
+  private minVoxelSizeElement = document.createElement('div');
+  private maxVoxelSizeElement = document.createElement('div');
+  private activeLevelsTextbox = document.createElement('textarea');
+  private waitingToSetup = true;
+  private voxelDropdownOptions: string[] = [];
+  private activeMinMIPLevel?: TrackableValue<number|undefined>;
+
+  constructor(private mipLevelConstraints: TrackableMIPLevelConstraints) {
+    super();
+    const header = document.createElement('div');
+    header.textContent = 'Voxel size limits (nm) desired';
+    header.id = 'voxelLimitsHeader';
+    this.element.appendChild(header);
+  }
+
+  public setup(voxelSizePerMIPLevel: vec3[], activeMinMIPLevel: TrackableValue<number|undefined>) {
+    if (this.waitingToSetup) {
+      this.waitingToSetup = false;
+      this.activeMinMIPLevel = activeMinMIPLevel;
+
+      const createVoxelDropdownOptions = () => {
+        voxelSizePerMIPLevel.forEach(voxelSize => {
+          let i: number;
+          let voxelString = '';
+          for (i = 0; i < 3; i++) {
+            if (i > 0) {
+              voxelString += ' x ';
+            }
+            voxelString += voxelSize[i];
+          }
+          this.voxelDropdownOptions.push(voxelString);
+        });
+      };
+
+      createVoxelDropdownOptions();
+      this.setupUIElements();
+      this.registerDisposer(activeMinMIPLevel.changed.add(this.updateActiveMinMIPLevelTextbox));
+      this.registerDisposer(this.mipLevelConstraints.changed.add(this.updateActiveMinMIPLevelTextbox));
+    } else {
+      throw new Error('Attempt to setup voxel widget more than once');
+    }
+  }
+
+  private setupUIElements() {
+    const {
+      element,
+      minVoxelSizeElement,
+      maxVoxelSizeElement,
+      createVoxelSizeDropdown,
+      mipLevelConstraints,
+      activeLevelsTextbox,
+      mipLevelConstraints: {minMIPLevel, maxMIPLevel}
+    } = this;
+    element.className = 'minmax-voxel-size-selection';
+    minVoxelSizeElement.className = 'voxel-size-selection';
+    maxVoxelSizeElement.className = 'voxel-size-selection';
+    const minVoxelSizeDropdown = createVoxelSizeDropdown(true);
+    const maxVoxelSizeDropdown = createVoxelSizeDropdown(false);
+    const minVoxelSizeLabel = document.createElement('span');
+    minVoxelSizeLabel.textContent = 'Min voxel size: ';
+    minVoxelSizeLabel.className = 'voxel-size-label';
+    minVoxelSizeLabel.id = 'minVoxelSizeLabel';
+    const maxVoxelSizeLabel = document.createElement('span');
+    maxVoxelSizeLabel.textContent = 'Max voxel size: ';
+    maxVoxelSizeLabel.className = 'voxel-size-label';
+    minVoxelSizeElement.appendChild(minVoxelSizeLabel);
+    minVoxelSizeElement.appendChild(minVoxelSizeDropdown);
+    maxVoxelSizeElement.appendChild(maxVoxelSizeLabel);
+    maxVoxelSizeElement.appendChild(maxVoxelSizeDropdown);
+    element.appendChild(minVoxelSizeElement);
+    element.appendChild(maxVoxelSizeElement);
+    const activeLevelsHeader = document.createElement('div');
+    activeLevelsHeader.textContent = 'Voxel sizes loaded (nm)';
+    activeLevelsHeader.id = 'activeLevelsHeader';
+    const activeLevelsTextboxElement = document.createElement('div');
+    element.appendChild(activeLevelsHeader);
+    activeLevelsTextbox.readOnly = true;
+    activeLevelsTextbox.id = 'activeLevelsTextbox';
+    activeLevelsTextboxElement.appendChild(activeLevelsTextbox);
+    element.appendChild(activeLevelsTextboxElement);
+    this.registerDisposer(minMIPLevel.changed.add(() => {
+      VoxelSizeSelectionWidget.setDropdownIndex(
+          minVoxelSizeDropdown, mipLevelConstraints.getDeFactoMinMIPLevel());
+    }));
+    this.registerDisposer(maxMIPLevel.changed.add(() => {
+      VoxelSizeSelectionWidget.setDropdownIndex(
+          maxVoxelSizeDropdown, mipLevelConstraints.getDeFactoMaxMIPLevel());
+    }));
+  }
+
+  private createVoxelSizeDropdown = (isMinLevelDropdown: boolean):
+      HTMLSelectElement => {
+        const {voxelDropdownOptions, mipLevelConstraints} = this;
+        const getMIPValue = (isMinLevelDropdown) ? mipLevelConstraints.getDeFactoMinMIPLevel :
+                                                   mipLevelConstraints.getDeFactoMaxMIPLevel;
+        const mipLevel = (isMinLevelDropdown) ? mipLevelConstraints.minMIPLevel :
+                                                mipLevelConstraints.maxMIPLevel;
+        const voxelSizeDropdown = document.createElement('select');
+        voxelSizeDropdown.className = 'voxel-selection-dropdown';
+        voxelDropdownOptions.forEach((voxelSizeString, index) => {
+          if (index === getMIPValue()) {
+            voxelSizeDropdown.add(new Option(voxelSizeString, index.toString(), false, true));
+          } else {
+            voxelSizeDropdown.add(new Option(voxelSizeString, index.toString(), false, false));
+          }
+        });
+        voxelSizeDropdown.addEventListener('change', () => {
+          if (getMIPValue() !== voxelSizeDropdown.selectedIndex) {
+            mipLevel.value = voxelSizeDropdown.selectedIndex;
+          }
+        });
+        return voxelSizeDropdown;
+      }
+
+  private static setDropdownIndex(dropdown: HTMLSelectElement, newIndex: number) {
+    if (dropdown.selectedIndex !== newIndex) {
+      dropdown.selectedIndex = newIndex;
+    }
+  }
+
+  private static getActiveLevelsTextboxText(
+      minLevelLoaded: number, maxLevelLoaded: number, voxelDropdownOptions: string[]) {
+    const minString = `Min voxel size: ${voxelDropdownOptions[minLevelLoaded]}`;
+    const maxString = `Max voxel size: ${voxelDropdownOptions[maxLevelLoaded]}`;
+    return minString + '\n' + maxString;
+  }
+
+  private updateActiveMinMIPLevelTextbox =
+      () => {
+        const {activeMinMIPLevel, mipLevelConstraints, voxelDropdownOptions} = this;
+        if (activeMinMIPLevel === undefined) {
+          throw new Error('Attempt to update active mip level textbox before voxel widget setup');
+        }
+        verifyInt(activeMinMIPLevel.value);
+        const maxMIPLevelValue = mipLevelConstraints.getDeFactoMaxMIPLevel();
+        if (maxMIPLevelValue < activeMinMIPLevel.value!) {
+          this.activeLevelsTextbox.value = VoxelSizeSelectionWidget.getActiveLevelsTextboxText(
+              activeMinMIPLevel.value!, activeMinMIPLevel.value!, voxelDropdownOptions);
+          StatusMessage.showTemporaryMessage(
+              `Desired voxel limits not visible, showing highest visible resolution, which is ${
+                  voxelDropdownOptions[activeMinMIPLevel.value!]}`,
+              9000);
+        } else {
+          this.activeLevelsTextbox.value = VoxelSizeSelectionWidget.getActiveLevelsTextboxText(
+              activeMinMIPLevel.value!, maxMIPLevelValue, voxelDropdownOptions);
+        }
+      }
+
+  disposed() {
+    removeFromParent(this.element);
+    super.disposed();
+  }
+}


### PR DESCRIPTION
This PR adds two dropdown menus into the Rendering tab for a selected image/segmentation layer; these dropdowns allow to user to limit the data that will be downloaded and displayed for the selected layer by specifying a min and a max voxel size/MIP level.