### PR TITLE
Allows query params in precomputed chunks

### DIFF
--- a/src/neuroglancer/datasource/precomputed/backend.ts
+++ b/src/neuroglancer/datasource/precomputed/backend.ts
@@ -38,7 +38,7 @@ import {Borrowed} from 'neuroglancer/util/disposable';
 import {convertEndian32, Endianness} from 'neuroglancer/util/endian';
 import {vec3} from 'neuroglancer/util/geom';
 import {murmurHash3_x86_128Hash64Bits} from 'neuroglancer/util/hash';
-import {isNotFoundError, responseArrayBuffer, responseJson} from 'neuroglancer/util/http_request';
+import {isNotFoundError, ParsedUrl, responseArrayBuffer, responseJson} from 'neuroglancer/util/http_request';
 import {stableStringify} from 'neuroglancer/util/json';
 import {getObjectId} from 'neuroglancer/util/object_id';
 import {cancellableFetchSpecialOk, SpecialProtocolCredentials, SpecialProtocolCredentialsProvider} from 'neuroglancer/util/special_protocol_request';
@@ -281,9 +281,11 @@ chunkDecoders.set(VolumeChunkEncoding.COMPRESSED_SEGMENTATION, decodeCompressedS
         // computeChunkBounds.
         let chunkPosition = this.computeChunkBounds(chunk);
         let chunkDataSize = chunk.chunkDataSize!;
-        url = `${parameters.url}/${chunkPosition[0]}-${chunkPosition[0] + chunkDataSize[0]}_` +
+        url = ParsedUrl.parse(parameters.url).concat(
+            `${chunkPosition[0]}-${chunkPosition[0] + chunkDataSize[0]}_` +
             `${chunkPosition[1]}-${chunkPosition[1] + chunkDataSize[1]}_` +
-            `${chunkPosition[2]}-${chunkPosition[2] + chunkDataSize[2]}`;
+            `${chunkPosition[2]}-${chunkPosition[2] + chunkDataSize[2]}`
+        ).href;
       }
       response = await cancellableFetchSpecialOk(
           this.credentialsProvider, url, {}, responseArrayBuffer, cancellationToken);

--- a/src/neuroglancer/datasource/precomputed/frontend.ts
+++ b/src/neuroglancer/datasource/precomputed/frontend.ts
@@ -36,7 +36,7 @@ import {DATA_TYPE_ARRAY_CONSTRUCTOR, DataType} from 'neuroglancer/util/data_type
 import {Borrowed} from 'neuroglancer/util/disposable';
 import {mat4, vec3} from 'neuroglancer/util/geom';
 import {completeHttpPath} from 'neuroglancer/util/http_path_completion';
-import {isNotFoundError, responseJson} from 'neuroglancer/util/http_request';
+import {isNotFoundError, ParsedUrl, responseJson} from 'neuroglancer/util/http_request';
 import {parseArray, parseFixedLengthArray, parseQueryStringParameters, unparseQueryStringParameters, verifyEnumString, verifyFiniteFloat, verifyFinitePositiveFloat, verifyInt, verifyObject, verifyObjectProperty, verifyOptionalObjectProperty, verifyOptionalString, verifyPositiveInt, verifyString, verifyStringArray} from 'neuroglancer/util/json';
 import * as matrix from 'neuroglancer/util/matrix';
 import {getObjectId} from 'neuroglancer/util/object_id';
@@ -63,17 +63,7 @@ class PrecomputedSkeletonSource extends
 }
 
 function resolvePath(a: string, b: string) {
-  const outputParts = a.split('/');
-  for (const part of b.split('/')) {
-    if (part === '..') {
-      if (outputParts.length !== 0) {
-        outputParts.length = outputParts.length - 1;
-        continue;
-      }
-    }
-    outputParts.push(part);
-  }
-  return outputParts.join('/');
+  return ParsedUrl.parse(a).concat(b).href
 }
 
 class ScaleInfo {
@@ -497,7 +487,7 @@ function getJsonMetadata(
       {'type': 'precomputed:metadata', url, credentialsProvider: getObjectId(credentialsProvider)},
       async () => {
         return await cancellableFetchSpecialOk(
-            credentialsProvider, `${url}/info`, {}, responseJson);
+            credentialsProvider, ParsedUrl.parse(url).concat("info").href, {}, responseJson);
       });
 }
 

--- a/src/neuroglancer/util/http_path_completion.ts
+++ b/src/neuroglancer/util/http_path_completion.ts
@@ -57,8 +57,10 @@ export async function getHtmlPathCompletions(
   const entries = await getHtmlDirectoryListing(m[1], cancellationToken);
   const offset = m[1].length;
   const matches: Completion[] = [];
+  const parsed_url = parseUrl(url)
+  const prefix = `${parsed_url.protocol}://${parsed_url.host}${parsed_url.path}`
   for (const entry of entries) {
-    if (!entry.startsWith(url)) continue;
+    if (!entry.startsWith(prefix)) continue;
     matches.push({value: entry.substring(offset)});
   }
   return {

--- a/src/neuroglancer/util/http_path_completion.ts
+++ b/src/neuroglancer/util/http_path_completion.ts
@@ -33,10 +33,10 @@ export async function getHtmlDirectoryListing(
       /*init=*/ {headers: {'accept': 'text/html'}},
       async x => ({text: await x.text(), contentType: x.headers.get('content-type')}),
       cancellationToken);
-  if (contentType !== 'text/html') {
+  if (contentType === null || /\btext\/html\b/i.exec(contentType) === null) {
     return [];
   }
-  const doc = new DOMParser().parseFromString(text, contentType);
+  const doc = new DOMParser().parseFromString(text, "text/html");
   const nodes =
       doc.evaluate('//a/@href', doc, null, XPathResult.UNORDERED_NODE_SNAPSHOT_TYPE, null);
   const results: string[] = [];


### PR DESCRIPTION
 - Creates the `ParsedUrl` class to streamline handling URLs 
 - uses `ParsedUrl` everywhere the PrecomputedChunks datasource composes URLs, concatenating paths and preserving query strings
 
Fixes  #316 

Needs #320

TODO:
- Wait for legal to give me the green light on licensing/CLA and for #320 to be merged
- Get some architectural feedback and comments =)
- Some more testing