### PR TITLE
feat(datasource/dvid): add credentials support for DVID datasource

### DIFF
--- a/src/neuroglancer/datasource/dvid/api.ts
+++ b/src/neuroglancer/datasource/dvid/api.ts
@@ -1,0 +1,163 @@
+/**
+ * @license
+ * This work is a derivative of the Google Neuroglancer project,
+ * Copyright 2016 Google Inc.
+ * The Derivative Work is covered by
+ * Copyright 2019 Howard Hughes Medical Institute
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {CancellationToken, uncancelableToken} from 'neuroglancer/util/cancellation';
+import {responseJson, cancellableFetchOk, responseArrayBuffer, ResponseTransform} from 'neuroglancer/util/http_request';
+import {CredentialsProvider} from 'neuroglancer/credentials_provider';
+import {fetchWithCredentials} from 'neuroglancer/credentials_provider/http_request';
+
+export type DVIDToken = string;
+
+export const credentialsKey = 'DVID';
+
+interface HttpCall {
+  method: 'GET' | 'POST' | 'DELETE' | 'HEAD';
+  url: string;
+  payload?: string;
+}
+
+export class DVIDInstance {
+  constructor(public baseUrl: string, public nodeKey: string) {}
+
+  getNodeApiUrl(path = ''): string {
+    return `${this.baseUrl}/api/node/${this.nodeKey}${path}`;
+  }
+
+  getRepoInfoUrl(): string {
+    return `${this.baseUrl}/api/repos/info`;
+  }
+
+  getKeyValueUrl(dataName: string, key: string) {
+    return `${this.getNodeApiUrl()}/${dataName}/key/${key}`;
+  }
+
+  getKeyValueRangeUrl(dataName: string, startKey: string, endKey:string) {
+    return `${this.getNodeApiUrl()}/${dataName}/keyrange/${startKey}/${endKey}`;
+  }
+
+  getKeyValuesUrl(dataName: string) {
+    return `${this.getNodeApiUrl()}/${dataName}/keyvalues?jsontar=false`;
+  }
+}
+
+export function appendQueryStringForDvid(url: string, user: string|null|undefined) {
+  if (url.includes('?')) {
+    url += '&';
+  } else {
+    url += '?';
+  }
+  url += 'app=Neuroglancer';
+  if (user) {
+    url += `&u=${user}`;
+  }
+  return url;
+}
+
+export function responseText(response: Response): Promise<any> {
+  return response.text();
+}
+
+export function makeRequest(
+  httpCall: HttpCall & { responseType: 'arraybuffer' },
+  cancellationToken?: CancellationToken): Promise<ArrayBuffer>;
+
+export function makeRequest(
+  httpCall: HttpCall & { responseType: 'json' }, cancellationToken?: CancellationToken): Promise<any>;
+
+export function makeRequest(
+  httpCall: HttpCall & { responseType: '' }, cancellationToken?: CancellationToken): Promise<any>;
+
+export function makeRequest(
+  httpCall: HttpCall & { responseType: XMLHttpRequestResponseType },
+  cancellationToken: CancellationToken = uncancelableToken): any {
+    let requestInfo = `${httpCall.url}`;
+    let init = { method: httpCall.method, body: httpCall.payload };
+
+    if (httpCall.responseType === '') {
+      return cancellableFetchOk(requestInfo, init, responseText, cancellationToken);
+    } else {
+      return cancellableFetchOk(requestInfo, init, responseJson, cancellationToken);
+    }
+}
+
+export function makeRequestWithCredentials(
+  credentialsProvider: CredentialsProvider<DVIDToken>,
+  httpCall: HttpCall & { responseType: 'arraybuffer' },
+  cancellationToken?: CancellationToken): Promise<ArrayBuffer>;
+
+export function makeRequestWithCredentials(
+  credentialsProvider: CredentialsProvider<DVIDToken>,
+  httpCall: HttpCall & { responseType: 'json' }, cancellationToken?: CancellationToken): Promise<any>;
+
+export function makeRequestWithCredentials(
+  credentialsProvider: CredentialsProvider<DVIDToken>,
+  httpCall: HttpCall & { responseType: '' }, cancellationToken?: CancellationToken): Promise<any>;
+
+export function makeRequestWithCredentials(
+  credentialsProvider: CredentialsProvider<DVIDToken>,
+  httpCall: HttpCall & { responseType: XMLHttpRequestResponseType },
+  cancellationToken: CancellationToken = uncancelableToken): Promise<any> {
+    return fetchWithDVIDCredentials(
+      credentialsProvider,
+      httpCall.url,
+      { method: httpCall.method, body: httpCall.payload },
+      httpCall.responseType === '' ? responseText : (httpCall.responseType === 'json' ? responseJson : responseArrayBuffer),
+      cancellationToken
+    );
+}
+
+function  applyCredentials(input: string) {
+  return (credentials: DVIDToken, init: RequestInit) => {
+    let newInit: RequestInit = { ...init };
+
+    if (credentials.length > 0) {
+      newInit.headers = {...newInit.headers, Authorization: `Bearer ${credentials}`};
+    } else if (input.startsWith('https:')) {
+      // DVID https without credentials provided expects credentials stored in the browser
+      newInit.credentials = 'include';
+    }
+
+    return newInit;
+  };
+}
+
+export function fetchWithDVIDCredentials<T>(
+  credentialsProvider: CredentialsProvider<DVIDToken>,
+  input: string,
+  init: RequestInit,
+  transformResponse: ResponseTransform<T>,
+  cancellationToken: CancellationToken = uncancelableToken): Promise<T> {
+  return fetchWithCredentials(
+    credentialsProvider, input, init, transformResponse,
+    applyCredentials(input),
+    error => {
+      const { status } = error;
+      if (status === 403 || status === 401) {
+        // Authorization needed.  Retry with refreshed token.
+        return 'refresh';
+      }
+      if (status === 504) {
+        // Gateway timeout can occur if the server takes too long to reply.  Retry.
+        return 'retry';
+      }
+      throw error;
+    },
+    cancellationToken);
+}

--- a/src/neuroglancer/datasource/dvid/base.ts
+++ b/src/neuroglancer/datasource/dvid/base.ts
@@ -25,6 +25,8 @@ export class DVIDSourceParameters {
   baseUrl: string;
   nodeKey: string;
   dataInstanceKey: string;
+  authServer?: string;
+  user?: string;
 }
 
 export class VolumeChunkSourceParameters extends DVIDSourceParameters {

--- a/src/neuroglancer/datasource/dvid/credentials_provider.ts
+++ b/src/neuroglancer/datasource/dvid/credentials_provider.ts
@@ -1,0 +1,107 @@
+/**
+ * @license
+ * This work is a derivative of the Google Neuroglancer project,
+ * Copyright 2016 Google Inc.
+ * The Derivative Work is covered by
+ * Copyright 2019 Howard Hughes Medical Institute
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {CredentialsProvider, makeCredentialsGetter} from 'neuroglancer/credentials_provider';
+import {StatusMessage} from 'neuroglancer/status';
+import {CANCELED, CancellationTokenSource, uncancelableToken} from 'neuroglancer/util/cancellation';
+import {cancellableFetchOk} from 'neuroglancer/util/http_request';
+import {DVIDToken, responseText} from 'neuroglancer/datasource/dvid/api';
+
+function getAuthToken(
+  authServer: string,
+  cancellationToken = uncancelableToken) {
+  if (!authServer) {
+    return Promise.resolve('');
+  } else {
+    return cancellableFetchOk(
+      authServer,
+      {'method': 'GET', credentials: 'include'},
+      responseText,
+      cancellationToken);
+  }
+}
+
+export class DVIDCredentialsProvider extends CredentialsProvider<DVIDToken> {
+  constructor(public authServer: string) {
+    super();
+  }
+
+  get = makeCredentialsGetter(cancellationToken => {
+    const status = new StatusMessage(/*delay=*/true);
+    let cancellationSource: CancellationTokenSource|undefined;
+    return new Promise<DVIDToken>((resolve, reject) => {
+      const dispose = () => {
+        cancellationSource = undefined;
+        status.dispose();
+      };
+      cancellationToken.add(() => {
+        if (cancellationSource !== undefined) {
+          cancellationSource.cancel();
+          cancellationSource = undefined;
+          status.dispose();
+          reject(CANCELED);
+        }
+      });
+      function writeAuthStatus(
+          authServer: string,
+          msg = 'DVID authorization required.',
+          linkMessage = 'Request authorization.') {
+        status.setText(msg + ' ');
+        let button = document.createElement('button');
+        button.textContent = linkMessage;
+        status.element.appendChild(button);
+        button.addEventListener('click', () => {
+          // In the current DVID setup, https://flyemlogin.<domain> is expected for the login server
+          let match = authServer.match(/^[^\/]+\/\/[^\/\.]+\.([^\/]+)/);
+          if (match) {
+            const loginServer = `https://flyemlogin.${match[1]}/login`;
+            window.alert(`Please log into ${loginServer} and then refresh the neurogalncer page to try again.\nIf you are unable to log into ${loginServer}, please check your authorization server ${authServer} to make sure it is correct.`);
+          } else {
+            window.alert(`Please check your authorization server ${authServer} to make sure it is correct.`);
+          }
+        });
+        status.setVisible(true);
+      }
+
+      function requestAuth(authServer: string) {
+        if (cancellationSource !== undefined) {
+          cancellationSource.cancel();
+        }
+        cancellationSource = new CancellationTokenSource();
+        writeAuthStatus(authServer, 'Waiting for DVID authorization...', 'Retry');
+        getAuthToken(authServer, cancellationSource)
+            .then(
+                token => {
+                  if (cancellationSource !== undefined) {
+                    dispose();
+                    resolve(token);
+                  }
+                },
+                reason => {
+                  if (cancellationSource !== undefined) {
+                    cancellationSource = undefined;
+                    writeAuthStatus(authServer, `DVID authorization failed: ${reason}.`, 'Retry');
+                  }
+                });
+      }
+      requestAuth(this.authServer);
+    });
+  });
+}

