### PR TITLE
n5: work with AWS (403 instead of 404)

### DIFF
--- a/src/neuroglancer/datasource/n5/frontend.ts
+++ b/src/neuroglancer/datasource/n5/frontend.ts
@@ -200,7 +200,7 @@ function getIndividualAttributesJson(
                   }
                 })
                 .catch(e => {
-                  if (e instanceof HttpError && e.status === 404) {
+                  if (e instanceof HttpError && (e.status === 404 || e.status === 403)) {
                     if (required) return undefined;
                     return {};
                   }


### PR DESCRIPTION
Public on AWS with GetObject but not ListObject permissions will get a 403 instead of 404 when a files does not exist.

This prevents access to n5 volumes with a fatal error when the first missing `attributes.json` gets a 403 response.

(This is from debugging access to a s3 hosted n5 volume with @sharmishtaa).