### PR TITLE
feat(datasource/dvid): add point annotation functions for DVID

### DIFF
--- a/src/neuroglancer/datasource/dvid/api.ts
+++ b/src/neuroglancer/datasource/dvid/api.ts
@@ -1,0 +1,47 @@
+import {CancellationToken, uncancelableToken} from 'neuroglancer/util/cancellation';
+import {responseJson, cancellableFetchOk} from 'neuroglancer/util/http_request';
+
+export interface HttpCall {
+  method: 'GET' | 'POST' | 'DELETE';
+  path: string;
+  payload?: string;
+}
+
+export class DVIDInstance {
+  constructor(public baseUrl: string, public nodeKey: string) {}
+
+  getNodeApiUrl(): string {
+    return `${this.baseUrl}/api/node/${this.nodeKey}`;
+  }
+}
+
+function responseText(response: Response): Promise<any> {
+  return response.text();
+}
+
+export function makeRequest(
+  instance: DVIDInstance,
+  httpCall: HttpCall & { responseType: 'arraybuffer' },
+  cancellationToken?: CancellationToken): Promise<ArrayBuffer>;
+
+export function makeRequest(
+  instance: DVIDInstance,
+  httpCall: HttpCall & { responseType: 'json' }, cancellationToken?: CancellationToken): Promise<any>;
+
+export function makeRequest(
+  instance: DVIDInstance,
+  httpCall: HttpCall & { responseType: '' }, cancellationToken?: CancellationToken): Promise<any>;
+
+export function makeRequest(
+  instance: DVIDInstance,
+  httpCall: HttpCall & { responseType: XMLHttpRequestResponseType },
+  cancellationToken: CancellationToken = uncancelableToken): any {
+    let requestInfo = `${instance.getNodeApiUrl()}${httpCall.path}`;
+    let init = { method: httpCall.method, body: httpCall.payload };
+
+    if (httpCall.responseType === '') {
+      return cancellableFetchOk(requestInfo, init, responseText, cancellationToken);
+    } else {
+      return cancellableFetchOk(requestInfo, init, responseJson, cancellationToken);
+    }
+}

--- a/src/neuroglancer/datasource/dvid/backend.ts
+++ b/src/neuroglancer/datasource/dvid/backend.ts
@@ -15,7 +15,7 @@
  */
 
 import {WithParameters} from 'neuroglancer/chunk_manager/backend';
-import {MeshSourceParameters, SkeletonSourceParameters, VolumeChunkEncoding, VolumeChunkSourceParameters} from 'neuroglancer/datasource/dvid/base';
+import {AnnotationSourceParameters, MeshSourceParameters, SkeletonSourceParameters, VolumeChunkEncoding, VolumeChunkSourceParameters} from 'neuroglancer/datasource/dvid/base';
 import {assignMeshFragmentData, decodeTriangleVertexPositionsAndIndices, FragmentChunk, ManifestChunk, MeshSource} from 'neuroglancer/mesh/backend';
 import {SkeletonChunk, SkeletonSource} from 'neuroglancer/skeleton/backend';
 import {decodeSwcSkeletonChunk} from 'neuroglancer/skeleton/decode_swc_skeleton';
@@ -25,7 +25,16 @@ import {VolumeChunk, VolumeChunkSource} from 'neuroglancer/sliceview/volume/back
 import {CancellationToken} from 'neuroglancer/util/cancellation';
 import {Endianness} from 'neuroglancer/util/endian';
 import {cancellableFetchOk, responseArrayBuffer} from 'neuroglancer/util/http_request';
