### PR TITLE
Include the right annotation id for error handling

### DIFF
--- a/src/neuroglancer/annotation/backend.ts
+++ b/src/neuroglancer/annotation/backend.ts
@@ -253,9 +253,11 @@ registerRPC(ANNOTATION_COMMIT_UPDATE_RPC_ID, function(x: any) {
       },
       (error: Error) => {
         if (!obj.wasDisposed) {
-          this.invoke(
-              ANNOTATION_COMMIT_UPDATE_RESULT_RPC_ID,
-              {id: obj.rpcId, annotationId, error: error.message});
+          this.invoke(ANNOTATION_COMMIT_UPDATE_RESULT_RPC_ID, {
+            id: obj.rpcId,
+            annotationId: annotationId || (newAnnotation && newAnnotation.id),
+            error: error.message
+          });
         }
       });
 });


### PR DESCRIPTION
In [sendCommitRequest](https://github.com/google/neuroglancer/blob/2e4a2c18705de6dc3a6e9cfbc441bac4230c82cb/src/neuroglancer/annotation/frontend_source.ts#L474), `annotationId` is undefined in the case of adding an annotation, causing an undefined `annotationId` in the message for the error handling. This can keep [handleFailedUpdate](https://github.com/google/neuroglancer/blob/2e4a2c18705de6dc3a6e9cfbc441bac4230c82cb/src/neuroglancer/annotation/frontend_source.ts#L680) in annotation/frontend_source.ts from  showing the right error message because `localUpdate` will always be undefined in this case. As a result, the status message will get stuck at 'Committing annotations' when adding an annotation fails.

This pr tries to fix this problem by including the new annotation id in the error message when the update is not on an existing annotation, just like what the resolve function does, except that I expect both `annotationId` and `newAnnotation` can be undefined or null in a failed update (maybe?).