### PR TITLE
feat(datasource/dvid): add credentials support for DVID datasource

### DIFF
--- a/src/neuroglancer/datasource/dvid/base.ts
+++ b/src/neuroglancer/datasource/dvid/base.ts
@@ -25,6 +25,8 @@ export class DVIDSourceParameters {
   baseUrl: string;
   nodeKey: string;
   dataInstanceKey: string;
+  authServer?: string;
+  user?: string;
 }
 
 export class VolumeChunkSourceParameters extends DVIDSourceParameters {

--- a/src/neuroglancer/datasource/dvid/register_default.ts
+++ b/src/neuroglancer/datasource/dvid/register_default.ts
@@ -17,4 +17,4 @@
 import {DVIDDataSource} from 'neuroglancer/datasource/dvid/frontend';
 import {registerProvider} from 'neuroglancer/datasource/default_provider';
 
-registerProvider('dvid', () => new DVIDDataSource());
+registerProvider('dvid', options => new DVIDDataSource(options.credentialsManager));


### PR DESCRIPTION
This PR adds credentials support for fetching data from DVID. In the current DVID implementation, the default entry point of getting an auto token is <baseUrl>/api/server/token, which is necessary for any DVID server with the https protocol. We also allow the user to set up an auth server in the source url through query strings in case different auth servers are used. Note that DVID does not provide the login process, which must be done through a separate server. We assume that it has the same domain as the auth server and has the pattern 'https://flyemlogin.[domain]/login'. This PR should not affect any DVID layers without auth settings like before.