-import {registerSharedObject} from 'neuroglancer/worker_rpc';
+import {registerSharedObject, SharedObject, RPC} from 'neuroglancer/worker_rpc';
+import {vec3} from 'neuroglancer/util/geom';
+import {Uint64} from 'neuroglancer/util/uint64';
+import {DVIDInstance, makeRequest} from 'neuroglancer/datasource/dvid/api';
+import {DVIDPointAnnotation, updateAnnotationTypeHandler} from 'neuroglancer/datasource/dvid/utils';
+import {Annotation, AnnotationId, AnnotationSerializer, AnnotationType} from 'neuroglancer/annotation';
+import {AnnotationGeometryChunk, AnnotationGeometryData, AnnotationMetadataChunk, AnnotationSource, AnnotationSubsetGeometryChunk} from 'neuroglancer/annotation/backend';
+import {verifyObject, verifyObjectProperty, verifyOptionalString, parseIntVec} from 'neuroglancer/util/json';
+import {ChunkSourceParametersConstructor} from 'neuroglancer/chunk_manager/base';
+
 
 @registerSharedObject() export class DVIDSkeletonSource extends
 (WithParameters(SkeletonSource, SkeletonSourceParameters)) {
@@ -121,5 +130,245 @@ export function decodeFragmentChunk(chunk: FragmentChunk, response: ArrayBuffer)
       // encoding is COMPRESSED_SEGMENTATION
       return decodeCompressedSegmentationChunk;
     }
