### PR TITLE
default viewer build option

### DIFF
--- a/src/neuroglancer/viewer.ts
+++ b/src/neuroglancer/viewer.ts
@@ -57,6 +57,8 @@ import {TrackableScaleBarOptions} from 'neuroglancer/widget/scale_bar';
 import {makeTextIconButton} from 'neuroglancer/widget/text_icon_button';
 import {RPC} from 'neuroglancer/worker_rpc';
 
+declare var OVERWRITE_DEFAULT_VIEWER_OPTIONS: any
+
 require('./viewer.css');
 require('neuroglancer/noselect.css');
 require('neuroglancer/ui/button.css');
@@ -144,7 +146,7 @@ export interface ViewerOptions extends ViewerUIOptions, VisibilityPrioritySpecif
   resetStateWhenEmpty: boolean;
 }
 
-const defaultViewerOptions = {
+const defaultViewerOptions = OVERWRITE_DEFAULT_VIEWER_OPTIONS || {
   showLayerDialog: true,
   resetStateWhenEmpty: true,
 };

--- a/src/neuroglancer/viewer.ts
+++ b/src/neuroglancer/viewer.ts
@@ -57,7 +57,7 @@ import {TrackableScaleBarOptions} from 'neuroglancer/widget/scale_bar';
 import {makeTextIconButton} from 'neuroglancer/widget/text_icon_button';
 import {RPC} from 'neuroglancer/worker_rpc';
 
-declare var OVERWRITE_DEFAULT_VIEWER_OPTIONS: any
+declare var NEUROGLANCER_OVERRIDE_DEFAULT_VIEWER_OPTIONS: any
 
 require('./viewer.css');
 require('neuroglancer/noselect.css');
@@ -146,8 +146,8 @@ export interface ViewerOptions extends ViewerUIOptions, VisibilityPrioritySpecif
   resetStateWhenEmpty: boolean;
 }
 
-const defaultViewerOptions = "undefined" !== typeof OVERWRITE_DEFAULT_VIEWER_OPTIONS ?
-  OVERWRITE_DEFAULT_VIEWER_OPTIONS : {
+const defaultViewerOptions = "undefined" !== typeof NEUROGLANCER_OVERRIDE_DEFAULT_VIEWER_OPTIONS ?
+  NEUROGLANCER_OVERRIDE_DEFAULT_VIEWER_OPTIONS : {
     showLayerDialog: true,
     resetStateWhenEmpty: true,
   };

--- a/src/neuroglancer/viewer.ts
+++ b/src/neuroglancer/viewer.ts
@@ -146,10 +146,11 @@ export interface ViewerOptions extends ViewerUIOptions, VisibilityPrioritySpecif
   resetStateWhenEmpty: boolean;
 }
 
-const defaultViewerOptions = OVERWRITE_DEFAULT_VIEWER_OPTIONS || {
-  showLayerDialog: true,
-  resetStateWhenEmpty: true,
-};
+const defaultViewerOptions = "undefined" !== typeof OVERWRITE_DEFAULT_VIEWER_OPTIONS ?
+  OVERWRITE_DEFAULT_VIEWER_OPTIONS : {
+    showLayerDialog: true,
+    resetStateWhenEmpty: true,
+  };
 
 function makeViewerContextMenu(viewer: Viewer) {
   const menu = new ContextMenu();


### PR DESCRIPTION
This adds a build option for `defaultViewerOptions`

To overwrite the options on build, run the following command (this one disables the layer dialog):

`npm run build-min -- --define OVERWRITE_DEFAULT_VIEWER_OPTIONS="'showLayerDialog: false, resetStateWhenEmpty: true'"`

Thanks @xgui3783 for your [example](https://github.com/xgui3783/neuroglancer/commit/9453eb1d640b88f723be2f24428239e086edd6ab), which I modified slightly to make the declaration inside `viewer.ts` as well as handle builds which don't specify the default viewer options.

The syntax I'm using to check if it's undefined is a bit ugly -- happy to change to something else if you prefer.

Related to issue https://github.com/google/neuroglancer/issues/147