### PR TITLE
feat(tools): default tool keybinds

### DIFF
--- a/src/neuroglancer/help/input_event_bindings.ts
+++ b/src/neuroglancer/help/input_event_bindings.ts
@@ -151,7 +151,14 @@ export class InputEventBindingHelpDialog extends SidePanel {
         layerBindings = [];
         layerToolBindingsMap.set(tool.layer, layerBindings);
       }
-      layerBindings.push([`shift+key${key.toLowerCase()}`, tool.description]);
+      const globalBindings = [...bindings][0][1].parents[0];
+      const bindingsForTool = [...globalBindings.bindings.entries()].filter(([event, eventAction]) => {
+        return eventAction.action === `tool-${key.toUpperCase()}` && event.startsWith('at');
+      });
+      const bindingIdentifiersForTool = bindingsForTool.map(([event, eventAction]) => {
+        return eventAction.originalEventIdentifier || event;
+      });
+      layerBindings.push([bindingIdentifiersForTool.join(', '), tool.description]);
     }
     const layerToolBindings = Array.from(layerToolBindingsMap.entries());
     if (layerToolBindings.length > 0) {

--- a/src/neuroglancer/ui/layer_data_sources_tab.ts
+++ b/src/neuroglancer/ui/layer_data_sources_tab.ts
@@ -321,6 +321,7 @@ function changeLayerTypeToDetected(userLayer: UserLayer) {
     const layerConstructor = userLayer.detectedLayerConstructor;
     if (layerConstructor !== undefined) {
       changeLayerType(userLayer.managedLayer, layerConstructor);
+      userLayer.managedLayer.layer!.toolBinder.loadDefaultKeybinds();
       return true;
     }
   }
@@ -362,7 +363,6 @@ export class LayerDataSourcesTab extends Tab {
       layerTypeDetection.classList.add('neuroglancer-layer-data-sources-tab-type-detection');
       layerTypeDetection.addEventListener('click', () => {
         changeLayerTypeToDetected(layer);
-        layer.managedLayer.layer!.toolBinder.loadDefaultKeybinds();
       });
     }
     const reRender = this.reRender = animationFrameDebounce(() => this.updateView());

--- a/src/neuroglancer/ui/layer_data_sources_tab.ts
+++ b/src/neuroglancer/ui/layer_data_sources_tab.ts
@@ -362,6 +362,7 @@ export class LayerDataSourcesTab extends Tab {
       layerTypeDetection.classList.add('neuroglancer-layer-data-sources-tab-type-detection');
       layerTypeDetection.addEventListener('click', () => {
         changeLayerTypeToDetected(layer);
+        layer.managedLayer.layer!.toolBinder.loadDefaultKeybinds();
       });
     }
     const reRender = this.reRender = animationFrameDebounce(() => this.updateView());

--- a/src/neuroglancer/ui/tool.ts
+++ b/src/neuroglancer/ui/tool.ts
@@ -413,12 +413,7 @@ export class LayerToolBinder {
       const obj: DefaultKeybindsForLayerType = {};
       const defaultKeybindsForLayer = DEFAULT_KEYBINDS[this.layer.type] || {};
       for (const [key, value] of Object.entries(defaultKeybindsForLayer)) {
-        const toolAlreadyBound = [...this.bindings.values()].includes(value);
-        if (toolAlreadyBound) {
-          continue;
-        }
-        const existingTool = this.globalBinder.get(key);
-        if (existingTool && !existingTool.layer.managedLayer.archived) {
+        if (this.globalBinder.get(key)) {
           continue;
         }
         obj[key] = value;


### PR DESCRIPTION
also added a fix to help menu so that it picks up changes to the tool global keybinds. We want to modify the defaultGlobalBindings to allow non-shift keybinds for certain tools.

I don't like this line ```const globalBindings = [...bindings][0][1].parents[0];``` I was hoping you had a better idea on how to handle it.

Also, the change I made to `src/neuroglancer/help/input_event_bindings.ts` is not enough. We only want to apply the default keybinds to layers that are created by the user, not layers loaded from the state.

If users change the layer type to 'auto' or 'segmentation' before entering the layer url, this code won't fire. I'm not sure the correct place to differentiate between newly created layers and those loaded from the state.