+  }
+}
+
+export function parseUint64ToArray(out: Uint64[], v: string): Uint64[] {
+  if (v) {
+    out.push(Uint64.parseString(v));
+  }
+
+  return out;
+}
+
+function parseAnnotation(entry: any): DVIDPointAnnotation|null {
+  const properties = verifyObjectProperty(entry, 'Prop', verifyObject);
+
+  let isCustom = false;
+  if (properties.custom) {
+    isCustom = (properties.custom === '1');
+  }
+  if (isCustom) {
+    const corner = verifyObjectProperty(entry, 'Pos', x => parseIntVec(vec3.create(), x));
+    const description = verifyObjectProperty(properties, 'comment', verifyOptionalString);
+    const segments = verifyObjectProperty(properties, 'body ID', x => parseUint64ToArray(Array<Uint64>(), x));
+
+    return {
+      type: AnnotationType.POINT,
+      id: `${corner[0]}_${corner[1]}_${corner[2]}`,
+      point: corner,
+      description,
+      segments,
+      properties
+    };
+  } else {
+    return null;
+  }
+}
+
+function parseAnnotations(
+    chunk: AnnotationGeometryChunk|AnnotationSubsetGeometryChunk, responses: any[]) {
+  const serializer = new AnnotationSerializer();
+
+  responses.forEach((response) => {
+    try {
+      let annotation = parseAnnotation(response);
+      if (annotation) {
+        serializer.add(annotation);
+      }
+    } catch (e) {
+      throw new Error(`Error parsing annotation: ${e.message}`);
+    }
+  });
+  chunk.data = Object.assign(new AnnotationGeometryData(), serializer.serialize());
+}
+
+function DVIDSource<Parameters, TBase extends {new (...args: any[]): SharedObject}>(
+  Base: TBase, parametersConstructor: ChunkSourceParametersConstructor<Parameters>) {
+  return WithParameters(Base, parametersConstructor);
+}
+
+function annotationToDVID(annotation: DVIDPointAnnotation, user: string|undefined): any {
+  const payload = annotation.description || '';
+  const objectLabels =
+      annotation.segments === undefined ? undefined : annotation.segments.map(x => x.toString());
+  switch (annotation.type) {
+    case AnnotationType.POINT: {
+      let obj: {[key: string]: any} = {
+        Kind: 'Note',
+        Pos: [annotation.point[0], annotation.point[1], annotation.point[2]],
+        Prop: {
+          comment: payload
+        }
+      };
+      if (annotation.properties) {
+        if (annotation.properties.custom) {
+          obj['Prop']['custom'] = annotation.properties.custom;
+        }
+        if (annotation.properties.type) {
+          obj['Prop']['type'] = annotation.properties.type;
+        }
+      }
+      if (objectLabels && objectLabels.length > 0) {
+        obj['Prop']['body ID'] = objectLabels[0];
+      }
+      if (user) {
+        obj['Tags'] = ['user:' + user];
+        obj['Prop']['user'] = user;
+      }
+      return obj;
+    }
+  }
+}
+
+@registerSharedObject() export class DVIDAnnotationSource extends (DVIDSource(AnnotationSource, AnnotationSourceParameters)) {
+  constructor(rpc: RPC, options: any) {
+    super(rpc, options);
+    updateAnnotationTypeHandler();
+  }
+
+  getPath(position: ArrayLike<number>, size: ArrayLike<number>): string {
+    return `/bookmark_annotations/elements/${size[0]}_${size[1]}_${size[2]}/${position[0]}_${position[1]}_${position[2]}`;
+  }
+
+  getPathByUserTag(user: string) {
+    return `/bookmark_annotations/tag/user:${user}`;
+  }
+
+  getPathByBodyId(bodyId: Uint64) {
+    return `/bookmark_annotations/label/${bodyId}`;
+  }
+
+  getPathByBodyAnnotationId(annotationId: string) {
+    return `/bookmark_annotations/elements/1_1_1/${annotationId}`;
+  }
+
+  downloadGeometry(chunk: AnnotationGeometryChunk, cancellationToken: CancellationToken) {
+    const {parameters} = this;
+
+    if (parameters.user) {
+      return makeRequest(
+        new DVIDInstance(parameters.baseUrl, parameters.nodeKey), {
+          method: 'GET',
+          path: this.getPathByUserTag(parameters.user),
+          payload: undefined,
+          responseType: 'json',
+        },
+        cancellationToken)
+        .then(values => {
+          parseAnnotations(chunk, values);
+        });
+    } else {
+      let instance = new DVIDInstance(parameters.baseUrl, parameters.nodeKey);
+      return makeRequest(instance, {
+        method: 'GET',
+        path: `/${parameters.dataInstanceKey}/info`,
+        payload: undefined,
+        responseType: 'json',
+      }).then(response => {
+        let extended = verifyObjectProperty(response, 'Extended', verifyObject);
+        let lowerVoxelBound = verifyObjectProperty(extended, 'MinPoint', x => parseIntVec(vec3.create(), x));
+        let upperVoxelBound = verifyObjectProperty(extended, 'MaxPoint', x => parseIntVec(vec3.create(), x));
+
+        let chunkPosition = lowerVoxelBound;
+        let chunkDataSize = vec3.subtract(vec3.create(), upperVoxelBound, lowerVoxelBound);
+
+        return makeRequest(
+          new DVIDInstance(parameters.baseUrl, parameters.nodeKey), {
+            method: 'GET',
+            path: this.getPath(chunkPosition, chunkDataSize),
+            payload: undefined,
+            responseType: 'json',
+          },
+          cancellationToken)
+          .then(values => {
+            parseAnnotations(chunk, values);
+          });
+      });
+    }
+  }
+
+  downloadSegmentFilteredGeometry(
+    chunk: AnnotationSubsetGeometryChunk, cancellationToken: CancellationToken) {
+    const { parameters } = this;
+
+    return makeRequest(
+      new DVIDInstance(parameters.baseUrl, parameters.nodeKey), {
+        method: 'GET',
+        path: this.getPathByBodyId(chunk.objectId),
+        payload: undefined,
+        responseType: 'json',
+      },
+      cancellationToken)
+      .then(values => {
+        parseAnnotations(chunk, values);
+      });
+  }
+
+  downloadMetadata(chunk: AnnotationMetadataChunk, cancellationToken: CancellationToken) {
+    const { parameters } = this;
+    const id = chunk.key!;
+    return makeRequest(
+      new DVIDInstance(parameters.baseUrl, parameters.nodeKey), {
+        method: 'GET',
+        path: this.getPathByBodyAnnotationId(id),
+        payload: undefined,
+        responseType: 'json',
+      },
+      cancellationToken)
+      .then(response => {
+        if (response.length > 0) {
+          chunk.annotation = parseAnnotation(response[0]);
+        } else {
+          chunk.annotation = null;
+        }
+      },
+        () => {
+          chunk.annotation = null;
+        });
+  }
+
+  add(annotation: Annotation) {
+    const { parameters } = this;
+
+    const dvidAnnotation = annotationToDVID(<DVIDPointAnnotation>annotation, parameters.user);
+
+    if (annotation.type === AnnotationType.POINT) {
+    return makeRequest(
+      new DVIDInstance(parameters.baseUrl, parameters.nodeKey), {
+      method: 'POST',
+      path: '/bookmark_annotations/elements',
+      payload: JSON.stringify([dvidAnnotation]),
+      responseType: '',
+    })
+      .then(() => {
+          return `${annotation.point[0]}_${annotation.point[1]}_${annotation.point[2]}`;
+      });
+    } else {
+      return Promise.resolve(`${annotation.type}_${JSON.stringify(annotation)}`);
+    }
+  }
+
+  update(_: AnnotationId, annotation: Annotation) {
+    const {parameters} = this;
+    const dvidAnnotation = annotationToDVID(<DVIDPointAnnotation>annotation, parameters.user);
+    return makeRequest(
+      new DVIDInstance(parameters.baseUrl, parameters.nodeKey), {
+             method: 'POST',
+             path: '/bookmark_annotations/elements',
+             payload: JSON.stringify([dvidAnnotation]),
+             responseType: '',
+           });
+  }
+
+  delete (id: AnnotationId) {
+    const {parameters} = this;
+    return makeRequest(
+      new DVIDInstance(parameters.baseUrl, parameters.nodeKey), {
+             method: 'DELETE',
+             path: `/bookmark_annotations/element/${id}`,
+             payload: undefined,
+             responseType: '',
+           });
   }
 }

