### PR TITLE
feat(datasource/precomputed): Layer redirection

### DIFF
--- a/src/neuroglancer/datasource/index.ts
+++ b/src/neuroglancer/datasource/index.ts
@@ -28,6 +28,12 @@ import {Owned, RefCounted} from 'neuroglancer/util/disposable';
 
 export type Completion = CompletionWithDescription;
 
+export class RedirectError extends Error {
+  constructor(public redirect_target: string) {
+    super(`Redirected to: ${redirect_target}`);
+  }
+}
+
 export interface CompletionResult {
   offset: number;
   completions: Completion[];
@@ -139,15 +145,32 @@ export class DataSourceProvider extends RefCounted {
 
   getVolume(
       chunkManager: ChunkManager, url: string, options: GetVolumeOptions = {},
-      cancellationToken = uncancelableToken) {
+      cancellationToken = uncancelableToken,
+      redirect_log = new Set<string>()): Promise<MultiscaleVolumeChunkSource> {
     let [dataSource, path] = this.getDataSource(url);
     if (options === undefined) {
       options = {};
     }
     options.dataSourceProvider = this;
+    redirect_log.add(url);
     return new Promise<MultiscaleVolumeChunkSource>(resolve => {
-      resolve(dataSource.getVolume!(chunkManager, path, options, cancellationToken));
-    });
+             resolve(dataSource.getVolume!(chunkManager, path, options, cancellationToken));
+           })
+        .catch((err: Error) => {
+          if (err instanceof RedirectError) {
+            const redirect = err.redirect_target;
+            if (redirect_log.has(redirect)) {
+              throw Error('Layer source redirection contains loop.');
+            }
+            if (redirect_log.size >= 10) {
+              throw Error('Too many layer source redirections.');
+            }
+            return this.getVolume!
+                (chunkManager, redirect, options, cancellationToken, redirect_log);
+          } else {
+            throw err;
+          }
+        });
   }
 
   getAnnotationSource(

--- a/src/neuroglancer/datasource/precomputed/frontend.ts
+++ b/src/neuroglancer/datasource/precomputed/frontend.ts
@@ -16,7 +16,7 @@
 
 import {AnnotationSource, makeDataBoundsBoundingBox} from 'neuroglancer/annotation';
 import {ChunkManager, WithParameters} from 'neuroglancer/chunk_manager/frontend';
-import {DataSource} from 'neuroglancer/datasource';
+import {DataSource, RedirectError} from 'neuroglancer/datasource';
 import {DataEncoding, MeshSourceParameters, MultiscaleMeshMetadata, MultiscaleMeshSourceParameters, ShardingHashFunction, ShardingParameters, SkeletonMetadata, SkeletonSourceParameters, VolumeChunkEncoding, VolumeChunkSourceParameters} from 'neuroglancer/datasource/precomputed/base';
 import {VertexPositionFormat} from 'neuroglancer/mesh/base';
 import {MeshSource, MultiscaleMeshSource} from 'neuroglancer/mesh/frontend';
@@ -121,6 +121,10 @@ export class MultiscaleVolumeChunkSource implements GenericMultiscaleVolumeChunk
 
   constructor(public chunkManager: ChunkManager, public url: string, obj: any) {
     verifyObject(obj);
+    const redirect = verifyObjectProperty(obj, 'redirect', verifyOptionalString);
+    if (redirect !== undefined) {
+      throw new RedirectError(redirect);
+    }
     const t = verifyObjectProperty(obj, '@type', verifyOptionalString);
     if (t !== undefined && t !== 'neuroglancer_multiscale_volume') {
       throw new Error(`Invalid type: ${JSON.stringify(t)}`);


### PR DESCRIPTION
This PR adds support for a new key `redirect` to the precomputed info file. If specified, it will work as an automatic layer source redirection. This is useful in order to forward users who use old, bookmarked links to newer versions / formats of the specified layer.

Throws an error if more than 10 redirects occur, or a cycle is detected.
Works for loading existing links, as well as when trying to add layers via the layer dialog.