### PR TITLE
Remove tornado<6 dep constraint

### DIFF
--- a/python/neuroglancer/server.py
+++ b/python/neuroglancer/server.py
@@ -33,7 +33,7 @@ import sockjs.tornado
 try:
     # Newer versions of tornado do not have the asynchronous decorator
     from sockjs.tornado.util import asynchronous
-except (ImportError, ModuleNotFoundError):
+except ImportError:
     from tornado.web import asynchronous
 
 from . import local_volume, static

--- a/python/neuroglancer/server.py
+++ b/python/neuroglancer/server.py
@@ -29,8 +29,12 @@ import tornado.netutil
 import tornado.web
 
 import sockjs.tornado
-from sockjs.tornado.util import asynchronous
 
+try:
+    # Newer versions of tornado do not have the asynchronous decorator
+    from sockjs.tornado.util import asynchronous
+except (ImportError, ModuleNotFoundError):
+    from tornado.web import asynchronous
 
 from . import local_volume, static
 from . import skeleton

--- a/python/neuroglancer/server.py
+++ b/python/neuroglancer/server.py
@@ -29,6 +29,7 @@ import tornado.netutil
 import tornado.web
 
 import sockjs.tornado
+from sockjs.tornado.util import asynchronous
 
 
 from . import local_volume, static
@@ -146,7 +147,7 @@ class SkeletonInfoHandler(BaseRequestHandler):
         self.finish(json.dumps(vol.info(), default=json_encoder_default).encode())
 
 class SubvolumeHandler(BaseRequestHandler):
-    @tornado.web.asynchronous
+    @asynchronous
     def get(self, data_format, token, scale_key, start, end):
         start_pos = np.array(start.split(','), dtype=np.int64)
         end_pos = np.array(end.split(','), dtype=np.int64)
@@ -172,7 +173,7 @@ class SubvolumeHandler(BaseRequestHandler):
 
 
 class MeshHandler(BaseRequestHandler):
-    @tornado.web.asynchronous
+    @asynchronous
     def get(self, key, object_id):
         object_id = int(object_id)
         vol = self.server.get_volume(key)
@@ -204,7 +205,7 @@ class MeshHandler(BaseRequestHandler):
 
 
 class SkeletonHandler(BaseRequestHandler):
-    @tornado.web.asynchronous
+    @asynchronous
     def get(self, key, object_id):
         object_id = int(object_id)
         vol = self.server.get_volume(key)

--- a/python/setup.py
+++ b/python/setup.py
@@ -126,7 +126,7 @@ setup(
         "numpy>=1.11.0",
         'requests',
         'tornado',
-        'sockjs-tornado',
+        'sockjs-tornado>=1.0.7',
         'six',
         'google-apitools',
     ],

--- a/python/setup.py
+++ b/python/setup.py
@@ -125,7 +125,7 @@ setup(
         "Pillow>=3.2.0",
         "numpy>=1.11.0",
         'requests',
-        'tornado<6',
+        'tornado',
         'sockjs-tornado',
         'six',
         'google-apitools',

--- a/python/setup.py
+++ b/python/setup.py
@@ -126,7 +126,7 @@ setup(
         "numpy>=1.11.0",
         'requests',
         'tornado',
-        'sockjs-tornado>=1.0.7',
+        'sockjs-tornado',
         'six',
         'google-apitools',
     ],


### PR DESCRIPTION
The following fix should make sockjs-tornado compatible with tornado6
https://github.com/mrjoes/sockjs-tornado/pull/118