### PR TITLE
feat(render): uint16 render support

### DIFF
--- a/src/neuroglancer/datasource/render/backend.ts
+++ b/src/neuroglancer/datasource/render/backend.ts
@@ -18,6 +18,7 @@ import {WithParameters} from 'neuroglancer/chunk_manager/backend';
 import {PointMatchChunkSourceParameters, TileChunkSourceParameters} from 'neuroglancer/datasource/render/base';
 import {ChunkDecoder} from 'neuroglancer/sliceview/backend_chunk_decoders';
 import {decodeJpegChunk} from 'neuroglancer/sliceview/backend_chunk_decoders/jpeg';
+import {decodeRawChunk} from 'neuroglancer/sliceview/backend_chunk_decoders/raw';
 import {VectorGraphicsChunk, VectorGraphicsChunkSource} from 'neuroglancer/sliceview/vector_graphics/backend';
 import {VolumeChunk, VolumeChunkSource} from 'neuroglancer/sliceview/volume/backend';
 import {CancellationToken} from 'neuroglancer/util/cancellation';
@@ -26,9 +27,14 @@ import {vec3} from 'neuroglancer/util/geom';
 import {cancellableFetchOk, responseArrayBuffer, responseJson} from 'neuroglancer/util/http_request';
 import {parseArray, verify3dVec, verifyObject, verifyString} from 'neuroglancer/util/json';
 import {registerSharedObject} from 'neuroglancer/worker_rpc';
+import {Endianness} from 'neuroglancer/util/endian';
 
 const chunkDecoders = new Map<string, ChunkDecoder>();
 chunkDecoders.set('jpg', decodeJpegChunk);
+chunkDecoders.set('raw16',
+  (chunk, cancellationToken, response) => {
+    return decodeRawChunk(chunk, cancellationToken, response, Endianness.BIG);
+  } );
 
 @registerSharedObject() export class TileChunkSource extends
 (WithParameters(VolumeChunkSource, TileChunkSourceParameters)) {
@@ -77,8 +83,12 @@ chunkDecoders.set('jpg', decodeJpegChunk);
 
     // GET
     // /v1/owner/{owner}/project/{project}/stack/{stack}/z/{z}/box/{x},{y},{width},{height},{scale}/jpeg-image
-    let path = `/render-ws/v1/owner/${parameters.owner}/project/${parameters.project}/stack/${parameters.stack}/z/${chunkPosition[2]}/box/${chunkPosition[0]},${chunkPosition[1]},${xTileSize},${yTileSize},${scale}/jpeg-image`;
-
+    let path:string;
+    if (parameters.encoding === 'raw16') {
+      path = `/render-ws/v1/owner/${parameters.owner}/project/${parameters.project}/stack/${parameters.stack}/z/${chunkPosition[2]}/box/${chunkPosition[0]},${chunkPosition[1]},${xTileSize},${yTileSize},${scale}/raw16-image`;
+    } else {
+      path = `/render-ws/v1/owner/${parameters.owner}/project/${parameters.project}/stack/${parameters.stack}/z/${chunkPosition[2]}/box/${chunkPosition[0]},${chunkPosition[1]},${xTileSize},${yTileSize},${scale}/jpeg-image`;
+    }
     const response = await cancellableFetchOk(
         `${parameters.baseUrl}${path}?${this.queryString}`, {}, responseArrayBuffer,
         cancellationToken);

--- a/src/neuroglancer/datasource/render/backend.ts
+++ b/src/neuroglancer/datasource/render/backend.ts
@@ -83,12 +83,13 @@ chunkDecoders.set('raw16',
 
     // GET
     // /v1/owner/{owner}/project/{project}/stack/{stack}/z/{z}/box/{x},{y},{width},{height},{scale}/jpeg-image
-    let path:string;
+    let imageMethod:string;
     if (parameters.encoding === 'raw16') {
-      path = `/render-ws/v1/owner/${parameters.owner}/project/${parameters.project}/stack/${parameters.stack}/z/${chunkPosition[2]}/box/${chunkPosition[0]},${chunkPosition[1]},${xTileSize},${yTileSize},${scale}/raw16-image`;
+      imageMethod = 'raw16-image';
     } else {
-      path = `/render-ws/v1/owner/${parameters.owner}/project/${parameters.project}/stack/${parameters.stack}/z/${chunkPosition[2]}/box/${chunkPosition[0]},${chunkPosition[1]},${xTileSize},${yTileSize},${scale}/jpeg-image`;
+      imageMethod = 'jpeg-image';
     }
+    let path = `/render-ws/v1/owner/${parameters.owner}/project/${parameters.project}/stack/${parameters.stack}/z/${chunkPosition[2]}/box/${chunkPosition[0]},${chunkPosition[1]},${xTileSize},${yTileSize},${scale}/${imageMethod}`;
     const response = await cancellableFetchOk(
         `${parameters.baseUrl}${path}?${this.queryString}`, {}, responseArrayBuffer,
         cancellationToken);

--- a/src/neuroglancer/datasource/render/frontend.ts
+++ b/src/neuroglancer/datasource/render/frontend.ts
@@ -31,7 +31,7 @@ import {vec3} from 'neuroglancer/util/geom';
 import {fetchOk} from 'neuroglancer/util/http_request';
 import {parseArray, parseQueryStringParameters, verifyFloat, verifyObject, verifyObjectProperty, verifyOptionalBoolean, verifyOptionalInt, verifyOptionalString, verifyString} from 'neuroglancer/util/json';
 
-const VALID_ENCODINGS = new Set<string>(['jpg']);
+const VALID_ENCODINGS = new Set<string>(['jpg', 'raw16']);
 
 const TileChunkSourceBase = WithParameters(VolumeChunkSource, TileChunkSourceParameters);
 class TileChunkSource extends TileChunkSourceBase {}
@@ -191,10 +191,20 @@ function parseStackProject(stackIdObj: any): string {
 
 export class MultiscaleVolumeChunkSource implements GenericMultiscaleVolumeChunkSource {
   get dataType() {
-    return DataType.UINT8;
+    if (this.parameters.encoding === 'raw16') {
+      return DataType.UINT16;
+    } else {
+      // JPEG
+      return DataType.UINT8;
+    }
   }
   get numChannels() {
-    return 3;
+    if (this.parameters.encoding === 'raw16') {
+      return 1;
+    } else {
+      // JPEG
+      return 3;
+    }
   }
   get volumeType() {
     return VolumeType.IMAGE;


### PR DESCRIPTION
Adds support for uint16 data from render via `?encoding=raw16`, added to render in https://github.com/saalfeldlab/render/pull/100.

Ultimately, I think I'd rather use png for 16-bit, but quickly aborted that effort when looking into the strange world of png libraries in npm.