### PR TITLE
fix: allow copy pasting layer location in Firefox

### DIFF
--- a/src/neuroglancer/widget/autocomplete.ts
+++ b/src/neuroglancer/widget/autocomplete.ts
@@ -239,11 +239,11 @@ export class AutocompleteTextInput extends RefCounted {
   }
 
   get disabled() {
-    return this.inputElement.disabled;
+    return this.inputElement.readOnly;
   }
 
   set disabled(value: boolean) {
-    this.inputElement.disabled = value;
+    this.inputElement.readOnly = value;
   }
 
   private handleDropdownMousedown(event: MouseEvent) {


### PR DESCRIPTION
In Firefox, "disabled" disables any interaction with the
layer entry field whereas in Chrome it allows you to select
the text in the box -- a common workflow when using CloudVolume
to grab the layer path.

A standard property "readOnly" is available that works cross-browser.