### PR TITLE
fix(compresso): format check was incorrect

### DIFF
--- a/src/neuroglancer/sliceview/compresso/index.ts
+++ b/src/neuroglancer/sliceview/compresso/index.ts
@@ -47,7 +47,7 @@ function readHeader(buffer: Uint8Array)
     throw new Error("compresso: didn't match magic numbers")
   }
   const format = buffer[4];
-  if (format !== 0) {
+  if (format > 1) {
     throw new Error("compresso: didn't match format version")
   }
 


### PR DESCRIPTION
Check was backwards compatible, but not forwards compatible with
the new version. Validated that this works with latest.