### PR TITLE
docs: add Igneous to related projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,7 @@ There is a Google Group/mailing list for discussion related to Neuroglancer:
 - [BigArrays.jl](https://github.com/seung-lab/BigArrays.jl) - Julia interface of neuroglancer precomputed data format.
 - [cloudvolume](https://github.com/seung-lab/cloud-volume) - Python interface of neuroglancer precomputed data format.
 - [multiresolution-mesh-creator](https://github.com/janelia-cosem/multiresolution-mesh-creator) - Python tool for creating [multi-resolution meshes](https://github.com/google/neuroglancer/blob/master/src/neuroglancer/datasource/precomputed/meshes.md#multi-resolution-mesh-format) from single resolution - or multiscale - meshes.
+- [Igneous](https://github.com/seung-lab/igneous) - Python pipeline for scalable meshing, skeletonizing, downsampling, and managment of large 3d images focusing on Neuroglancer Precomputed format.
 
 # Contributing
 


### PR DESCRIPTION
Hi Jeremy,

If this is okay, I'd like to add Igneous to the related projects section to make it easier for people to find it. It might help people get started with Neuroglancer more quickly.