### PR TITLE
fix(python): Constrain tornado<6 due to sockjs-tornado incompatibility

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -117,7 +117,7 @@ setup(
         "Pillow>=3.2.0",
         "numpy>=1.11.0",
         'requests',
-        'tornado',
+        'tornado<6',
         'sockjs-tornado',
         'six',
         'google-apitools',


### PR DESCRIPTION
This works around issue #125.