### PR TITLE
Update compressed morton code algorithm

### DIFF
--- a/src/neuroglancer/datasource/precomputed/volume.md
+++ b/src/neuroglancer/datasource/precomputed/volume.md
@@ -157,7 +157,7 @@ grid_size`, the compressed Morton code is computed as follows:
 2. For `i` from `0` to `n-1`, where `n` is the number of bits needed to encode the grid cell
    coordinates:
    - For `dim` in `0, 1, 2` (corresponding to `x`, `y`, `z`):
-     - If `2**i <= grid_size[dim]`:
+     - If `2**i < grid_size[dim]`:
        - Set output bit `j` of the compressed Morton code to bit `i` of `g[dim]`.
        - Set `j := j + 1`.
        


### PR DESCRIPTION
The current algorithm adds an extra bit for grid sizes that are a power of 2.  This was discovered by me and @william-silversmith when I was debugging grids of that size.  I was seeing missing/swapped data when reading sharded tensorstore datasets with cloud-volume, which had implemented the current version of the algorithm.  See https://github.com/seung-lab/cloud-volume/pull/482