### PR TITLE
fix(python): work with jupyter-server-proxy

### DIFF
--- a/src/neuroglancer/python_integration/server_connection.ts
+++ b/src/neuroglancer/python_integration/server_connection.ts
@@ -21,11 +21,11 @@ import SockJS from 'sockjs-client';
 import {StatusMessage} from 'neuroglancer/status';
 
 function getServerConnectionURL() {
-  const match = window.location.pathname.match(/^\/v\/([^\/]+)/);
+  const match = window.location.pathname.match(/^(.*)\/v\/([^\/]+)/);
   if (match === null) {
     throw new Error('Failed to determine token from URL.');
   }
-  return `${window.location.origin}/socket/${match[1]}`;
+  return `${window.location.origin}${match[1]}/socket/${match[2]}`;
 }
 
 const defaultReconnectionDelay = 1000;


### PR DESCRIPTION
A very small tweak to the token parsing in the python client to preserve the path.  The current regex expects the path to be in the form `^/v/<token>/`, which will not work with [Jupyter Server Proxy](https://github.com/jupyterhub/jupyter-server-proxy/).

With Jupyter Server Proxy server extension enabled in jupyter, the normal neuroglancer URL (e.g. `http://127.0.0.1:51119/v/2df69e9395e0adb8b0d14b7dbec99751220625aa/`) can be accessed as  `http://localhost:8888/proxy/51119/v/2df69e9395e0adb8b0d14b7dbec99751220625aa/`.

My goal here is have neuroglancer notebooks working with [binder](https://mybinder.org/), which does not allow remote access to additional ports except through a proxy.