### PR TITLE
feat: @type 'neuroglancer_legacy_mesh' triggers legacy mesh format

### DIFF
--- a/src/neuroglancer/datasource/precomputed/README.md
+++ b/src/neuroglancer/datasource/precomputed/README.md
@@ -171,7 +171,7 @@ The actual storage of the manifest and mesh fragment data depends on whether the
 
 The `info` file is a JSON-format text file.  The root value must be a JSON object with the following
 members:
-- `"@type"`: Must be `"neuroglancer_multilod_draco"`.
+- `"@type"`: Must be `"neuroglancer_multilod_draco"` or `"neuroglancer_legacy_mesh"`.
 - `"vertex_quantization_bits"`: Specifies the number of bits needed to represent each vertex
   position coordinate within a mesh fragment.  Must be `10` or `16`.
 - `"transform"`: JSON array of 12 numbers specifying a 4x3 homogeneous coordinate transform from the
@@ -254,7 +254,7 @@ and the sum of the mesh fragment sizes specified in the manifest.
 ## Legacy single-resolution mesh format
 
 In addition to the multi-resolution mesh format, an older single-resolution mesh format is also
-supported.
+supported. Legacy format processing is specified by either the absence of an `info` file in the mesh subdirectory or an info file containing `"@type": "neuroglancer_legacy_mesh"` as one of the dictionary keys.
 
 The surface mesh representation for a given segmented object may be split into one or more separate
 fragments (e.g. corresponding to subvolumes).

--- a/src/neuroglancer/datasource/precomputed/README.md
+++ b/src/neuroglancer/datasource/precomputed/README.md
@@ -171,7 +171,7 @@ The actual storage of the manifest and mesh fragment data depends on whether the
 
 The `info` file is a JSON-format text file.  The root value must be a JSON object with the following
 members:
-- `"@type"`: Must be `"neuroglancer_multilod_draco"` or `"neuroglancer_legacy_mesh"`.
+- `"@type"`: Must be `"neuroglancer_multilod_draco"`.
 - `"vertex_quantization_bits"`: Specifies the number of bits needed to represent each vertex
   position coordinate within a mesh fragment.  Must be `10` or `16`.
 - `"transform"`: JSON array of 12 numbers specifying a 4x3 homogeneous coordinate transform from the

--- a/src/neuroglancer/datasource/precomputed/frontend.ts
+++ b/src/neuroglancer/datasource/precomputed/frontend.ts
@@ -239,10 +239,13 @@ function parseTransform(data: any): mat4 {
   });
 }
 
-function parseMeshMetadata(data: any): MultiscaleMeshMetadata {
+function parseMeshMetadata(data: any): MultiscaleMeshMetadata|undefined {
   verifyObject(data);
   const t = verifyObjectProperty(data, '@type', verifyString);
-  if (t !== 'neuroglancer_multilod_draco') {
+  if (t === 'neuroglancer_legacy_mesh') {
+    return undefined; 
+  }
+  else if (t !== 'neuroglancer_multilod_draco') {
     throw new Error(`Unsupported mesh type: ${JSON.stringify(t)}`);
   }
   const lodScaleMultiplier =
@@ -260,7 +263,7 @@ async function getMeshMetadata(
   try {
     metadata = await getJsonMetadata(chunkManager, url);
   } catch (e) {
-    if (e instanceof HttpError && e.status === 404) {
+    if (e instanceof HttpError && (e.status === 404 || e.status === 403)) {
       // If we fail to fetch the info file, assume it is the legacy
       // single-resolution mesh format.
       return undefined;


### PR DESCRIPTION
Currently, neuroglancer treats missing mesh info files as legacy
format, but we found that it is necessary to add some attributes
to mesh info files in order to deduplicate chunk boundaries. However,
this leaves us with no way to read legacy formats. Thus, we add
neuroglancer_legacy_mesh as an explicit type to enable continued use.