### PR TITLE
fix some rendering issues on re: opacity slider

### DIFF
--- a/src/neuroglancer/image_user_layer.css
+++ b/src/neuroglancer/image_user_layer.css
@@ -26,6 +26,17 @@
   align-items: center;
 }
 
+/* for the ? button next to the opacity slider */
+.image-dropdown-top-row a > button {
+  font-weight: bold;
+  margin-right: 2px;
+  margin-left: 2px;
+  width: 20px;
+  padding: 0px;
+  border-left: 2px;
+  border-right: 2px;
+}
+
 /* .image-dropdown-top-row .range-slider {
   flex: 1;
 } */

--- a/src/neuroglancer/image_user_layer.ts
+++ b/src/neuroglancer/image_user_layer.ts
@@ -119,6 +119,7 @@ class RenderingOptionsTab extends Tab {
     let topRow = document.createElement('div');
     topRow.className = 'image-dropdown-top-row';
     opacityWidget.promptElement.textContent = 'Opacity';
+    opacityWidget.numericInputElement.style.display="None";
 
     {
       const renderScaleWidget = this.registerDisposer(new RenderScaleWidget(

--- a/src/neuroglancer/image_user_layer.ts
+++ b/src/neuroglancer/image_user_layer.ts
@@ -119,7 +119,7 @@ class RenderingOptionsTab extends Tab {
     let topRow = document.createElement('div');
     topRow.className = 'image-dropdown-top-row';
     opacityWidget.promptElement.textContent = 'Opacity';
-    opacityWidget.numericInputElement.style.display="None";
+    opacityWidget.numericInputElement.style.width="45px";
 
     {
       const renderScaleWidget = this.registerDisposer(new RenderScaleWidget(

--- a/src/neuroglancer/maximize_button.css
+++ b/src/neuroglancer/maximize_button.css
@@ -18,4 +18,8 @@
   font-weight: bold;
   margin-right: 2px;
   margin-left: 2px;
+  width: 20px;
+  padding: 0px;
+  border-left: 2px;
+  border-right: 2px;
 }

--- a/src/neuroglancer/widget/range.css
+++ b/src/neuroglancer/widget/range.css
@@ -22,5 +22,6 @@
 }
 
 .range-slider input[type='range'] {
+  width: 129px;
 }
 


### PR DESCRIPTION
In the right pane when editing a layer I see a rendering bug on the opacity slider.

I'm on Arch Linux/Gnome. Possibly fine on Windows/Mac

in Chrome seems fine:
![image](https://user-images.githubusercontent.com/653031/65274756-158cca80-daf2-11e9-818c-43a5b6dd4620.png)

on Firefox, the slider is too long, and the additional text inputs push the other buttons completely off:
![image](https://user-images.githubusercontent.com/653031/65274574-9f886380-daf1-11e9-99d2-d38bd66b9b62.png)

The attached solution "fixes" the layout problem (for me) by hiding the text input and forcing the slider to be a "sane" width.  I'm not sure if the new text input was desired, so it's possible this fix needs additional work if we don't want to hide the input box.

Chrome:
![image](https://user-images.githubusercontent.com/653031/65274721-0443be00-daf2-11e9-9409-ce63c3df2c46.png)

Firefox:
![image](https://user-images.githubusercontent.com/653031/65274702-f8f09280-daf1-11e9-859b-c9f117922d81.png)

Also, I noticed that neuroglancer-demo.appspot.com doesn't seem to be running "master" at the moment.

If the input numeric dialog is desired, we could just set `opacityWidget.numericInputElement.style.width="50px";` instead of `display None`.  However, the buttons in Firefox/Gnome need to be made smaller.  I struggled with that for a while until I gave up for this simpler solution.