### PR TITLE
html colors for selected segments in Python API

### DIFF
--- a/python/neuroglancer/__init__.py
+++ b/python/neuroglancer/__init__.py
@@ -24,3 +24,5 @@ from .url_state import to_url, parse_url
 from .screenshot import ScreenshotSaver
 from . import skeleton
 from . import server
+from . import segment_colors
+

--- a/python/neuroglancer/segment_colors.py
+++ b/python/neuroglancer/segment_colors.py
@@ -14,10 +14,6 @@
 
 import math
 
-def zero_fill_right_shift(val, n):
-    """ Python implementation of javascript's >>> operator """
-    return (val >> n) if val >= 0 else ((val + 0x100000000) >> n)
-
 def hash_function(state,value):
     """ Python implementation of hashCombine() function
     in src/neuroglancer/gpu_hash/hash_function.ts,

--- a/python/neuroglancer/segment_colors.py
+++ b/python/neuroglancer/segment_colors.py
@@ -1,0 +1,85 @@
+# @license
+# Copyright 2017 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import math
+
+def zero_fill_right_shift(val, n):
+    """ Python implementation of javascript's >>> operator """
+    return (val >> n) if val >= 0 else ((val + 0x100000000) >> n)
+
+def hash_function(state,value):
+    """ Python implementation of hashCombine() function
+    in src/neuroglancer/gpu_hash/hash_function.ts,
+    a modified murmur hash
+    """
+    k1 = 0xcc9e2d51
+    k2 = 0x1b873593
+    state = state & 0xffffffff
+    value = (value * k1) & 0xffffffff
+    value = ((value << 15) | zero_fill_right_shift(value,17)) & 0xffffffff
+    value = (value * k2) & 0xffffffff
+    state = (state ^ value) & 0xffffffff
+    state = (( state << 13) | (zero_fill_right_shift(state,19))) & 0xffffffff
+    state = (( state * 5) + 0xe6546b64) & 0xffffffff
+    return state
+
+def hsv_to_rgb(h,s,v):
+    """ Convert H,S,V values to RGB values.
+    Python implementation of hsvToRgb in src/neuroglancer/util/colorspace.ts """
+    h*=6
+    hue_index = math.floor(h)
+    remainder = h - hue_index
+    val1 = v*(1-s)
+    val2 = v*(1-(s*remainder))
+    val3 = v*(1-(s*(1-remainder)))
+    hue_remainder = hue_index % 6
+    if hue_remainder == 0:
+        return (v,val3,val1)
+    elif hue_remainder == 1:
+        return (val2,v,val1)
+    elif hue_remainder == 2:
+        return (val1,v,val3)
+    elif hue_remainder == 3:
+        return (val1,val2,v)
+    elif hue_remainder == 4:
+        return (val3,val1,v)
+    elif hue_remainder == 5: 
+        return (v,val1,val2)   
+
+def pack_color(rgb_vec):
+    """ Returns an integer formed
+    by concatenating the channels of the input color vector.
+    Python implementation of packColor in src/neuroglancer/util/color.ts
+    """
+    result = 0
+    for i in range(len(rgb_vec)):
+        result = ((result << 8) & 0xffffffff) + min(255,max(0,round(rgb_vec[i]*255)))
+    return result
+
+def hex_string_from_segment_id(color_seed,segment_id):
+    """ Return the hex color string for a segment
+    given a color seed and the segment id """
+    segment_id = int(segment_id) # necessary since segment_id is 64 bit originally 
+    result = hash_function(state=color_seed,value=segment_id)
+    newvalue = segment_id >> 32
+    result2 = hash_function(state=result,value=newvalue)
+    c0 = (result2 & 0xFF) / 255.
+    c1 = ((result2 >> 8) & 0xFF) / 255.;
+    h = c0
+    s =  0.5 + 0.5 * c1
+    v = 1.0
+    rgb=hsv_to_rgb(h,s,v)
+    packed_color = pack_color(rgb_vec=rgb)
+    hex_string = '#' + format(packed_color, 'x')
+    return hex_string

--- a/python/neuroglancer/segment_colors.py
+++ b/python/neuroglancer/segment_colors.py
@@ -81,5 +81,9 @@ def hex_string_from_segment_id(color_seed,segment_id):
     v = 1.0
     rgb=hsv_to_rgb(h,s,v)
     packed_color = pack_color(rgb_vec=rgb)
-    hex_string = '#' + format(packed_color, 'x')
+    hex_string = format(packed_color, 'x')
+    """ Zero pad the hex string if less than 6 characeters """
+    if len(hex_string) < 6:
+        hex_string = '0'*(6-len(hex_string)) + hex_string
+    hex_string = '#' + hex_string
     return hex_string

