### PR TITLE
Support default keys for makeToolButton

### DIFF
--- a/src/neuroglancer/ui/segment_list.ts
+++ b/src/neuroglancer/ui/segment_list.ts
@@ -788,14 +788,12 @@ export class SegmentDisplayTab extends Tab {
                                     toolbox.appendChild(makeToolButton(context, layer, {
                                       toolJson: ANNOTATE_MERGE_SEGMENTS_TOOL_ID,
                                       label: 'Merge',
-                                      title: 'Merge segments',
-                                      defaultKey: 'M'
+                                      title: 'Merge segments'
                                     }));
                                     toolbox.appendChild(makeToolButton(context, layer, {
                                       toolJson: ANNOTATE_SPLIT_SEGMENTS_TOOL_ID,
                                       label: 'Split',
-                                      title: 'Split segments',
-                                      defaultKey: 'S'
+                                      title: 'Split segments'
                                     }));
                                     parent.appendChild(toolbox);
                                   }))

--- a/src/neuroglancer/ui/segment_list.ts
+++ b/src/neuroglancer/ui/segment_list.ts
@@ -788,12 +788,14 @@ export class SegmentDisplayTab extends Tab {
                                     toolbox.appendChild(makeToolButton(context, layer, {
                                       toolJson: ANNOTATE_MERGE_SEGMENTS_TOOL_ID,
                                       label: 'Merge',
-                                      title: 'Merge segments'
+                                      title: 'Merge segments',
+                                      defaultKey: 'M'
                                     }));
                                     toolbox.appendChild(makeToolButton(context, layer, {
                                       toolJson: ANNOTATE_SPLIT_SEGMENTS_TOOL_ID,
                                       label: 'Split',
-                                      title: 'Split segments'
+                                      title: 'Split segments',
+                                      defaultKey: 'S'
                                     }));
                                     parent.appendChild(toolbox);
                                   }))

--- a/src/neuroglancer/ui/tool.ts
+++ b/src/neuroglancer/ui/tool.ts
@@ -389,11 +389,9 @@ export class ToolBindingWidget<LayerType extends UserLayer> extends RefCounted {
     });
     addToolKeyBindHandlers(this, element, key => this.layer.toolBinder.setJson(key, this.toolJson));
     if (defaultKey) {
-      // TODO: Need to check if it was already set by the user,
-      // but jsonToKey does not appear to be populated
-      const key = this.layer.toolBinder.jsonToKey.get(this.toolJson);
+      const key = this.layer.toolBinder.jsonToKey.get(JSON.stringify(toolJson));
       if (key === undefined) {
-        this.layer.toolBinder.setJson(defaultKey, this.toolJson);
+        this.layer.toolBinder.setJson(defaultKey, toolJson);
       }
     }
   }

--- a/src/neuroglancer/ui/tool.ts
+++ b/src/neuroglancer/ui/tool.ts
@@ -376,7 +376,7 @@ export class LayerToolBinder {
 export class ToolBindingWidget<LayerType extends UserLayer> extends RefCounted {
   element = document.createElement('div');
   private toolJsonString = JSON.stringify(this.toolJson);
-  constructor(public layer: LayerType, public toolJson: any) {
+  constructor(public layer: LayerType, public toolJson: any, defaultKey?: string) {
     super();
     const {element} = this;
     element.classList.add('neuroglancer-tool-key-binding');
@@ -388,6 +388,14 @@ export class ToolBindingWidget<LayerType extends UserLayer> extends RefCounted {
       this.layer.toolBinder.removeJsonString(this.toolJsonString);
     });
     addToolKeyBindHandlers(this, element, key => this.layer.toolBinder.setJson(key, this.toolJson));
+    if (defaultKey) {
+      // TODO: Need to check if it was already set by the user,
+      // but jsonToKey does not appear to be populated
+      const key = this.layer.toolBinder.jsonToKey.get(this.toolJson);
+      if (key === undefined) {
+        this.layer.toolBinder.setJson(defaultKey, this.toolJson);
+      }
+    }
   }
 
   private updateView() {
@@ -434,11 +442,11 @@ export function addToolKeyBindHandlers(
 
 export function makeToolButton(
     context: RefCounted, layer: UserLayer,
-    options: {toolJson: any, label: string, title?: string}) {
+    options: {toolJson: any, label: string, title?: string, defaultKey?: string}) {
   const element = document.createElement('div');
   element.classList.add('neuroglancer-tool-button');
   element.appendChild(
-      context.registerDisposer(new ToolBindingWidget(layer, options.toolJson)).element);
+      context.registerDisposer(new ToolBindingWidget(layer, options.toolJson, options.defaultKey)).element);
   const labelElement = document.createElement('div');
   labelElement.classList.add('neuroglancer-tool-button-label');
   labelElement.textContent = options.label;


### PR DESCRIPTION
This is part of the seung-lab merge project (see #340).

It would be convenient to have default keybinds for operations like merge and split, so that the user doesn't have to set them manually. This PR adds an optional `defaultKey` parameter to the `ToolBindingWidget` constructor and `makeToolButton` function, which will fill in the tool button with that key the first time Neuroglancer is loaded, but respect the user's choice and use a different key if one has been set manually.

Caveat: If the user unsets the tool (by double-clicking) then reloads Neuroglancer, it will be set back to the default. The `LayerToolBinder.jsonToKey` isn't structured to support tool -> `undefined` mappings, so I'm not sure if there's a good way around this, but it's a minor annoyance.