### PR TITLE
feat: support explicit segment colors

### DIFF
--- a/src/neuroglancer/segmentation_display_state/backend.ts
+++ b/src/neuroglancer/segmentation_display_state/backend.ts
@@ -17,6 +17,7 @@
 // Import to register the shared object types.
 import 'neuroglancer/shared_disjoint_sets';
 import 'neuroglancer/uint64_set';
+import 'neuroglancer/uint64_map';
 
 import {withChunkManager} from 'neuroglancer/chunk_manager/backend';
 import {VisibleSegmentsState} from 'neuroglancer/segmentation_display_state/base';

--- a/src/neuroglancer/segmentation_display_state/frontend.ts
+++ b/src/neuroglancer/segmentation_display_state/frontend.ts
@@ -24,6 +24,7 @@ import {SharedWatchableValue} from 'neuroglancer/shared_watchable_value';
 import {TrackableAlphaValue} from 'neuroglancer/trackable_alpha';
 import {TrackableValue} from 'neuroglancer/trackable_value';
 import {Uint64Set} from 'neuroglancer/uint64_set';
+import {Uint64Map} from 'neuroglancer/uint64_map';
 import {hsvToRgb, rgbToHsv} from 'neuroglancer/util/colorspace';
 import {RefCounted} from 'neuroglancer/util/disposable';
 import {vec4} from 'neuroglancer/util/geom';
