### PR TITLE
Support toggle activation for tools

### DIFF
--- a/src/neuroglancer/ui/tool.ts
+++ b/src/neuroglancer/ui/tool.ts
@@ -264,7 +264,8 @@ export class ToolBinder extends RefCounted {
       return;
     }
     else if (this.activeTool) {
-      StatusMessage.showTemporaryMessage(`Can't activate tool ${tool} while tool ${this.activeTool} is active`);
+      StatusMessage.showTemporaryMessage(
+        `Can't activate tool ${tool.description} while tool ${this.activeTool.tool.description} is active`);
       return;
     }
     const activation = new ToolActivation(tool, inputEventMapBinder);

--- a/src/neuroglancer/ui/tool.ts
+++ b/src/neuroglancer/ui/tool.ts
@@ -213,7 +213,7 @@ export class ToolBinder extends RefCounted {
   bindings = new Map<string, Borrowed<Tool>>();
   changed = new Signal();
   private activeTool: Owned<ToolActivation>|undefined;
-  private queuedTool: ToolActivation|undefined;
+  private queuedTool: Tool|undefined;
   private debounceDeactivate = this.registerCancellable(debounce(() => this.deactivate_(), 1));
   private debounceReactivate = this.registerCancellable(debounce(
     (inputEventMapBinder: InputEventMapBinder) => this.reactivateQueuedTool(inputEventMapBinder), 1));
@@ -271,7 +271,7 @@ export class ToolBinder extends RefCounted {
     }
     else if (this.activeTool) {
       if (this.activeTool.tool.toggle && !tool.toggle) {
-        this.queuedTool = this.activeTool;
+        this.queuedTool = this.activeTool.tool;
       }
       this.deactivate_();
     }
@@ -296,9 +296,9 @@ export class ToolBinder extends RefCounted {
 
   private reactivateQueuedTool(inputEventMapBinder: InputEventMapBinder) {
     if (this.queuedTool) {
-      const activation = new ToolActivation(this.queuedTool.tool, inputEventMapBinder);
+      const activation = new ToolActivation(this.queuedTool, inputEventMapBinder);
       this.activeTool = activation;
-      this.queuedTool.tool.activate(activation);
+      this.queuedTool.activate(activation);
       this.queuedTool = undefined;
     }
   }

--- a/src/neuroglancer/ui/tool.ts
+++ b/src/neuroglancer/ui/tool.ts
@@ -309,6 +309,9 @@ export class ToolBinder extends RefCounted {
   }
 
   destroyTool(tool: Owned<Tool>) {
+    if (this.queuedTool === tool) {
+      this.queuedTool = undefined;
+    }
     if (this.activeTool_?.tool === tool) {
       this.deactivate_();
     }

--- a/src/neuroglancer/ui/tool.ts
+++ b/src/neuroglancer/ui/tool.ts
@@ -46,7 +46,9 @@ export class ToolActivation<ToolType extends Tool = Tool> extends RefCounted {
     this.inputEventMapBinder(inputEventMap, this);
   }
   cancel() {
-    this.tool.layer.manager.root.toolBinder.deactivate_();
+    if (this == this.tool.layer.manager.root.toolBinder.activeTool_) {
+      this.tool.layer.manager.root.toolBinder.deactivate_();
+    }
   }
 }
 
@@ -212,11 +214,14 @@ export class SelectedLegacyTool extends RefCounted implements
 export class ToolBinder extends RefCounted {
   bindings = new Map<string, Borrowed<Tool>>();
   changed = new Signal();
-  private activeTool: Owned<ToolActivation>|undefined;
+  activeTool_: Owned<ToolActivation>|undefined; // For internal use only- should only be called by ToolBinder and ToolActivation.cancel()
   private queuedTool: Tool|undefined;
   private debounceDeactivate = this.registerCancellable(debounce(() => this.deactivate_(), 1));
-  private debounceReactivate = this.registerCancellable(debounce(
-    (inputEventMapBinder: InputEventMapBinder) => this.reactivateQueuedTool(inputEventMapBinder), 1));
+  private debounceReactivate = this.registerCancellable(debounce(() => this.reactivateQueuedTool(), 1));
+
+  constructor(private inputEventMapBinder: InputEventMapBinder) {
+    super();
+  }
 
   get(key: string): Borrowed<Tool>|undefined {
     return this.bindings.get(key);
@@ -255,7 +260,7 @@ export class ToolBinder extends RefCounted {
     this.changed.dispatch();
   }
 
-  activate(key: string, inputEventMapBinder: InputEventMapBinder): Borrowed<Tool>|undefined {
+  activate(key: string): Borrowed<Tool>|undefined {
     const tool = this.get(key);
     if (tool === undefined) {
       this.deactivate_();
@@ -263,48 +268,48 @@ export class ToolBinder extends RefCounted {
     }
     this.debounceDeactivate.cancel();
     this.debounceReactivate.cancel();
-    if (tool === this.activeTool?.tool) {
+    if (tool === this.activeTool_?.tool) {
       if (tool.toggle) {
         this.deactivate_();
       }
       return;
     }
-    else if (this.activeTool) {
-      if (this.activeTool.tool.toggle && !tool.toggle) {
-        this.queuedTool = this.activeTool.tool;
+    else if (this.activeTool_) {
+      if (this.activeTool_.tool.toggle && !tool.toggle) {
+        this.queuedTool = this.activeTool_.tool;
       }
       this.deactivate_();
     }
-    const activation = new ToolActivation(tool, inputEventMapBinder);
-    this.activeTool = activation;
+    const activation = new ToolActivation(tool, this.inputEventMapBinder);
+    this.activeTool_ = activation;
     if (!tool.toggle) {
       const expectedCode = `Key${key}`;
       activation.registerEventListener(window, 'keyup', (event: KeyboardEvent) => {
         if (event.code === expectedCode) {
           this.debounceDeactivate();
-          this.debounceReactivate(inputEventMapBinder);
+          this.debounceReactivate();
         }
       });
       activation.registerEventListener(window, 'blur', () => {
         this.debounceDeactivate();
-        this.debounceReactivate(inputEventMapBinder);
+        this.debounceReactivate();
       });
     }
     tool.activate(activation);
     return tool;
   }
 
-  private reactivateQueuedTool(inputEventMapBinder: InputEventMapBinder) {
+  private reactivateQueuedTool() {
     if (this.queuedTool) {
-      const activation = new ToolActivation(this.queuedTool, inputEventMapBinder);
-      this.activeTool = activation;
+      const activation = new ToolActivation(this.queuedTool, this.inputEventMapBinder);
+      this.activeTool_ = activation;
       this.queuedTool.activate(activation);
       this.queuedTool = undefined;
     }
   }
 
   destroyTool(tool: Owned<Tool>) {
-    if (this.activeTool?.tool === tool) {
+    if (this.activeTool_?.tool === tool) {
       this.deactivate_();
     }
     tool.dispose();
@@ -318,9 +323,9 @@ export class ToolBinder extends RefCounted {
   deactivate_() {
     // For internal use only- should only be called by ToolBinder and ToolActivation.cancel()
     this.debounceDeactivate.cancel();
-    const activation = this.activeTool;
+    const activation = this.activeTool_;
     if (activation === undefined) return;
-    this.activeTool = undefined;
+    this.activeTool_ = undefined;
     activation.dispose();
   }
 }

--- a/src/neuroglancer/ui/tool.ts
+++ b/src/neuroglancer/ui/tool.ts
@@ -210,7 +210,10 @@ export class ToolBinder extends RefCounted {
   bindings = new Map<string, Borrowed<Tool>>();
   changed = new Signal();
   private activeTool: Owned<ToolActivation>|undefined;
+  private queuedTool: ToolActivation|undefined;
   private debounceDeactivate = this.registerCancellable(debounce(() => this.deactivate(), 1));
+  private debounceReactivate = this.registerCancellable(debounce(
+    (inputEventMapBinder: InputEventMapBinder) => this.reactivateQueuedTool(inputEventMapBinder), 1));
 
   get(key: string): Borrowed<Tool>|undefined {
     return this.bindings.get(key);
@@ -256,6 +259,7 @@ export class ToolBinder extends RefCounted {
       return;
     }
     this.debounceDeactivate.cancel();
+    this.debounceReactivate.cancel();
     if (tool === this.activeTool?.tool) {
       if (tool.toggle) {
         this.deactivate();
@@ -263,9 +267,10 @@ export class ToolBinder extends RefCounted {
       return;
     }
     else if (this.activeTool) {
-      StatusMessage.showTemporaryMessage(
-        `Can't activate tool ${tool.description} while tool ${this.activeTool.tool.description} is active`);
-      return;
+      if (this.activeTool.tool.toggle && !tool.toggle) {
+        this.queuedTool = this.activeTool;
+      }
+      this.deactivate();
     }
     const activation = new ToolActivation(tool, inputEventMapBinder);
     this.activeTool = activation;
@@ -274,14 +279,25 @@ export class ToolBinder extends RefCounted {
       activation.registerEventListener(window, 'keyup', (event: KeyboardEvent) => {
         if (event.code === expectedCode) {
           this.debounceDeactivate();
+          this.debounceReactivate(inputEventMapBinder);
         }
       });
       activation.registerEventListener(window, 'blur', () => {
         this.debounceDeactivate();
+        this.debounceReactivate(inputEventMapBinder);
       });
     }
     tool.activate(activation);
     return tool;
+  }
+
+  private reactivateQueuedTool(inputEventMapBinder: InputEventMapBinder) {
+    if (this.queuedTool) {
+      const activation = new ToolActivation(this.queuedTool.tool, inputEventMapBinder);
+      this.activeTool = activation;
+      this.queuedTool.tool.activate(activation);
+      this.queuedTool = undefined;
+    }
   }
 
   destroyTool(tool: Owned<Tool>) {

--- a/src/neuroglancer/ui/tool.ts
+++ b/src/neuroglancer/ui/tool.ts
@@ -58,7 +58,6 @@ export abstract class Tool<LayerType extends UserLayer = UserLayer> extends RefC
   }
   abstract activate(activation: ToolActivation<this>): void;
   abstract toJSON(): any;
-  deactivate(): void {}
   abstract description: string;
   unbind() {
     const {layer} = this;
@@ -302,7 +301,6 @@ export class ToolBinder extends RefCounted {
     const activation = this.activeTool;
     if (activation === undefined) return;
     this.activeTool = undefined;
-    activation.tool.deactivate();
     activation.dispose();
   }
 }

--- a/src/neuroglancer/viewer.ts
+++ b/src/neuroglancer/viewer.ts
@@ -302,7 +302,6 @@ export class Viewer extends RefCounted implements ViewerState {
       new TrackableDataSelectionState(this.coordinateSpace, this.layerSelectedValues));
   selectedStateServer = new TrackableValue<string>('', verifyString);
   layerListPanelState = new LayerListPanelState();
-  toolBinder = this.registerDisposer(new ToolBinder());
 
   resetInitiated = new NullarySignal();
 
@@ -776,9 +775,11 @@ export class Viewer extends RefCounted implements ViewerState {
     context.registerDisposer(this.inputEventBindings.perspectiveView.addParent(
           inputEventMap, Number.POSITIVE_INFINITY));
   };
+  
+  private toolBinder = this.registerDisposer(new ToolBinder(this.toolInputEventMapBinder));
 
   activateTool(uppercase: string) {
-    this.toolBinder.activate(uppercase, this.toolInputEventMapBinder);
+    this.toolBinder.activate(uppercase);
   }
 
   editJsonState() {


### PR DESCRIPTION
This is part of the seung-lab merge project.

For some tools (such as merge and split), it is more convenient to have the tool be activated by toggle (press and release the key once to activate, then press and release the key again to deactivate) rather than hold (press the key to activate, then release the key to deactivate). This PR adds a `toggle` parameter (defaulting to `false`) in the `Tool` constructor which supports this behavior. To preserve default behavior, I don't set this to `true` for any currently existing tools, but I could if you think that's a good idea (it would be a small change to `MergeSegmentsTool` and `SplitSegmentsTool`, or any other tool you think would be suited to this behavior).

It also makes the `deactivate` method on the `ToolBinder` public. This is needed for tools to be able to disable themselves upon the completion of an operation (i.e. finishing a merge, then the merge tool gets automatically deactivated). Also, it calls the `Tool.deactivate()` method in `ToolBinder.deactivate()`, so that tools can clear their own internal state.