### PR TITLE
http_path_completion: Loosens check for content-type

### DIFF
--- a/src/neuroglancer/util/http_path_completion.ts
+++ b/src/neuroglancer/util/http_path_completion.ts
@@ -33,10 +33,10 @@ export async function getHtmlDirectoryListing(
       /*init=*/ {headers: {'accept': 'text/html'}},
       async x => ({text: await x.text(), contentType: x.headers.get('content-type')}),
       cancellationToken);
-  if (contentType !== 'text/html') {
+  if (contentType === null || /\btext\/html\b/i.exec(contentType) === null) {
     return [];
   }
-  const doc = new DOMParser().parseFromString(text, contentType);
+  const doc = new DOMParser().parseFromString(text, "text/html");
   const nodes =
       doc.evaluate('//a/@href', doc, null, XPathResult.UNORDERED_NODE_SNAPSHOT_TYPE, null);
   const results: string[] = [];


### PR DESCRIPTION
This patch allows the Content-Type header to have any case
and also allows charset specification, like so:

`Content-type: text/html; charset=UTF-8`

which wasn't allowed before