### PR TITLE
chore: Fix appveyor setup

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -7,7 +7,7 @@ init:
   - "ECHO %PYTHON_VERSION% %MINICONDA%"
 
 install:
-  - "set PATH=%MINICONDA%;%MINICONDA%\\Scripts;%PATH%"
+  - call %MINICONDA%\Scripts\activate
   - conda config --set always_yes yes --set changeps1 no
   - conda update -q conda
   - conda info -a


### PR DESCRIPTION
On Windows, recent versions of conda require you to actually 'activate' the base environment, not merely adjust your PATH.

(Explained in conda/conda#8836)