--- a/python/neuroglancer/segment_colors.py
+++ b/python/neuroglancer/segment_colors.py
@@ -27,10 +27,10 @@ def hash_function(state,value):
     k2 = 0x1b873593
     state = state & 0xffffffff
     value = (value * k1) & 0xffffffff
-    value = ((value << 15) | zero_fill_right_shift(value,17)) & 0xffffffff
+    value = ((value << 15) | value >> 17) & 0xffffffff
     value = (value * k2) & 0xffffffff
     state = (state ^ value) & 0xffffffff
-    state = (( state << 13) | (zero_fill_right_shift(state,19))) & 0xffffffff
+    state = (( state << 13) | state >> 19) & 0xffffffff
     state = (( state * 5) + 0xe6546b64) & 0xffffffff
     return state
 

--- a/python/neuroglancer/viewer_state.py
+++ b/python/neuroglancer/viewer_state.py
@@ -31,6 +31,7 @@ import six
 
 from . import local_volume
 from . import skeleton
+from . import segment_colors
 from .equivalence_map import EquivalenceMap
 from .json_utils import encode_json_for_repr
 from .json_wrappers import (JsonObjectWrapper, array_wrapper, optional, text_type, typed_list,
@@ -428,6 +429,20 @@ class SegmentationLayer(Layer, _AnnotationLayerOptions):
     mesh_render_scale = meshRenderScale = wrapped_property('meshRenderScale', optional(float, 10))
     mesh_silhouette_rendering = meshSilhouetteRendering = wrapped_property('meshSilhouetteRendering', optional(float, 0))
     segment_query = segmentQuery = wrapped_property('segmentQuery', optional(text_type))
+
+    @property
+    def segment_html_color_dict(self):
+        """ Returns a dictionary whose keys 
+        are segments and values are the 6-digit hex strings
+        representing the colors of those segments
+        given the current color seed """
+        d = {}
+        for segment in self.segments:
+            hex_string = segment_colors.hex_string_from_segment_id(
+                color_seed=self.color_seed,segment_id=segment)
+            d[segment] = hex_string
+            
+        return d
 
     @staticmethod
     def interpolate(a, b, t):

--- a/python/tests/segment_colors_test.py
+++ b/python/tests/segment_colors_test.py
@@ -1,0 +1,78 @@
+# @license
+# Copyright 2017 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for equivalence_map.py"""
+
+from __future__ import absolute_import
+
+from neuroglancer.segment_colors import (hash_function,
+    hex_string_from_segment_id)
+import numpy as np
+
+def test_hash_function():
+    """ Test that the Python implementation
+    of the modified murmur hash function
+    returns the same result as the javascript
+    implementation for a few different 
+    color seed/segment id combinations """
+    color_seed = 0
+    segment_id = 39
+    result = hash_function(state=color_seed,value=segment_id)
+    assert result == 761471253
+
+    color_seed = 0
+    segment_id = 92
+    result = hash_function(state=color_seed,value=segment_id)
+    assert result == 2920775201   
+
+    color_seed = 1125505311
+    segment_id = 47
+    result = hash_function(state=color_seed,value=segment_id)
+    assert result == 251450508
+
+    color_seed = 1125505311
+    segment_id = 30
+    result = hash_function(state=color_seed,value=segment_id)
+    assert result == 2403373702
+
+def test_hex_string_from_segment_id():
+    """ Test that the hex string obtained
+    via the Python implementation is identical to
+    the value obtained using the javascript implementation
+    for a few different color seed/segment id combinations """
+    color_seed = 0
+    segment_id = 39
+    result = hex_string_from_segment_id(
+        color_seed,segment_id)
+    assert result.upper() == "#992CFF"
+
+    color_seed = 1965848648
+    segment_id = 40
+    result = hex_string_from_segment_id(
+        color_seed,segment_id)
+    assert result.upper() == "#FF981E"
+
+    color_seed = 2183424408
+    segment_id = 143
+    result = hex_string_from_segment_id(
+        color_seed,segment_id)
+    assert result.upper() == "#0410FF"
+    
+    color_seed = 2092967958
+    segment_id = 58
+    result = hex_string_from_segment_id(
+        color_seed,segment_id)
+    assert result.upper() == "#FF4ACE"
+
+    
+


### PR DESCRIPTION
This feature adds a property: "segment_html_color_dict" to segmentation
layers via the Python API. The property returns a dictionary where
keys are segment ids and values are the html color codes,
e.g. #F9F607 (yellow) corresponding to each currently selected segment.
The colors are the same as what is rendered in the viewer for the segments,
given a color seed. This property uses the current color seed when
calculating the color codes.