--- a/src/neuroglancer/datasource/dvid/register_credentials_provider.ts
+++ b/src/neuroglancer/datasource/dvid/register_credentials_provider.ts
@@ -1,0 +1,38 @@
+/**
+ * @license
+ * This work is a derivative of the Google Neuroglancer project,
+ * Copyright 2016 Google Inc.
+ * The Derivative Work is covered by
+ * Copyright 2019 Howard Hughes Medical Institute
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {defaultCredentialsManager} from 'neuroglancer/credentials_provider/default_manager';
+import {credentialsKey} from 'neuroglancer/datasource/dvid/api';
+import {DVIDCredentialsProvider} from 'neuroglancer/datasource/dvid/credentials_provider';
+
+export function dvidCredentailsKey(authServer: string) {
+  return credentialsKey + authServer;
+}
+
+export function registerDVIDCredentialsProvider(key: string) {
+  defaultCredentialsManager.register(
+    key, (authServer) => new DVIDCredentialsProvider(authServer));
+}
+
+export function isDVIDCredentialsProviderRegistered(key: string) {
+  return defaultCredentialsManager.base.providers.has(key);
+}
+
+registerDVIDCredentialsProvider(dvidCredentailsKey(''));

--- a/src/neuroglancer/datasource/dvid/register_default.ts
+++ b/src/neuroglancer/datasource/dvid/register_default.ts
@@ -17,4 +17,4 @@
 import {DVIDDataSource} from 'neuroglancer/datasource/dvid/frontend';
 import {registerProvider} from 'neuroglancer/datasource/default_provider';
 
-registerProvider('dvid', () => new DVIDDataSource());
+registerProvider('dvid', options => new DVIDDataSource(options.credentialsManager));


### PR DESCRIPTION
This PR adds credentials support for fetching data from DVID. In the current DVID implementation, the default entry point of getting an auto token is /api/server/token, which is necessary for any DVID server with the https protocol. We also allow the user to set up an auth server in the source url through query strings in case different auth servers are used. Note that DVID does not provide the login process, which must be done through a separate server. We assume that it has the same domain as the auth server and has the pattern 'https://flyemlogin.[domain]/login'. This PR should not affect any DVID layers without auth settings like before.