### PR TITLE
Make range track visible on FireFox 80/81 on MacOS.

### DIFF
--- a/src/neuroglancer/widget/range.css
+++ b/src/neuroglancer/widget/range.css
@@ -22,5 +22,9 @@
 }
 
 .range-slider input[type='range'] {
+  background: transparent;
 }
 
+.range-slider input[type=range]::-moz-range-track {
+  background-color: white;
+}


### PR DESCRIPTION
A possible fix for https://github.com/google/neuroglancer/issues/245 .

The sliders now look like this with FireFox 80 on MacOS dark mode:
![image](https://user-images.githubusercontent.com/671841/93283621-e65d7780-f79e-11ea-9546-b21cbb758b3b.png)

These changes appear to have no effect on MacOS Chrome. I have not tested on Windows or Linux.