### PR TITLE
Use relative paths for python data source.

### DIFF
--- a/src/neuroglancer/datasource/python/backend.ts
+++ b/src/neuroglancer/datasource/python/backend.ts
@@ -41,7 +41,7 @@ chunkDecoders.set(VolumeChunkEncoding.RAW, decodeRawChunk);
 
   async download(chunk: VolumeChunk, cancellationToken: CancellationToken) {
     let {parameters} = this;
-    let path = `/neuroglancer/${this.encoding}/${parameters.key}/${parameters.scaleKey}`;
+    let path = `../../neuroglancer/${this.encoding}/${parameters.key}/${parameters.scaleKey}`;
     {
       // chunkPosition must not be captured, since it will be invalidated by the next call to
       // computeChunkBounds.

--- a/src/neuroglancer/datasource/python/backend.ts
+++ b/src/neuroglancer/datasource/python/backend.ts
@@ -79,7 +79,7 @@ export function decodeFragmentChunk(chunk: FragmentChunk, response: ArrayBuffer)
 
   downloadFragment(chunk: FragmentChunk, cancellationToken: CancellationToken) {
     let {parameters} = this;
-    let requestPath = `/neuroglancer/mesh/${parameters.key}/${chunk.manifestChunk!.objectId}`;
+    let requestPath = `../../neuroglancer/mesh/${parameters.key}/${chunk.manifestChunk!.objectId}`;
     return cancellableFetchOk(requestPath, {}, responseArrayBuffer, cancellationToken)
         .then(response => decodeFragmentChunk(chunk, response));
   }
@@ -89,7 +89,7 @@ export function decodeFragmentChunk(chunk: FragmentChunk, response: ArrayBuffer)
 (WithParameters(SkeletonSource, SkeletonSourceParameters)) {
   download(chunk: SkeletonChunk, cancellationToken: CancellationToken) {
     const {parameters} = this;
-    let requestPath = `/neuroglancer/skeleton/${parameters.key}/${chunk.objectId}`;
+    let requestPath = `../../neuroglancer/skeleton/${parameters.key}/${chunk.objectId}`;
     return cancellableFetchOk(requestPath, {}, responseArrayBuffer, cancellationToken)
         .then(response => decodeSkeletonChunk(chunk, response, parameters.vertexAttributes));
   }

--- a/src/neuroglancer/datasource/python/frontend.ts
+++ b/src/neuroglancer/datasource/python/frontend.ts
@@ -340,7 +340,7 @@ function getVolumeDataSource(
     dataSourceProvider: PythonDataSource, options: GetDataSourceOptions, key: string) {
   return options.chunkManager.memoize.getUncounted(
       {'type': 'python:VolumeDataSource', key}, async () => {
-        const response = await (await fetchOk(`/neuroglancer/info/${key}`)).json();
+        const response = await (await fetchOk(`../../neuroglancer/info/${key}`)).json();
         const volume = new PythonMultiscaleVolumeChunkSource(
             dataSourceProvider, options.chunkManager, key, response);
         const dataSource: DataSource = {
@@ -391,7 +391,7 @@ function getSkeletonDataSource(
     dataSourceProvider: PythonDataSource, options: GetDataSourceOptions, key: string) {
   return options.chunkManager.memoize.getUncounted(
       {'type': 'python:SkeletonDataSource', key}, async () => {
-        const response = await (await fetchOk(`/neuroglancer/skeletoninfo/${key}`)).json();
+        const response = await (await fetchOk(`../../neuroglancer/skeletoninfo/${key}`)).json();
         const {baseModelSpace, subsourceToModelTransform} =
             parseCoordinateSpaceAndVoxelOffset(response);
         const vertexAttributes = verifyObjectProperty(


### PR DESCRIPTION
As @chrisroat noticed in the comment thread of #150, local data sources are no longer working through [jupyter-server-proxy](https://github.com/jupyterhub/jupyter-server-proxy).  The problem stems from the root-relative URLs.

An example URL for neuroglancer with jupyter-server-proxy would be `http://localhost:8888/proxy/58060/v/f9dd9e35803d93ee67997951bf4a138a9abb7983/`

This PR is a quick & dirty fix illustrating the problem. I'm not sure what a proper @jbms solution would be. 🙂

I know this worked ~1-2 years ago. Were the data URLs previously under the token?