### PR TITLE
Annotation shortcuts for tagging annotations + other annotation utilities

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1131,7 +1131,7 @@
     },
     "browserify-rsa": {
       "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
+      "resolved": "http://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
       "integrity": "sha1-IeCr+vbyApzy+vsTNWenAdQTVSQ=",
       "requires": {
         "bn.js": "^4.1.0",
@@ -1162,7 +1162,7 @@
     },
     "buffer": {
       "version": "4.9.1",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
+      "resolved": "http://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
       "integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
       "requires": {
         "base64-js": "^1.0.2",
@@ -1341,7 +1341,7 @@
     },
     "camelcase-keys": {
       "version": "2.1.0",
-      "resolved": "http://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
       "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
       "dev": true,
       "requires": {
@@ -1970,7 +1970,7 @@
     },
     "css-select": {
       "version": "1.2.0",
-      "resolved": "http://registry.npmjs.org/css-select/-/css-select-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/css-select/-/css-select-1.2.0.tgz",
       "integrity": "sha1-KzoRBTnFNV8c2NMUYj6HCxIeyFg=",
       "requires": {
         "boolbase": "~1.0.0",
@@ -2011,7 +2011,7 @@
     },
     "d": {
       "version": "1.0.0",
-      "resolved": "http://registry.npmjs.org/d/-/d-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
       "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
       "dev": true,
       "requires": {
@@ -2370,7 +2370,7 @@
     },
     "duplexer": {
       "version": "0.1.1",
-      "resolved": "http://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
       "integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E=",
       "dev": true
     },
@@ -2755,7 +2755,7 @@
     },
     "events": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
+      "resolved": "http://registry.npmjs.org/events/-/events-1.1.1.tgz",
       "integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ="
     },
     "eventsource": {
@@ -4018,7 +4018,7 @@
       "dependencies": {
         "codemirror": {
           "version": "4.13.0",
-          "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-4.13.0.tgz",
+          "resolved": "http://registry.npmjs.org/codemirror/-/codemirror-4.13.0.tgz",
           "integrity": "sha1-IJdy04p7uZZHw3tQDbEhEQ3Zr28="
         }
       }
@@ -4231,7 +4231,7 @@
     },
     "gulp-diff": {
       "version": "1.0.0",
-      "resolved": "http://registry.npmjs.org/gulp-diff/-/gulp-diff-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/gulp-diff/-/gulp-diff-1.0.0.tgz",
       "integrity": "sha1-EBsjcS3WsQe9B9BauI6jrEhf7Xc=",
       "dev": true,
       "requires": {
@@ -4613,7 +4613,7 @@
     },
     "html-webpack-plugin": {
       "version": "3.2.0",
-      "resolved": "http://registry.npmjs.org/html-webpack-plugin/-/html-webpack-plugin-3.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/html-webpack-plugin/-/html-webpack-plugin-3.2.0.tgz",
       "integrity": "sha1-sBq71yOsqqeze2r0SS69oD2d03s=",
       "requires": {
         "html-minifier": "^3.2.3",
@@ -5379,7 +5379,7 @@
     "karma-chrome-launcher": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/karma-chrome-launcher/-/karma-chrome-launcher-2.2.0.tgz",
-      "integrity": "sha1-zxudBxNswY/iOTJ9JGVMPbw2is8=",
+      "integrity": "sha512-uf/ZVpAabDBPvdPdveyk1EPgbnloPvFFGgmRhYLTDH7gEB4nZdSBk8yTU47w1g/drLSx5uMOkjKk7IWKfWg/+w==",
       "dev": true,
       "requires": {
         "fs-access": "^1.0.0",
@@ -5595,7 +5595,7 @@
     },
     "load-json-file": {
       "version": "1.1.0",
-      "resolved": "http://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
       "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
       "dev": true,
       "requires": {
@@ -6006,7 +6006,7 @@
     },
     "media-typer": {
       "version": "0.3.0",
-      "resolved": "http://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
       "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=",
       "dev": true
     },
@@ -6048,7 +6048,7 @@
     },
     "meow": {
       "version": "3.7.0",
-      "resolved": "http://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
+      "resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
       "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
       "dev": true,
       "requires": {
@@ -6201,7 +6201,7 @@
     },
     "minimist": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+      "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
       "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
     },
     "mississippi": {
@@ -6289,7 +6289,7 @@
     },
     "mkdirp": {
       "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
       "requires": {
         "minimist": "0.0.8"
@@ -6297,7 +6297,7 @@
       "dependencies": {
         "minimist": {
           "version": "0.0.8",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+          "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
           "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
         }
       }
@@ -6395,7 +6395,7 @@
     },
     "next-tick": {
       "version": "1.0.0",
-      "resolved": "http://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
       "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw=",
       "dev": true
     },
@@ -6808,7 +6808,7 @@
     },
     "os-locale": {
       "version": "1.4.0",
-      "resolved": "http://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
       "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
       "dev": true,
       "requires": {
@@ -7041,7 +7041,7 @@
     },
     "pause-stream": {
       "version": "0.0.11",
-      "resolved": "http://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz",
+      "resolved": "https://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz",
       "integrity": "sha1-/lo0sMvOErWqaitAPuLnO2AvFEU=",
       "dev": true,
       "requires": {
@@ -7240,7 +7240,7 @@
     },
     "pretty-hrtime": {
       "version": "1.0.3",
-      "resolved": "http://registry.npmjs.org/pretty-hrtime/-/pretty-hrtime-1.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/pretty-hrtime/-/pretty-hrtime-1.0.3.tgz",
       "integrity": "sha1-t+PqQkNaTJsnWdmeDyAesZWALuE=",
       "dev": true
     },
@@ -7870,7 +7870,7 @@
     },
     "safe-regex": {
       "version": "1.1.0",
-      "resolved": "http://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
       "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
       "requires": {
         "ret": "~0.1.10"
@@ -8773,7 +8773,7 @@
     },
     "strip-ansi": {
       "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
       "requires": {
         "ansi-regex": "^2.0.0"
@@ -9010,7 +9010,7 @@
         },
         "readable-stream": {
           "version": "1.0.34",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
           "requires": {
             "core-util-is": "~1.0.0",
@@ -10092,7 +10092,7 @@
     },
     "webpack-dev-middleware": {
       "version": "2.0.6",
-      "resolved": "http://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-2.0.6.tgz",
+      "resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-2.0.6.tgz",
       "integrity": "sha512-tj5LLD9r4tDuRIDa5Mu9lnY2qBBehAITv6A9irqXhw/HQquZgTx3BCd57zYbU2gMDnncA49ufK2qVQSbaKJwOw==",
       "dev": true,
       "requires": {

--- a/src/neuroglancer/annotation/annotation_layer_state.ts
+++ b/src/neuroglancer/annotation/annotation_layer_state.ts
@@ -21,10 +21,11 @@ import {RenderLayerRole} from 'neuroglancer/layer';
 import {SegmentationDisplayState} from 'neuroglancer/segmentation_display_state/frontend';
 import {TrackableAlphaValue} from 'neuroglancer/trackable_alpha';
 import {TrackableBoolean} from 'neuroglancer/trackable_boolean';
-import {WatchableValue} from 'neuroglancer/trackable_value';
+import {WatchableValue, TrackableValue} from 'neuroglancer/trackable_value';
 import {TrackableRGB} from 'neuroglancer/util/color';
 import {Owned, RefCounted} from 'neuroglancer/util/disposable';
 import {mat4} from 'neuroglancer/util/geom';
+import {verifyNonnegativeInt} from 'neuroglancer/util/json';
 
 export class AnnotationHoverState extends
     WatchableValue<{id: string, partIndex: number}|undefined> {}
@@ -42,6 +43,8 @@ export class AnnotationLayerState extends RefCounted {
    */
   segmentationState: WatchableValue<SegmentationDisplayState|undefined|null>;
   filterBySegmentation: TrackableBoolean;
+  annotationJumpingDisplaysSegmentation = new TrackableBoolean(false);
+  selectedAnnotationTagId = new TrackableValue<number>(0, verifyNonnegativeInt, 0);
 
   private transformCacheGeneration = -1;
   private cachedObjectToGlobal = mat4.create();

--- a/src/neuroglancer/annotation/frontend_source.ts
+++ b/src/neuroglancer/annotation/frontend_source.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {Annotation, AnnotationId, AnnotationReference, AnnotationType, annotationTypes, deserializeAnnotation, getAnnotationTypeHandler, makeAnnotationId, AnnotationSourceSignals} from 'neuroglancer/annotation';
+import {Annotation, AnnotationId, AnnotationReference, AnnotationTag, AnnotationType, annotationTypes, deserializeAnnotation, getAnnotationTypeHandler, makeAnnotationId, AnnotationSourceSignals} from 'neuroglancer/annotation';
 import {ANNOTATION_COMMIT_UPDATE_RESULT_RPC_ID, ANNOTATION_COMMIT_UPDATE_RPC_ID, ANNOTATION_GEOMETRY_CHUNK_SOURCE_RPC_ID, ANNOTATION_METADATA_CHUNK_SOURCE_RPC_ID, ANNOTATION_REFERENCE_ADD_RPC_ID, ANNOTATION_REFERENCE_DELETE_RPC_ID, ANNOTATION_SUBSET_GEOMETRY_CHUNK_SOURCE_RPC_ID, AnnotationGeometryChunkSpecification} from 'neuroglancer/annotation/base';
 import {getAnnotationTypeRenderHandler} from 'neuroglancer/annotation/type_handler';
 import {Chunk, ChunkManager, ChunkSource} from 'neuroglancer/chunk_manager/frontend';
@@ -592,10 +592,19 @@ export class MultiscaleAnnotationSource extends SharedObject implements
   // FIXME
   changed = new NullarySignal();
   * [Symbol.iterator](): Iterator<Annotation> {}
+  getTags() {
+    return Array<AnnotationTag>();
+  }
+  isAnnotationTaggedWithTag() {
+    return true;
+  }
   readonly = false;
   childAdded: Signal<(annotation: Annotation) => void>;
   childUpdated: Signal<(annotation: Annotation) => void>;
   childDeleted: Signal<(annotationId: string) => void>;
+  tagAdded:Signal<(tag: AnnotationTag) => void>;
+  tagUpdated:Signal<(tag: AnnotationTag) => void>;
+  tagDeleted:Signal<(tagId: number) => void>;
 }
 
 registerRPC(ANNOTATION_COMMIT_UPDATE_RESULT_RPC_ID, function(x) {

--- a/src/neuroglancer/annotation/user_layer.css
+++ b/src/neuroglancer/annotation/user_layer.css
@@ -17,3 +17,25 @@
 .neuroglancer-annotation-point-list-dropdown {
   display: flex;
 }
+
+.display-annotation-shortcut-textbox {
+  margin-right: 7%;
+  font-family: monospace;
+}
+
+.neuroglancer-annotation-shortcut {
+  margin-top: 3px;
+}
+
+.annotation-tag-input {
+  margin-right: 3%;
+}
+
+.annotation-key-shortcut-header {
+  margin-right: 15%;
+}
+
+.annotation-shorcut-list-header {
+  margin-top: 3px;
+  margin-bottom: 5px;
+}

--- a/src/neuroglancer/annotation/user_layer.ts
+++ b/src/neuroglancer/annotation/user_layer.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {AnnotationType, LocalAnnotationSource} from 'neuroglancer/annotation';
+import {Annotation, AnnotationId, AnnotationType, LocalAnnotationSource} from 'neuroglancer/annotation';
 import {AnnotationLayerState} from 'neuroglancer/annotation/frontend';
 import {CoordinateTransform, makeDerivedCoordinateTransform} from 'neuroglancer/coordinate_transform';
 import {LayerReference, ManagedUserLayer, UserLayer} from 'neuroglancer/layer';
@@ -27,14 +27,19 @@ import {ElementVisibilityFromTrackableBoolean, TrackableBoolean, TrackableBoolea
 import {makeDerivedWatchableValue, WatchableValue} from 'neuroglancer/trackable_value';
 import {AnnotationLayerView, getAnnotationRenderOptions, UserLayerWithAnnotationsMixin} from 'neuroglancer/ui/annotations';
 import {UserLayerWithCoordinateTransformMixin} from 'neuroglancer/user_layer_with_coordinate_transform';
+import {Borrowed, RefCounted, registerEventListener} from 'neuroglancer/util/disposable';
+import {EventActionMap, registerActionListener} from 'neuroglancer/util/event_action_map';
 import {mat4, vec3} from 'neuroglancer/util/geom';
 import {parseArray, verify3dVec} from 'neuroglancer/util/json';
+import {KeyboardEventBinder} from 'neuroglancer/util/keyboard_bindings';
 import {LayerReferenceWidget} from 'neuroglancer/widget/layer_reference';
+import {Tab} from 'neuroglancer/widget/tab_view';
 
 require('./user_layer.css');
 
 const POINTS_JSON_KEY = 'points';
 const ANNOTATIONS_JSON_KEY = 'annotations';
+const ANNOTATION_TAGS_JSON_KEY = 'annotationTags';
 
 function addPointAnnotations(annotations: LocalAnnotationSource, obj: any) {
   if (obj === undefined) {
@@ -75,6 +80,18 @@ function getSegmentationDisplayState(layer: ManagedUserLayer|undefined): Segment
   return userLayer.displayState;
 }
 
+function getPointFromAnnotation(annotation: Annotation) {
+  switch (annotation.type) {
+    case AnnotationType.AXIS_ALIGNED_BOUNDING_BOX:
+    case AnnotationType.LINE:
+      return annotation.pointA;
+    case AnnotationType.POINT:
+      return annotation.point;
+    case AnnotationType.ELLIPSOID:
+      return annotation.center;
+  }
+}
+
 const VOXEL_SIZE_JSON_KEY = 'voxelSize';
 const SOURCE_JSON_KEY = 'source';
 const LINKED_SEGMENTATION_LAYER_JSON_KEY = 'linkedSegmentationLayer';
@@ -87,6 +104,11 @@ export class AnnotationUserLayer extends Base {
   linkedSegmentationLayer = this.registerDisposer(
       new LayerReference(this.manager.rootLayers.addRef(), isValidLinkedSegmentationLayer));
   filterBySegmentation = new TrackableBoolean(false);
+  shortcutHandler = this.registerDisposer(new AnnotationShortcutHandler());
+  private keyShortcutModifier = 'shift+';
+  private keyShortcuts = ['q', 'w', 'e', 'r', 't', 'a', 's', 'd', 'f', 'g', 'z', 'x', 'c', 'v'];
+  private tagToShortcut: Map<number, string> = new Map<number, string>();
+  private _numTagsAllowed = this.keyShortcuts.length;
 
   getAnnotationRenderOptions() {
     const segmentationState =
@@ -117,7 +139,8 @@ export class AnnotationUserLayer extends Base {
     if (sourceUrl === undefined) {
       this.isReady = true;
       this.voxelSize.restoreState(specification[VOXEL_SIZE_JSON_KEY]);
-      this.localAnnotations.restoreState(specification[ANNOTATIONS_JSON_KEY]);
+      this.localAnnotations.restoreState(
+          specification[ANNOTATIONS_JSON_KEY], specification[ANNOTATION_TAGS_JSON_KEY]);
       // Handle legacy "points" property.
       addPointAnnotations(this.localAnnotations, specification[POINTS_JSON_KEY]);
       let voxelSizeValid = false;
@@ -148,6 +171,15 @@ export class AnnotationUserLayer extends Base {
       this.registerDisposer(this.voxelSize.changed.add(handleVoxelSizeChanged));
       this.registerDisposer(this.manager.voxelSize.changed.add(handleVoxelSizeChanged));
       handleVoxelSizeChanged();
+      if (!this.localAnnotations.readonly) {
+        this.tabs.add(
+            'annotation-shortcuts',
+            {label: 'Shortcuts', order: 1000, getter: () => new AnnotationShortcutsTab(this)});
+        this.setupAnnotationShortcuts();
+        for (const tagId of this.localAnnotations.getTagIds()) {
+          this.addAnnotationTagShortcut(tagId);
+        }
+      }
     } else {
       StatusMessage
           .forPromise(
@@ -195,12 +227,311 @@ export class AnnotationUserLayer extends Base {
     x['type'] = 'annotation';
     x[SOURCE_JSON_KEY] = this.sourceUrl;
     if (this.sourceUrl === undefined) {
-      x[ANNOTATIONS_JSON_KEY] = this.localAnnotations.toJSON();
+      const localAnnotationsJSONObj = this.localAnnotations.toJSON();
+      x[ANNOTATIONS_JSON_KEY] = localAnnotationsJSONObj.annotations;
+      x[ANNOTATION_TAGS_JSON_KEY] = localAnnotationsJSONObj.tags;
       x[VOXEL_SIZE_JSON_KEY] = this.voxelSize.toJSON();
     }
     x[LINKED_SEGMENTATION_LAYER_JSON_KEY] = this.linkedSegmentationLayer.toJSON();
     x[FILTER_BY_SEGMENTATION_JSON_KEY] = this.filterBySegmentation.toJSON();
     return x;
+  }
+
+  getPrevAnnotation(annotationId: AnnotationId) {
+    return this.localAnnotations.getPrevAnnotation(annotationId);
+  }
+
+  getNextAnnotation(annotationId: AnnotationId) {
+    return this.localAnnotations.getNextAnnotation(annotationId);
+  }
+
+  enableAnnotationShortcuts() {
+    this.shortcutHandler.enable();
+  }
+
+  disableAnnotationShortcuts() {
+    this.shortcutHandler.disable();
+  }
+
+  setupAnnotationShortcuts() {
+    const element = document.getElementById('neuroglancerViewer');
+    if (element) {
+      this.shortcutHandler.setup(this.getDefaultShortcutActions());
+    } else {
+      throw new Error('Viewer element does not exist');
+    }
+  }
+
+  private getDefaultShortcutActions() {
+    let lastAnnotation: Annotation|undefined;
+    const jumpToAnnotation = (annotation: Annotation|undefined, movingForward: boolean) => {
+      if (annotation && this.annotationLayerState.value) {
+        const selectedTagId = this.annotationLayerState.value.selectedAnnotationTagId.value;
+        if (selectedTagId === 0 || (annotation.tagIds && annotation.tagIds.has(selectedTagId))) {
+          this.selectedAnnotation.value = {id: annotation.id, partIndex: 0};
+          const point = getPointFromAnnotation(annotation);
+          const spatialPoint = vec3.create();
+          vec3.transformMat4(spatialPoint, point, this.annotationLayerState.value.objectToGlobal);
+          this.manager.setSpatialCoordinates(spatialPoint);
+          if (this.linkedSegmentationLayer &&
+              this.annotationLayerState.value.segmentationState.value &&
+              this.annotationLayerState.value.annotationJumpingDisplaysSegmentation.value) {
+            const rootSegs = this.annotationLayerState.value.segmentationState.value.visibleSegments;
+            if (lastAnnotation && lastAnnotation.segments) {
+              lastAnnotation.segments.forEach(segment => {
+                if (rootSegs.has(segment)) {
+                  rootSegs.delete(segment);
+                }
+              });
+            }
+            if (annotation.segments) {
+              annotation.segments.forEach(segment => {
+                if (!rootSegs.has(segment)) {
+                  rootSegs.add(segment);
+                }
+              });
+            }
+            lastAnnotation = annotation;
+          }
+        } else {
+          if (movingForward) {
+            jumpToAnnotation(this.getNextAnnotation(annotation.id), true);
+          } else {
+            jumpToAnnotation(this.getPrevAnnotation(annotation.id), false);
+          }
+        }
+      }
+    };
+    return [
+      {
+        keyCode: 'bracketright',
+        actionName: 'go-to-next-annotation',
+        actionFunction: () => {
+          if (this.selectedAnnotation.value) {
+            jumpToAnnotation(this.getNextAnnotation(this.selectedAnnotation.value.id), true);
+          }
+        }
+      },
+      {
+        keyCode: 'bracketleft',
+        actionName: 'go-to-prev-annotation',
+        actionFunction: () => {
+          if (this.selectedAnnotation.value) {
+            jumpToAnnotation(this.getPrevAnnotation(this.selectedAnnotation.value.id), false);
+          }
+        }
+      }
+    ];
+  }
+
+  getAnnotationText(annotation: Annotation) {
+    let text = super.getAnnotationText(annotation);
+    if (annotation.tagIds) {
+      annotation.tagIds.forEach(tagId => {
+        const tag = this.localAnnotations.getTag(tagId);
+        if (tag) {
+          text += ' #' + tag.label;
+        }
+      });
+    }
+    return text;
+  }
+
+  addAnnotationTagShortcut(tagId: number) {
+    const {localAnnotations, selectedAnnotation, shortcutHandler: shortcutHandlerViewer} = this;
+    const shortcutKey = this.keyShortcuts.splice(0, 1)[0];
+    const shortcutCode = this.keyShortcutModifier + 'key' + shortcutKey;
+    this.tagToShortcut.set(tagId, shortcutCode);
+    const addAnnotationTagToAnnotation = () => {
+      const reference = selectedAnnotation.reference;
+      if (reference && reference.value) {
+        localAnnotations.toggleAnnotationTag(reference, tagId);
+      }
+    };
+    shortcutHandlerViewer.addShortcut(shortcutCode, addAnnotationTagToAnnotation);
+  }
+
+  addAnnotationTag() {
+    if (this.keyShortcuts.length > 0) {
+      const newTagId = this.localAnnotations.addTag('');
+      this.addAnnotationTagShortcut(newTagId);
+      return newTagId;
+    }
+    return;
+  }
+
+  get numTagsAllowed() {
+    return this._numTagsAllowed;
+  }
+
+  getShortcutText(tagId: number) {
+    const shortcutCode = this.tagToShortcut.get(tagId)!;
+    return shortcutCode.charAt(0).toUpperCase() + shortcutCode.slice(1, -4) +
+        shortcutCode.slice(-1);
+  }
+
+  deleteAnnotationTag(tagId: number) {
+    const shortcutCode = this.tagToShortcut.get(tagId)!;
+    this.shortcutHandler.removeShortcut(shortcutCode);
+    this.keyShortcuts.push(shortcutCode);
+    this.tagToShortcut.delete(tagId);
+    this.localAnnotations.deleteTag(tagId);
+  }
+}
+
+class AnnotationShortcutsTab extends Tab {
+  constructor(public layer: Borrowed<AnnotationUserLayer>) {
+    super();
+    const {element} = this;
+    element.classList.add('neuroglancer-annotation-shortcuts-tab');
+    const addAnnotationTagDiv = document.createElement('div');
+    const addShortcutButton = document.createElement('button');
+    addShortcutButton.classList.add('neuroglancer-annotation-shortcut-button');
+    addShortcutButton.textContent = '+';
+    addShortcutButton.addEventListener('click', () => {
+      const newTagId = this.layer.addAnnotationTag();
+      if (newTagId === undefined) {
+        alert(`Reached max number of shortcuts. Currently, only ${
+            this.layer.numTagsAllowed} are supported.`);
+      } else {
+        this.addNewTagElement(newTagId);
+      }
+    });
+    const addShortcutButtonLabel = document.createElement('span');
+    addShortcutButtonLabel.classList.add('neuroglancer-annotation-shortcut-button-label');
+    addShortcutButtonLabel.textContent = 'Add annotation shortcut: ';
+    addAnnotationTagDiv.appendChild(addShortcutButtonLabel);
+    addAnnotationTagDiv.appendChild(addShortcutButton);
+    const shortcutListHeader = document.createElement('div');
+    shortcutListHeader.classList.add('annotation-shorcut-list-header');
+    const shortcutHeader = document.createElement('span');
+    shortcutHeader.textContent = 'Key shortcut';
+    shortcutHeader.classList.add('annotation-key-shortcut-header');
+    const tagHeader = document.createElement('span');
+    tagHeader.textContent = 'Tag input';
+    shortcutListHeader.appendChild(shortcutHeader);
+    shortcutListHeader.appendChild(tagHeader);
+    element.appendChild(addAnnotationTagDiv);
+    element.appendChild(shortcutListHeader);
+    for (const tagId of this.layer.localAnnotations.getTagIds()) {
+      this.addNewTagElement(tagId);
+    }
+  }
+
+  private addNewTagElement(tagId: number) {
+    const {layer} = this;
+    const {localAnnotations} = layer;
+    const newTagElement = document.createElement('div');
+    newTagElement.classList.add('neuroglancer-annotation-shortcut');
+    const shortcutTextbox = document.createElement('span');
+    shortcutTextbox.className = 'display-annotation-shortcut-textbox';
+    shortcutTextbox.textContent = this.layer.getShortcutText(tagId);
+    const annotationTagName = document.createElement('input');
+    annotationTagName.className = 'annotation-tag-input';
+    const tag = localAnnotations.getTag(tagId);
+    if (tag) {
+      annotationTagName.value = tag.label;
+    } else {
+      throw new Error(`Tag ${tagId} does not exist`);
+    }
+    const tagChangeListenerDisposer = registerEventListener(annotationTagName, 'change', () => {
+      const updateConfirmed =
+          tag.label === '' ||
+          confirm(
+              `Are you sure you want to change the name of the tag? All associated annotations will be tagged with the new tag name.`);
+      if (updateConfirmed) {
+        localAnnotations.updateTagLabel(tagId, annotationTagName.value);
+      } else {
+        annotationTagName.value = tag.label;
+      }
+    });
+    this.registerDisposer(tagChangeListenerDisposer);
+    const deleteTag = document.createElement('button');
+    deleteTag.className = 'delete-annotation-tag';
+    deleteTag.textContent = 'x';
+    deleteTag.addEventListener('click', () => {
+      const deleteConfirmed = confirm(`Are you sure you want to delete #${
+          tag.label}? This tag will be removed from all annotations associated with it`);
+      if (deleteConfirmed) {
+        newTagElement.remove();
+        tagChangeListenerDisposer();
+        this.unregisterDisposer(tagChangeListenerDisposer);
+        layer.deleteAnnotationTag(tagId);
+      }
+    });
+    newTagElement.appendChild(shortcutTextbox);
+    newTagElement.appendChild(annotationTagName);
+    newTagElement.appendChild(deleteTag);
+    this.element.appendChild(newTagElement);
+  }
+}
+
+class AnnotationShortcutHandler extends RefCounted {
+  private shortcutEventBinder = this.registerDisposer(new KeyboardEventBinder<EventActionMap>(
+      document.getElementById('neuroglancerViewer')!, new EventActionMap()));
+  private shortcutEventActions =
+      new Map<string, {actionName: string, actionFunction: () => void}>();
+  private shortcutEventDisposers = new Map<string, () => void>();
+  private enabled = false;
+
+  private static getShortcutEventName(shortcutKeyCode: string) {
+    return 'annotationShortcutEvent:' + shortcutKeyCode;
+  }
+
+  private disableShortcut(shortcutCode: string) {
+    const actionRemover = this.shortcutEventDisposers.get(shortcutCode);
+    this.shortcutEventBinder!.eventMap.delete(shortcutCode);
+    if (actionRemover) {
+      actionRemover();
+      this.shortcutEventDisposers.delete(shortcutCode);
+      this.unregisterDisposer(actionRemover);
+    }
+  }
+
+  private enableShortcut(
+      shortcutCode: string, shortcutEventName: string, shortcutAction: () => void) {
+    this.shortcutEventBinder!.eventMap.set(shortcutCode, shortcutEventName);
+    const actionRemover =
+        registerActionListener(this.shortcutEventBinder!.target, shortcutEventName, shortcutAction);
+    this.registerDisposer(actionRemover);
+    this.shortcutEventDisposers.set(shortcutCode, actionRemover);
+  }
+
+  addShortcut(shortcutCode: string, shortcutAction: () => void) {
+    const shortcutEventName = AnnotationShortcutHandler.getShortcutEventName(shortcutCode);
+    if (this.enabled) {
+      this.enableShortcut(shortcutCode, shortcutEventName, shortcutAction);
+    }
+    this.shortcutEventActions.set(
+        shortcutCode, {actionName: shortcutEventName, actionFunction: shortcutAction});
+  }
+
+  removeShortcut(shortcutCode: string) {
+    if (this.enabled) {
+      this.disableShortcut(shortcutCode);
+    }
+    this.shortcutEventActions.delete(shortcutCode);
+  }
+
+  enable() {
+    for (const [shortcutCode, {actionName, actionFunction}] of this.shortcutEventActions) {
+      this.enableShortcut(shortcutCode, actionName, actionFunction);
+    }
+    this.enabled = true;
+  }
+
+  disable() {
+    for (const shortcutCode of this.shortcutEventActions.keys()) {
+      this.disableShortcut(shortcutCode);
+    }
+    this.enabled = false;
+  }
+
+  setup(initialActions: {keyCode: string, actionName: string, actionFunction: () => void}[]) {
+    for (const action of initialActions) {
+      this.shortcutEventActions.set(
+          action.keyCode, {actionName: action.actionName, actionFunction: action.actionFunction});
+    }
   }
 }
 

--- a/src/neuroglancer/ui/annotations.css
+++ b/src/neuroglancer/ui/annotations.css
@@ -46,12 +46,6 @@
   left: 0px;
 }
 
-.neuroglancer-annotation-description {
-  text-overflow: ellipsis;
-  overflow: hidden;
-  white-space: nowrap;
-}
-
 .neuroglancer-annotation-hover {
   background-color: #333;
 }

--- a/src/neuroglancer/util/json.ts
+++ b/src/neuroglancer/util/json.ts
@@ -395,6 +395,14 @@ export function verifyPositiveInt(obj: any) {
   return result;
 }
 
+export function verifyNonnegativeInt(obj: any) {
+  let result = verifyInt(obj);
+  if (result < 0) {
+    throw new Error(`Expected non-negative integer, but received: ${result}.`);
+  }
+  return result;
+}
+
 export function verifyMapKey<U>(obj: any, map: Map<string, U>) {
   let result = map.get(obj);
   if (result === undefined) {

--- a/src/neuroglancer/viewer.ts
+++ b/src/neuroglancer/viewer.ts
@@ -22,7 +22,7 @@ import {DataSourceProvider} from 'neuroglancer/datasource';
 import {getDefaultDataSourceProvider} from 'neuroglancer/datasource/default_provider';
 import {DisplayContext} from 'neuroglancer/display_context';
 import {InputEventBindingHelpDialog} from 'neuroglancer/help/input_event_bindings';
-import {allRenderLayerRoles, LayerManager, LayerSelectedValues, MouseSelectionState, RenderLayerRole, SelectedLayerState} from 'neuroglancer/layer';
+import {allRenderLayerRoles, LayerManager, LayerSelectedValues, MouseSelectionState, RenderLayerRole, SelectedLayerState, UserLayer, ManagedUserLayer} from 'neuroglancer/layer';
 import {LayerDialog} from 'neuroglancer/layer_dialog';
 import {RootLayoutContainer} from 'neuroglancer/layer_groups_layout';
 import {TopLevelLayerListSpecification} from 'neuroglancer/layer_specification';
@@ -56,6 +56,7 @@ import {MousePositionWidget, PositionWidget, VoxelSizeWidget} from 'neuroglancer
 import {TrackableScaleBarOptions} from 'neuroglancer/widget/scale_bar';
 import {makeTextIconButton} from 'neuroglancer/widget/text_icon_button';
 import {RPC} from 'neuroglancer/worker_rpc';
+import {AnnotationUserLayer} from 'neuroglancer/annotation/user_layer';
 
 require('./viewer.css');
 require('neuroglancer/noselect.css');
@@ -260,6 +261,7 @@ export class Viewer extends RefCounted implements ViewerState {
     this.visibility = visibility;
     this.inputEventBindings = inputEventBindings;
     this.element = element;
+    this.element.id = 'neuroglancerViewer';
     this.dataSourceProvider = dataSourceProvider;
     this.uiConfiguration = uiConfiguration;
 
@@ -382,6 +384,9 @@ export class Viewer extends RefCounted implements ViewerState {
 
     this.registerDisposer(new MouseSelectionStateTooltipManager(
         this.mouseState, this.layerManager, this.navigationState.voxelSize));
+
+    const maybeAddOrRemoveAnnotationShortcuts = this.annotationShortcutControllerFactory();
+    this.registerDisposer(this.selectedLayer.changed.add(() => maybeAddOrRemoveAnnotationShortcuts()));
   }
 
   private updateShowBorders() {
@@ -619,5 +624,27 @@ export class Viewer extends RefCounted implements ViewerState {
         chunkQueueManager.chunkUpdateDeadline = Date.now() + 10;
       }
     }
+  }
+
+  private annotationShortcutControllerFactory() {
+    let lastLayerSelected: UserLayer|null = null;
+    let lastManagerLayerSelected: ManagedUserLayer|undefined;
+    const maybeAddOrRemoveAnnotationShortcuts = () => {
+      if (this.selectedLayer.layer !== lastManagerLayerSelected) {
+        if (lastLayerSelected && lastLayerSelected instanceof AnnotationUserLayer) {
+          lastLayerSelected.disableAnnotationShortcuts();
+        }
+        const selectedLayer = this.selectedLayer.layer;
+        if (selectedLayer) {
+          const userLayer = selectedLayer.layer;
+          if (userLayer instanceof AnnotationUserLayer) {
+            userLayer.enableAnnotationShortcuts();
+          }
+          lastLayerSelected = userLayer;
+        }
+        lastManagerLayerSelected = this.selectedLayer.layer;
+      }
+    };
+    return maybeAddOrRemoveAnnotationShortcuts;
   }
 }


### PR DESCRIPTION
This PR aims to bring useful shortcuts and utilities to annotations.
The two main features introduced are:

- Annotation tags. Tags are like descriptions except they are bound to a shortcut when created (I was unsure of the best choice of shortcut, but decided on shift + different letters). Tags are meant to make categorizing annotations into different groups a faster process. Instead of copying different strings into the description box, just hit the appropriate shortcut. You can also "check your work" by filtering annotations by their tag in the dropdown above the list.
- Bracket key shortcuts to move to the next/previous annotation. This enables a workflow where you can tag annotations solely from your keyboard. It's also useful if you want to do a quick review of some annotations without using your mouse.

I was unsure of the best way of adding dynamic keyboard shortcuts to Neuroglancer, so I realize the way I chose might not be ideal, but I'm deciding to open this PR to start this conversation.