### PR TITLE
modify single annotation instead of recreating the entire list

### DIFF
--- a/src/neuroglancer/annotation/frontend_source.ts
+++ b/src/neuroglancer/annotation/frontend_source.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {Annotation, AnnotationId, AnnotationReference, AnnotationType, annotationTypes, deserializeAnnotation, getAnnotationTypeHandler, makeAnnotationId} from 'neuroglancer/annotation';
+import {Annotation, AnnotationId, AnnotationReference, AnnotationType, annotationTypes, deserializeAnnotation, getAnnotationTypeHandler, makeAnnotationId, AnnotationSourceSignals} from 'neuroglancer/annotation';
 import {ANNOTATION_COMMIT_UPDATE_RESULT_RPC_ID, ANNOTATION_COMMIT_UPDATE_RPC_ID, ANNOTATION_GEOMETRY_CHUNK_SOURCE_RPC_ID, ANNOTATION_METADATA_CHUNK_SOURCE_RPC_ID, ANNOTATION_REFERENCE_ADD_RPC_ID, ANNOTATION_REFERENCE_DELETE_RPC_ID, ANNOTATION_SUBSET_GEOMETRY_CHUNK_SOURCE_RPC_ID, AnnotationGeometryChunkSpecification} from 'neuroglancer/annotation/base';
 import {getAnnotationTypeRenderHandler} from 'neuroglancer/annotation/type_handler';
 import {Chunk, ChunkManager, ChunkSource} from 'neuroglancer/chunk_manager/frontend';
@@ -26,7 +26,7 @@ import {StatusMessage} from 'neuroglancer/status';
 import {binarySearch} from 'neuroglancer/util/array';
 import {Borrowed, Owned} from 'neuroglancer/util/disposable';
 import {mat4} from 'neuroglancer/util/geom';
-import {NullarySignal} from 'neuroglancer/util/signal';
+import {Signal, NullarySignal} from 'neuroglancer/util/signal';
 import {Buffer} from 'neuroglancer/webgl/buffer';
 import {GL} from 'neuroglancer/webgl/context';
 import {registerRPC, registerSharedObjectOwner, RPC, SharedObject} from 'neuroglancer/worker_rpc';
@@ -292,7 +292,7 @@ function makeTemporaryChunk() {
 }
 
 export class MultiscaleAnnotationSource extends SharedObject implements
-    MultiscaleSliceViewChunkSource {
+    MultiscaleSliceViewChunkSource, AnnotationSourceSignals {
   metadataChunkSource =
       this.registerDisposer(new AnnotationMetadataChunkSource(this.chunkManager, this));
   sources: Owned<AnnotationGeometryChunkSource>[][];
@@ -593,6 +593,9 @@ export class MultiscaleAnnotationSource extends SharedObject implements
   changed = new NullarySignal();
   * [Symbol.iterator](): Iterator<Annotation> {}
   readonly = false;
+  childAdded: Signal<(annotation: Annotation) => void>;
+  childUpdated: Signal<(annotation: Annotation) => void>;
+  childDeleted: Signal<(annotationId: string) => void>;
 }
 
 registerRPC(ANNOTATION_COMMIT_UPDATE_RESULT_RPC_ID, function(x) {


### PR DESCRIPTION
Currently all the annotations are removed from the DOM and recreated everytime there is an add/update/delete on a single annotation. This affects performance as the list grows.
This PR aims to avoid that by targeting specific annotations when the list is modified.
There maybe better way to solve this but I think this solution avoids any changes to the core framework.

  * Create separate functions and signals for add/update/delete annotation and trigger signals accordingly
  * Create interface for common signals between AnnotationSource and MultiscaleAnnotationSource