@@ -85,6 +86,7 @@ export class SegmentSelectionState extends RefCounted {
 export interface SegmentationDisplayState extends VisibleSegmentsState {
   segmentSelectionState: SegmentSelectionState;
   segmentColorHash: SegmentColorHash;
+  segmentStatedColors: Uint64Map;
   saturation: TrackableAlphaValue;
   highlightedSegments: Uint64Set;
 }
@@ -130,9 +132,10 @@ export function registerRedrawWhenSegmentationDisplayState3DChanged(
 }
 
 /**
- * Temporary value used by getObjectColor.
+ * Temporary values used by getObjectColor.
  */
 const tempColor = vec4.create();
+const tempStatedColor = new Uint64();
 
 /**
  * Returns the alpha-premultiplied color to use.
@@ -141,7 +144,16 @@ export function getObjectColor(
     displayState: SegmentationDisplayState, objectId: Uint64, alpha: number = 1) {
   const color = tempColor;
   color[3] = alpha;
-  displayState.segmentColorHash.compute(color, objectId);
+  if (displayState.segmentStatedColors.has(objectId)) {
+    // If displayState maps the ID to a color, use it
+    displayState.segmentStatedColors.get(objectId, tempStatedColor);
+    color[0] = ((tempStatedColor.low & 0xff0000) >>> 16) / 255.0;
+    color[1] = ((tempStatedColor.low & 0x00ff00) >>>  8) / 255.0;
+    color[2] = ((tempStatedColor.low & 0x0000ff))        / 255.0;
+  } else {
+    displayState.segmentColorHash.compute(color, objectId);
+  }
+
   if (displayState.segmentSelectionState.isSelected(objectId)) {
     for (let i = 0; i < 3; ++i) {
       color[i] = color[i] * 0.5 + 0.5;

--- a/src/neuroglancer/segmentation_user_layer.ts
+++ b/src/neuroglancer/segmentation_user_layer.ts
@@ -33,9 +33,10 @@ import {trackableAlphaValue} from 'neuroglancer/trackable_alpha';
 import {ElementVisibilityFromTrackableBoolean, TrackableBoolean, TrackableBooleanCheckbox} from 'neuroglancer/trackable_boolean';
 import {ComputedWatchableValue} from 'neuroglancer/trackable_value';
 import {Uint64Set} from 'neuroglancer/uint64_set';
+import {Uint64Map} from 'neuroglancer/uint64_map';
 import {UserLayerWithVolumeSourceMixin} from 'neuroglancer/user_layer_with_volume_source';
 import {Borrowed} from 'neuroglancer/util/disposable';
-import {parseArray, verifyObjectProperty, verifyOptionalString} from 'neuroglancer/util/json';
+import {parseArray, verifyObjectProperty, verifyOptionalString, verifyObjectAsMap} from 'neuroglancer/util/json';
 import {NullarySignal} from 'neuroglancer/util/signal';
 import {Uint64} from 'neuroglancer/util/uint64';
 import {makeWatchableShaderError} from 'neuroglancer/webgl/dynamic_shader';
@@ -58,6 +59,7 @@ const SEGMENTS_JSON_KEY = 'segments';
 const HIGHLIGHTS_JSON_KEY = 'highlights';
 const EQUIVALENCES_JSON_KEY = 'equivalences';
 const COLOR_SEED_JSON_KEY = 'colorSeed';
+const SEGMENT_STATED_COLORS_JSON_KEY = 'segmentColors';
 const MESH_RENDER_SCALE_JSON_KEY = 'meshRenderScale';
 
 const SKELETON_RENDERING_JSON_KEY = 'skeletonRendering';
@@ -67,6 +69,7 @@ const Base = UserLayerWithVolumeSourceMixin(UserLayer);
 export class SegmentationUserLayer extends Base {
   displayState = {
     segmentColorHash: SegmentColorHash.getDefault(),
+    segmentStatedColors: Uint64Map.makeWithCounterpart(this.manager.worker),
     segmentSelectionState: new SegmentSelectionState(),
     selectedAlpha: trackableAlphaValue(0.5),
     saturation: trackableAlphaValue(1.0),
@@ -107,6 +110,7 @@ export class SegmentationUserLayer extends Base {
     this.displayState.hideSegmentZero.changed.add(this.specificationChanged.dispatch);
     this.displayState.skeletonRenderingOptions.changed.add(this.specificationChanged.dispatch);
     this.displayState.segmentColorHash.changed.add(this.specificationChanged.dispatch);
+    this.displayState.segmentStatedColors.changed.add(this.specificationChanged.dispatch);
     this.displayState.renderScaleTarget.changed.add(this.specificationChanged.dispatch);
     this.tabs.add(
         'rendering', {label: 'Rendering', order: -100, getter: () => new DisplayOptionsTab(this)});
@@ -155,6 +159,21 @@ export class SegmentationUserLayer extends Base {
 
     this.displayState.highlightedSegments.changed.add(() => {
       this.specificationChanged.dispatch();
+    });
+
+    verifyObjectProperty(specification, SEGMENT_STATED_COLORS_JSON_KEY, y => {
+      if (y !== undefined) {
+        let {segmentEquivalences} = this.displayState;
+        // Parse the color as a 32-bit integer here, because the Uint64.parseString()
+        // function does not seem to handle strings of the form '0xRRGGBB'.
+        // And support a CSS color "#RRGGBB" by turning into "0xRRGGBB".
+        let result = verifyObjectAsMap(y, x => parseInt(String(x).replace(/^#/, '0x'), 0));
+        for (let [idStr, colorInt] of result) {
+          const id = Uint64.parseString(String(idStr));
+          const color = new Uint64(colorInt);
+          this.displayState.segmentStatedColors.set(segmentEquivalences.get(id), color);
+        }
+      }
     });
 
     const {multiscaleSource} = this;
@@ -261,6 +280,13 @@ export class SegmentationUserLayer extends Base {
     x[OBJECT_ALPHA_JSON_KEY] = this.displayState.objectAlpha.toJSON();
     x[HIDE_SEGMENT_ZERO_JSON_KEY] = this.displayState.hideSegmentZero.toJSON();
     x[COLOR_SEED_JSON_KEY] = this.displayState.segmentColorHash.toJSON();
+    let {segmentStatedColors} = this.displayState;
+    if (segmentStatedColors.size > 0) {
+      let json = segmentStatedColors.toJSON();
+      // Convert colors from decimal integers to CSS "#RRGGBB" format.
+      Object.keys(json).map(k => json[k] = '#' + parseInt(json[k], 10).toString(16));
+      x[SEGMENT_STATED_COLORS_JSON_KEY] = json;
+    }
     let {visibleSegments} = this.displayState;
     if (visibleSegments.size > 0) {
       x[SEGMENTS_JSON_KEY] = visibleSegments.toJSON();

--- a/src/neuroglancer/uint64_map.spec.ts
+++ b/src/neuroglancer/uint64_map.spec.ts
@@ -1,0 +1,121 @@
+/**
+ * @license
+ * This work is a derivative of the Google Neuroglancer project,
+ * Copyright 2016 Google Inc.
+ * The Derivative Work is covered by
+ * Copyright 2019 Howard Hughes Medical Institute
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {Uint64Map} from 'neuroglancer/uint64_map';
+import {Uint64} from 'neuroglancer/util/uint64';
+
+describe('Uint64Map', () => {
+  it('basic', () => {
+    let m = new Uint64Map();
+
+    let k1 = new Uint64(1);
+    let v1 = new Uint64(11);
+    expect(m.has(k1)).toBe(false);
+    expect(m.size).toBe(0);
+    m.set(k1, v1);
+    expect(m.has(k1)).toBe(true);
+    expect(m.size).toBe(1);
+    let k1Gotten = new Uint64();
+    m.get(k1, k1Gotten);
+    expect(k1Gotten).toEqual(v1);
+
+    let k2 = new Uint64(2, 3);
+    let v2 = new Uint64(22, 33);
+    expect(m.has(k2)).toBe(false);
+    m.set(k2, v2);
+    expect(m.has(k1)).toBe(true);
+    expect(m.has(k2)).toBe(true);
+    expect(m.size).toBe(2);
+    let k2Gotten = new Uint64();
+    m.get(k2, k2Gotten);
+    expect(k2Gotten).toEqual(v2);
+
+    let v2a = new Uint64(222, 333);
+    m.set(k2, v2a);
+    expect(m.has(k1)).toBe(true);
+    expect(m.has(k2)).toBe(true);
+    expect(m.size).toBe(2);
+    m.get(k2, k2Gotten);
+    expect(k2Gotten).toEqual(v2);
+
+    m.delete(k2);
+    expect(m.has(k1)).toBe(true);
+    expect(m.has(k2)).toBe(false);
+    expect(m.size).toBe(1);
+    m.set(k2, v2a);
+    expect(m.has(k1)).toBe(true);
+    expect(m.has(k2)).toBe(true);
+    expect(m.size).toBe(2);
+    m.get(k2, k2Gotten);
+    expect(k2Gotten).toEqual(v2a);
+
+    m.clear();
+    expect(m.has(k1)).toBe(false);
+    expect(m.has(k2)).toBe(false);
+    expect(m.size).toBe(0);
+  });
+
+  it('iterate', () => {
+    let m = new Uint64Map();
+
+    let k1 = new Uint64(1);
+    let v1 = new Uint64(11);
+    let k2 = new Uint64(2, 3);
+    let v2 = new Uint64(22, 33);
+    let k3 = new Uint64(3, 4);
+    let v3 = new Uint64(33, 44);
+    m.set(k2, v2);
+    m.set(k1, v1);
+    m.set(k3, v3);
+
+    let iterated = [];
+    for (let [k, v] of m) {
+      iterated.push([k.clone(), v.clone()]);
+    }
+    iterated.sort((a, b) => Uint64.compare(a[0], b[0]));
+    expect(iterated).toEqual([[k1, v1], [k2, v2], [k3, v3]]);
+
+  });
+
+  it('toJSON', () => {
+    let m = new Uint64Map();
+
+    let k1 = new Uint64(1);
+    let v1 = new Uint64(11);
+    let k2 = new Uint64(2, 3);
+    let v2 = new Uint64(22, 33);
+    let k3 = new Uint64(3, 4);
+    let v3 = new Uint64(33, 44);
+    m.set(k2, v2);
+    m.set(k1, v1);
+    m.set(k3, v3);
+
+    let json = m.toJSON();
+    let expected: {[key: string]: string} = {};
+    expected[k1.toString()] = v1.toString();
+    expected[k2.toString()] = v2.toString();
+    expected[k3.toString()] = v3.toString();
+    expect(json).toEqual(expected);
+
+    expect(json.hasOwnProperty(k1.toString())).toBe(true);
+    expect(json.hasOwnProperty(k2.toString())).toBe(true);
+    expect(json.hasOwnProperty(k3.toString())).toBe(true);
+  });
+});

--- a/src/neuroglancer/uint64_map.ts
+++ b/src/neuroglancer/uint64_map.ts
@@ -1,0 +1,125 @@
+/**
+ * @license
+ * This work is a derivative of the Google Neuroglancer project,
+ * Copyright 2016 Google Inc.
+ * The Derivative Work is covered by
+ * Copyright 2019 Howard Hughes Medical Institute
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {HashMapUint64} from 'neuroglancer/gpu_hash/hash_table';
+import {Signal} from 'neuroglancer/util/signal';
+import {Uint64} from 'neuroglancer/util/uint64';
+import {registerRPC, registerSharedObject, RPC, SharedObjectCounterpart} from 'neuroglancer/worker_rpc';
+
+@registerSharedObject('Uint64Map')
+export class Uint64Map extends SharedObjectCounterpart {
+  hashTable = new HashMapUint64();
+  changed = new Signal<(x: Uint64 | null, add: boolean) => void>();
+
+  static makeWithCounterpart(rpc: RPC) {
+    let obj = new Uint64Map();
+    obj.initializeCounterpart(rpc);
+    return obj;
+  }
+
+  disposed() {
+    super.disposed();
+    this.hashTable = <any>undefined;
+    this.changed = <any>undefined;
+  }
+
+  set_(key: Uint64, value: Uint64) {
+    return this.hashTable.set(key, value);
+  }
+
+  set(key: Uint64, value: Uint64) {
+    if (this.set_(key, value)) {
+      let {rpc} = this;
+      if (rpc) {
+        rpc.invoke('Uint64Map.set', {'id': this.rpcId, 'key': key, 'value': value});
+      }
+      this.changed.dispatch(key, true);
+    }
+  }
+
+  has(key: Uint64) {
+    return this.hashTable.has(key);
+  }
+
+  get(key: Uint64, value: Uint64): boolean {
+    return this.hashTable.get(key, value);
+  }
+
+  [Symbol.iterator]() {
+    return this.hashTable.entries();
+  }
+
+  delete_(key: Uint64) {
+    return this.hashTable.delete(key);
+  }
+
+  delete(key: Uint64) {
+    if (this.delete_(key)) {
+      let {rpc} = this;
+      if (rpc) {
+        rpc.invoke('Uint64Map.delete', {'id': this.rpcId, 'key': key});
+      }
+      this.changed.dispatch(key, false);
+    }
+  }
+
+  get size() {
+    return this.hashTable.size;
+  }
+
+  clear() {
+    if (this.hashTable.clear()) {
+      let {rpc} = this;
+      if (rpc) {
+        rpc.invoke('Uint64Map.clear', {'id': this.rpcId});
+      }
+      this.changed.dispatch(null, false);
+    }
+  }
+
+  toJSON() {
+    let result: {[key: string]: string} = {};
+    for (let [key, value] of this.hashTable.entries()) {
+      result[key.toString()] = value.toString();
+    }
+    return result;
+  }
+}
+
+registerRPC('Uint64Map.set', function(x) {
+  let obj = this.get(x['id']);
+  if (obj.set_(x['key'], x['value'])) {
+    obj.changed.dispatch();
+  }
+});
+
+registerRPC('Uint64Map.delete', function(x) {
+  let obj = this.get(x['id']);
+  if (obj.delete_(x['key'])) {
+    obj.changed.dispatch();
+  }
+});
+
+registerRPC('Uint64Map.clear', function(x) {
+  let obj = this.get(x['id']);
+  if (obj.hashTable.clear()) {
+    obj.changed.dispatch();
+  }
+});

--- a/src/neuroglancer/uint64_set.spec.ts
+++ b/src/neuroglancer/uint64_set.spec.ts
@@ -1,0 +1,100 @@
+/**
+ * @license
+ * This work is a derivative of the Google Neuroglancer project,
+ * Copyright 2016 Google Inc.
+ * The Derivative Work is covered by
+ * Copyright 2019 Howard Hughes Medical Institute
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {Uint64Set} from 'neuroglancer/uint64_set';
+import {Uint64} from 'neuroglancer/util/uint64';
+
+describe('Uint64Set', () => {
+  it('basic', () => {
+    let s = new Uint64Set();
+
+    let v1 = new Uint64(1);
+    expect(s.has(v1)).toBe(false);
+    expect(s.size).toBe(0);
+    s.add(v1);
+    expect(s.has(v1)).toBe(true);
+    expect(s.size).toBe(1);
+
+    let v2 = new Uint64(2, 3);
+    expect(s.has(v2)).toBe(false);
+    s.add(v2);
+    expect(s.has(v1)).toBe(true);
+    expect(s.has(v2)).toBe(true);
+    expect(s.size).toBe(2);
+
+    let v1a = new Uint64(1);
+    s.add(v1a);
+    expect(s.has(v1)).toBe(true);
+    expect(s.has(v2)).toBe(true);
+    expect(s.has(v1a)).toBe(true);
+    expect(s.size).toBe(2);
+
+    s.delete(v1);
+    expect(s.has(v1)).toBe(false);
+    expect(s.has(v2)).toBe(true);
+    expect(s.size).toBe(1);
+
+    let v3 = new Uint64(3, 4);
+    expect(s.has(v3)).toBe(false);
+    s.add(v3);
+    expect(s.has(v1)).toBe(false);
+    expect(s.has(v2)).toBe(true);
+    expect(s.has(v3)).toBe(true);
+    expect(s.size).toBe(2);
+
+    s.clear();
+    expect(s.has(v1)).toBe(false);
+    expect(s.has(v2)).toBe(false);
+    expect(s.has(v3)).toBe(false);
+    expect(s.size).toBe(0);
+  });
+
+  it('iterate', () => {
+    let s = new Uint64Set();
+
+    let v1 = new Uint64(1);
+    let v2 = new Uint64(2, 3);
+    let v3 = new Uint64(3, 4);
+    s.add(v2);
+    s.add(v1);
+    s.add(v3);
+
+    let iterated = [];
+    for (let v of s) {
+      iterated.push(v.clone());
+    }
+    iterated.sort();
+    expect(iterated).toEqual([v1, v2, v3]);
+  });
+
+  it('toJSON', () => {
+    let s = new Uint64Set();
+
+    let v1 = new Uint64(1);
+    let v2 = new Uint64(2, 3);
+    let v3 = new Uint64(3, 4);
+    s.add(v2);
+    s.add(v1);
+    s.add(v3);
+
+    let json = s.toJSON();
+    expect(json).toEqual([v1.toString(), v2.toString(), v3.toString()]);
+  });
+});

--- a/src/neuroglancer/util/color.spec.ts
+++ b/src/neuroglancer/util/color.spec.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {parseColorSerialization, parseRGBColorSpecification, serializeColor} from 'neuroglancer/util/color';
+import {parseColorSerialization, parseRGBColorSpecification, packColor, serializeColor} from 'neuroglancer/util/color';
 import {vec3, vec4} from 'neuroglancer/util/geom';
 
 describe('color', () => {
@@ -36,5 +36,29 @@ describe('color', () => {
     expect(parseRGBColorSpecification('red')).toEqual(vec3.fromValues(1, 0, 0));
     expect(parseRGBColorSpecification('lime')).toEqual(vec3.fromValues(0, 1, 0));
     expect(parseRGBColorSpecification('blue')).toEqual(vec3.fromValues(0, 0, 1));
+  });
+
+  it('packColor works', () => {
+    expect(packColor(vec3.fromValues( 0,    0,    0  ))).toEqual(0x000000);
+    expect(packColor(vec3.fromValues( 0.2,  0,    1  ))).toEqual(0x3300ff);
+    expect(packColor(vec3.fromValues( 0,    0.4,  1.0))).toEqual(0x0066ff);
+    expect(packColor(vec3.fromValues( 0.6,  0.4,  0  ))).toEqual(0x996600);
+    expect(packColor(vec3.fromValues( 1,    0.6,  0.8))).toEqual(0xff99cc);
+    expect(packColor(vec3.fromValues( 1,    1,    1  ))).toEqual(0xffffff);
+
+    expect(packColor(vec3.fromValues(-1,    0,    0  ))).toEqual(0x000000);
+    expect(packColor(vec3.fromValues( 0,    0.2,  2  ))).toEqual(0x0033ff);
+    expect(packColor(vec3.fromValues( 0.4,  4.4, -0.4))).toEqual(0x66ff00);
+
+    expect(packColor(vec4.fromValues( 0,    0,    0,    0  ))).toEqual(0x00000000);
+    expect(packColor(vec4.fromValues( 0.2,  0,    1,    0.2))).toEqual(0x3300ff33);
+    expect(packColor(vec4.fromValues( 0,    0.4,  1.0,  0.4))).toEqual(0x0066ff66);
+    expect(packColor(vec4.fromValues( 0.6,  0.4,  0,    0.6))).toEqual(0x99660099);
+    expect(packColor(vec4.fromValues( 1,    0.6,  0.8,  0.8))).toEqual(0xff99cccc);
+    expect(packColor(vec4.fromValues( 1,    1,    1,    1  ))).toEqual(0xffffffff);
+
+    expect(packColor(vec4.fromValues(-1,    0,    0,   -1  ))).toEqual(0x00000000);
+    expect(packColor(vec4.fromValues( 0,    0.2,  2,    1  ))).toEqual(0x0033ffff);
+    expect(packColor(vec4.fromValues( 0.4,  4.4, -0.4,  4  ))).toEqual(0x66ff00ff);
   });
 });

--- a/src/neuroglancer/util/color.ts
+++ b/src/neuroglancer/util/color.ts
@@ -66,6 +66,21 @@ export function parseRGBColorSpecification(x: any) {
   return <vec3>result.subarray(0, 3);
 }
 
+/**
+ * Returns an integer formed by concatenating the channels of the input color vector.
+ * Each channel is clamped to the range [0.0, 1.0] before being converted to 8 bits.
+ * An RGB color is packed into 24 bits, and a RGBA into 32 bits.
+ */
+export function packColor(x: vec3|vec4): number {
+  const size = (x[3] === undefined) ? 3 : 4;
+  let result = 0;
+  for (let i = 0; i < size; i++) {
+    // The ">>> 0" ensures an unsigned value.
+    result = ((result << 8) >>> 0) + Math.min(255, Math.max(0, (Math.round(x[i] * 255))));
+  }
+  return result;
+}
+
 export function serializeColor(x: vec3|vec4) {
   if (x[3] === undefined || x[3] === 1) {
     let result = '#';


### PR DESCRIPTION
In our experience at Janelia, it is helpful for proofreading tools to have explicit control over the colors of bodies in the segmentation.  This code adds that capability to Neuroglancer.  The display state of a layer now can include a map like the following, making one body purple and another green:

"segmentColors": { "193125660": "#ff00ff", "206326381": “#00ff00” }

The implementation uses a new Uint64Map class that is quite similar to the Uint64Set class.  I added some unit tests for both of those classes.

For slice rendering, there is a new SegmentStatedColorShaderManager class that uses a HashMapShaderManager and adds shader code to find a segment’s explicit color if present.  For mesh rendering, the getObjectColor function now checks for the segment’s explicit color.