--- a/src/neuroglancer/datasource/dvid/base.ts
+++ b/src/neuroglancer/datasource/dvid/base.ts
@@ -25,6 +25,7 @@ export class DVIDSourceParameters {
   baseUrl: string;
   nodeKey: string;
   dataInstanceKey: string;
+  user?: string;
 }
 
 export class VolumeChunkSourceParameters extends DVIDSourceParameters {
@@ -39,4 +40,8 @@ export class SkeletonSourceParameters extends DVIDSourceParameters {
 
 export class MeshSourceParameters extends DVIDSourceParameters {
   static RPC_ID = 'dvid/MeshSource';
+}
+
+export class AnnotationSourceParameters extends DVIDSourceParameters {
+  static RPC_ID = 'dvid/Annotation';
 }

--- a/src/neuroglancer/datasource/dvid/utils.ts
+++ b/src/neuroglancer/datasource/dvid/utils.ts
@@ -1,0 +1,195 @@
+/**
+ * @license
+ * This work is a derivative of the Google Neuroglancer project,
+ * Copyright 2016 Google Inc.
+ * The Derivative Work is covered by
+ * Copyright 2019 Howard Hughes Medical Institute
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {AnnotationRenderContext, AnnotationRenderHelper, getAnnotationTypeRenderHandler} from 'neuroglancer/annotation/type_handler';
+import {AnnotationType, getAnnotationTypeHandler} from 'neuroglancer/annotation';
+import {CircleShader} from 'neuroglancer/webgl/circles';
+import {emitterDependentShaderGetter, ShaderBuilder} from 'neuroglancer/webgl/shader';
+import {Point} from 'neuroglancer/annotation/index';
+import {StringMemoize} from 'neuroglancer/util/memoize';
+
+let EnvMemoize = new StringMemoize();
+
+export let Env = {
+    getUser: function () {
+        return EnvMemoize.getUncounted(
+            'user', () => prompt('User:') || '');
+    }
+};
+
+export interface DVIDPointAnnotation extends Point {
+  properties?: {[key:string]: any};
+}
+
+function getRenderingAttribute(annotation: Point): number {
+  let {properties} = <DVIDPointAnnotation>annotation;
+  if (properties) {
+    if (properties.checked) {
+      if (properties.checked === '1') {
+        return 1;
+      }
+    }
+    if (properties.type) {
+      if (properties.type === 'Merge') {
+        return 2;
+      } else if (properties.type === 'Split') {
+        return 3;
+      }
+    }
+  }
+
+  return 0;
+}
+
+const numDVIDPointAnnotationElements = 4;
+
+function DVIDPointAnnotationSerializer(buffer: ArrayBuffer, offset: number, numAnnotations: number) {
+  const coordinates = new Float32Array(buffer, offset, numAnnotations * numDVIDPointAnnotationElements);
+  return (annotation: Point, index: number) => {
+    const {point} = annotation;
+    const coordinateOffset = index * numDVIDPointAnnotationElements;
+    coordinates[coordinateOffset] = point[0];
+    coordinates[coordinateOffset + 1] = point[1];
+    coordinates[coordinateOffset + 2] = point[2];
+    coordinates[coordinateOffset + 3] = getRenderingAttribute(annotation);
+  };
+}
+
+export function updateAnnotationTypeHandler() {
+  let typeHandler = getAnnotationTypeHandler(AnnotationType.POINT);
+  typeHandler.serializer = DVIDPointAnnotationSerializer;
+  typeHandler.serializedBytes = numDVIDPointAnnotationElements * 4;
+}
+
+function setFillColor(builder: ShaderBuilder) {
+  let s = `
+vec3 rgb2hsv(vec3 c)
+{
+    vec4 K = vec4(0.0, -1.0 / 3.0, 2.0 / 3.0, -1.0);
+    vec4 p = mix(vec4(c.bg, K.wz), vec4(c.gb, K.xy), step(c.b, c.g));
+    vec4 q = mix(vec4(p.xyw, c.r), vec4(c.r, p.yzx), step(p.x, c.r));
+
+    float d = q.x - min(q.w, q.y);
+    float e = 1.0e-10;
+    return vec3(abs(q.z + (q.w - q.y) / (6.0 * d + e)), d / (q.x + e), q.x);
+}
+
+vec3 hsv2rgb(vec3 c)
+{
+    vec4 K = vec4(1.0, 2.0 / 3.0, 1.0 / 3.0, 3.0);
+    vec3 p = abs(fract(c.xxx + K.xyz) * 6.0 - K.www);
+    return c.z * mix(K.xxx, clamp(p - K.xxx, 0.0, 1.0), c.y);
+}
+
+void setFillColor() {
+  if (vRenderingAttribute >= 1 && vRenderingAttribute <= 3) {
+    vec3 hsv = rgb2hsv(vColor.rgb);
+    if (vRenderingAttribute == 1) {
+      vColor.rgb = vec3(0.0, 1.0, 0.0);
+    } else if (vRenderingAttribute == 2) {
+      vColor.rgb = hsv2rgb(vec3(mod(hsv.x - 0.1, 1.0), 1.0, hsv.z));
+    } else if (vRenderingAttribute == 3) {
+      vColor.rgb = hsv2rgb(vec3(mod(hsv.x - 0.3, 1.0), 1.0, hsv.z));
+    }
+  }
+}
+`;
+  builder.addVertexCode(s);
+  return `setFillColor()`;
+}
+
+function getBorderColor(builder: ShaderBuilder) {
+  let s = `
+vec4 getBorderColor() {
+  vec4 borderColor = vec4(0.0, 0.0, 0.0, 1.0);
+  if (vRenderingAttribute == 2) {
+    borderColor = vec4(1.0, 0.0, 0.0, 1.0);
+  } else if (vRenderingAttribute == 3) {
+    borderColor = vec4(0.0, 0.0, 1.0, 1.0);
+  } else if (vRenderingAttribute == 1) {
+    borderColor = vec4(0.0, 1.0, 0.0, 1.0);
+  }
+  return borderColor;
+}
+  `;
+
+  builder.addFragmentCode(s);
+  return `getBorderColor()`;
+}
+
+class DVIDRenderHelper extends AnnotationRenderHelper {
+  private circleShader = this.registerDisposer(new CircleShader(this.gl));
+  private shaderGetter =
+      emitterDependentShaderGetter(this, this.gl, (builder: ShaderBuilder) => this.defineShader(builder));
+
+  defineShader(builder: ShaderBuilder) {
+    super.defineShader(builder);
+    this.circleShader.defineShader(builder, /*crossSectionFade=*/this.targetIsSliceView);
+    // Position of point in camera coordinates.
+    builder.addAttribute('highp vec3', 'aVertexPosition');
+    builder.addAttribute('highp float', 'aRenderingAttribute');
+    builder.addVarying('int', 'vRenderingAttribute', 'flat');
+    builder.setVertexMain(`
+emitCircle(uProjection * vec4(aVertexPosition, 1.0));
+${this.setPartIndex(builder)};
+vRenderingAttribute = int(aRenderingAttribute);
+${setFillColor(builder)};
+`);
+    builder.setFragmentMain(`
+vec4 borderColor = ${getBorderColor(builder)};
+emitAnnotation(getCircleColor(vColor, borderColor));
+`);
+  }
+
+  draw(context: AnnotationRenderContext) {
+    const shader = this.shaderGetter(context.renderContext.emitter);
+    this.enable(shader, context, () => {
+      const {gl} = this;
+      const aVertexPosition = shader.attribute('aVertexPosition');
+      const aRenderingAttribute = shader.attribute('aRenderingAttribute');
+      context.buffer.bindToVertexAttrib(
+          aVertexPosition, /*components=*/3, /*attributeType=*/WebGL2RenderingContext.FLOAT,
+          /*normalized=*/false,
+          /*stride=*/numDVIDPointAnnotationElements * 4, /*offset=*/context.bufferOffset);
+      context.buffer.bindToVertexAttrib(
+        aRenderingAttribute, /*components=*/1, /*attributeType=*/WebGL2RenderingContext.FLOAT,
+        /*normalized=*/false,
+        /*stride=*/numDVIDPointAnnotationElements * 4, /*offset=*/context.bufferOffset + 3 * 4);
+      gl.vertexAttribDivisor(aVertexPosition, 1);
+      gl.vertexAttribDivisor(aRenderingAttribute, 1);
+      this.circleShader.draw(
+          shader, context.renderContext,
+          {interiorRadiusInPixels: 6, borderWidthInPixels: 2, featherWidthInPixels: 1},
+          context.count);
+      gl.vertexAttribDivisor(aRenderingAttribute, 0);
+      gl.vertexAttribDivisor(aVertexPosition, 0);
+      gl.disableVertexAttribArray(aVertexPosition);
+      gl.disableVertexAttribArray(aRenderingAttribute);
+    });
+  }
+}
+
+export function updateRenderHelper() {
+  let renderHandler = getAnnotationTypeRenderHandler(AnnotationType.POINT);
+  renderHandler.bytes = numDVIDPointAnnotationElements * 4;
+  renderHandler.serializer = DVIDPointAnnotationSerializer;
+  renderHandler.sliceViewRenderHelper = DVIDRenderHelper;
+  renderHandler.perspectiveViewRenderHelper = DVIDRenderHelper;
+}


### PR DESCRIPTION
This PR adds basic features for fetching, displaying and editing DVID bookmark annotations. It only involves changes in datasource/DVID, including:

1. Frontend DVIDAnnotationSource class for handling parameter parsing and point annotation creation. It will ask the user to specify in a user name to fetch annotations with a certain user tag. We do have more changes to handle annotations without tags by using multiscale chunks, but in this PR we decided to include tag-based annotation only.

2. Backend annotation fetching and parsing functions and DVIDAnnotationSource class designed for our own bookmark JSON format.

3. Helper functions in datasource/dvid/api.ts and datasource/dvid/utils.ts, including those for handling special properties in DVID bookmarks, which are instantiated the DVIDPointAnnotation class. The DVIDPointAnnotation class extends from Point to have additional properties. The helper functions will parse these additional properties and render annotations accordingly with our own shaders.

According to our testing, these changes do not affect any other functions in Neuroglancer if no DVID annotation layer is specified.