### PR TITLE
feat(segmentation_user_layer): hide segments

### DIFF
--- a/src/neuroglancer/datasource/graphene/frontend.ts
+++ b/src/neuroglancer/datasource/graphene/frontend.ts
@@ -646,11 +646,11 @@ class GraphConnection extends SegmentationGraphSourceConnection {
       public state: GrapheneState) {
     super(graph, layer.displayState.segmentationGroupState.value);
     const segmentsState = layer.displayState.segmentationGroupState.value;
-    segmentsState.visibleSegments.changed.add((segmentIds: Uint64[]|Uint64|null, add: boolean) => {
+    segmentsState.selectedSegments.changed.add((segmentIds: Uint64[]|Uint64|null, add: boolean) => {
       if (segmentIds !== null) {
         segmentIds = Array<Uint64>().concat(segmentIds);
       }
-      this.visibleSegmentsChanged(segmentIds, add);
+      this.selectedSegmentsChanged(segmentIds, add);
     });
 
     const {annotationLayerStates, state: {multicutState}} = this;
@@ -678,11 +678,11 @@ class GraphConnection extends SegmentationGraphSourceConnection {
   private lastDeselectionMessage: StatusMessage|undefined;
   private lastDeselectionMessageExists = false;
 
-  private visibleSegmentsChanged(segments: Uint64[]|null, added: boolean) {
+  private selectedSegmentsChanged(segments: Uint64[]|null, added: boolean) {
     const {segmentsState} = this;
 
     if (segments === null) {
-      const leafSegmentCount = this.segmentsState.visibleSegments.size;
+      const leafSegmentCount = this.segmentsState.selectedSegments.size;
       this.segmentsState.segmentEquivalences.clear();
       StatusMessage.showTemporaryMessage(`Deselected all ${leafSegmentCount} segments.`, 3000);
       return;
@@ -696,14 +696,14 @@ class GraphConnection extends SegmentationGraphSourceConnection {
       if (added) {
         if (isBaseSegment) {
           this.graph.getRoot(segmentConst).then(rootId => {
-            segmentsState.visibleSegments.delete(segmentConst);
-            segmentsState.visibleSegments.add(rootId);
+            segmentsState.selectedSegments.delete(segmentConst);
+            segmentsState.selectedSegments.add(rootId);
           });
         }
       } else if (!isBaseSegment) {
         const {focusSegment: {value: focusSegment}} = this.graph.state.multicutState;
         if (focusSegment && Uint64.equal(segmentId, focusSegment)) {
-          segmentsState.visibleSegments.add(segmentId);
+          segmentsState.selectedSegments.add(segmentId);
           StatusMessage.showTemporaryMessage(`Can't deselect active multicut segment.`, 3000);
           return;
         }
@@ -748,12 +748,10 @@ class GraphConnection extends SegmentationGraphSourceConnection {
         return false;
       } else {
         const {segmentsState} = this;
-
         for (const segment of [...sinks, ...sources]) {
-          segmentsState.visibleSegments.delete(segment.rootId);
+          segmentsState.selectedSegments.delete(segment.rootId);
         }
-
-        segmentsState.visibleSegments.add(splitRoots);
+        segmentsState.selectedSegments.add(splitRoots);
         multicutState.reset();
         return true;
       }
@@ -1235,11 +1233,10 @@ class MulticutSegmentsTool extends Tool<SegmentationUserLayer> {
 
     activation.bindAction('set-anchor', event => {
       event.stopPropagation();
-      
       const {segmentSelectionState: {baseValue, value}} = this.layer.displayState;
       if (!baseValue || !value) return;
 
-      if (!segmentationGroupState.visibleSegments.has(value)) {
+      if (!segmentationGroupState.selectedSegments.has(value)) {
         StatusMessage.showTemporaryMessage(
             'The selected supervoxel is of an unselected segment', 7000);
         return;

--- a/src/neuroglancer/datasource/nggraph/frontend.ts
+++ b/src/neuroglancer/datasource/nggraph/frontend.ts
@@ -217,9 +217,9 @@ class GraphConnection extends SegmentationGraphSourceConnection {
       this.segmentQueries.delete(segmentIdString);
       try {
         this.ignoreVisibleSegmentsChanged = true;
-        if (this.segmentsState.visibleSegments.has(oldId)) {
-          this.segmentsState.visibleSegments.delete(oldId);
-          this.segmentsState.visibleSegments.add(newId);
+        if (this.segmentsState.selectedSegments.has(oldId)) {
+          this.segmentsState.selectedSegments.delete(oldId);
+          this.segmentsState.selectedSegments.add(newId);
         }
         if (this.segmentsState.temporaryVisibleSegments.has(oldId)) {
           this.segmentsState.temporaryVisibleSegments.delete(oldId);

--- a/src/neuroglancer/segmentation_display_state/backend.ts
+++ b/src/neuroglancer/segmentation_display_state/backend.ts
@@ -43,6 +43,7 @@ export const withSegmentationLayerBackendState =
     <TBase extends AnyConstructor<ChunkRequester>>(Base: TBase) =>
         class SegmentationLayerState extends Base implements VisibleSegmentsState {
   visibleSegments: Uint64Set;
+  selectedSegments: Uint64Set;
   segmentEquivalences: SharedDisjointUint64Sets;
   temporaryVisibleSegments: Uint64Set;
   temporarySegmentEquivalences: SharedDisjointUint64Sets;

--- a/src/neuroglancer/segmentation_display_state/base.ts
+++ b/src/neuroglancer/segmentation_display_state/base.ts
@@ -23,6 +23,7 @@ import {VisibleSegmentEquivalencePolicy} from 'neuroglancer/segmentation_graph/s
 
 export interface VisibleSegmentsState {
   visibleSegments: Uint64Set;
+  selectedSegments: Uint64Set;
   segmentEquivalences: SharedDisjointUint64Sets;
 
   // Specifies a temporary/alternative set of segments/equivalences to use for display purposes,

--- a/src/neuroglancer/segmentation_display_state/frontend.ts
+++ b/src/neuroglancer/segmentation_display_state/frontend.ts
@@ -396,14 +396,17 @@ function makeRegisterSegmentWidgetEventHandlers(displayState: SegmentationDispla
   };
 
   const onMousedown = (event: MouseEvent) => {
-    if (event.button !== 2 || event.ctrlKey || event.altKey || event.metaKey || event.shiftKey) {
-      return;
-    }
     const entryElement = event.currentTarget as HTMLElement;
     const idString = entryElement.dataset.id!;
     const id = tempStatedColor
     id.tryParseString(idString);
-    displayState.moveToSegment(id);
+
+    if (event.button === 0 && event.ctrlKey && !event.altKey && !event.metaKey && !event.shiftKey) {
+      const {selectedSegments} = displayState.segmentationGroupState.value;
+      selectedSegments.delete(id);
+    } else if (event.button === 2 && !event.ctrlKey && !event.altKey && !event.metaKey && !event.shiftKey) {
+      displayState.moveToSegment(id);
+    }
   };
 
   return (element: HTMLElement, template: SegmentWidgetTemplate) => {

--- a/src/neuroglancer/segmentation_graph/local.ts
+++ b/src/neuroglancer/segmentation_graph/local.ts
@@ -179,10 +179,10 @@ export class LocalSegmentationGraphSource extends SegmentationGraphSource {
     removeSplitEdges(includeBaseSegments, includeRoot);
     removeSplitEdges(excludeBaseSegments, excludeRoot);
     for (const connection of this.connections) {
-      const {visibleSegments} = connection.segmentsState;
-      if (visibleSegments.has(excludeRepresentative)) {
-        visibleSegments.delete(excludeRepresentative);
-        visibleSegments.add(includeRepresentative);
+      const {selectedSegments} = connection.segmentsState;
+      if (selectedSegments.has(excludeRepresentative)) {
+        selectedSegments.delete(excludeRepresentative);
+        selectedSegments.add(includeRepresentative);
       }
     }
     this.normalizeAll();

--- a/src/neuroglancer/segmentation_user_layer.ts
+++ b/src/neuroglancer/segmentation_user_layer.ts
@@ -70,7 +70,8 @@ const BASE_SEGMENT_COLORING_JSON_KEY = 'baseSegmentColoring';
 const IGNORE_NULL_VISIBLE_SET_JSON_KEY = 'ignoreNullVisibleSet';
 const MESH_JSON_KEY = 'mesh';
 const SKELETONS_JSON_KEY = 'skeletons';
-const SEGMENTS_JSON_KEY = 'segments';
+const SELECTED_SEGMENTS_JSON_KEY = 'segments';
+// const VISIBLE_SEGMENTS_JSON_KEY = 'visibleSegments';
 const EQUIVALENCES_JSON_KEY = 'equivalences';
 const COLOR_SEED_JSON_KEY = 'colorSeed';
 const SEGMENT_STATED_COLORS_JSON_KEY = 'segmentColors';
@@ -92,9 +93,26 @@ export class SegmentationUserLayerGroupState extends RefCounted implements Segme
   constructor(public layer: SegmentationUserLayer) {
     super();
     const {specificationChanged} = this;
-    this.visibleSegments.changed.add(specificationChanged.dispatch);
     this.hideSegmentZero.changed.add(specificationChanged.dispatch);
     this.segmentQuery.changed.add(specificationChanged.dispatch);
+
+    const {visibleSegments, selectedSegments} = this;
+    visibleSegments.changed.add(specificationChanged.dispatch);
+    selectedSegments.changed.add(specificationChanged.dispatch);
+    selectedSegments.changed.add((x, add) => {
+      if (x === null && !add) {
+        visibleSegments.clear();
+      } else if (x) {
+        if (add) {
+          visibleSegments.add(x);
+        } else {
+          visibleSegments.delete(x);
+        }
+      }
+    });
+
+    visibleSegments.changed.add(() => { console.log('visibleSegments', visibleSegments.toJSON())});
+    selectedSegments.changed.add(() => { console.log('selectedSegments', selectedSegments.toJSON())});
   }
 
   restoreState(specification: unknown) {
@@ -105,11 +123,11 @@ export class SegmentationUserLayerGroupState extends RefCounted implements Segme
       this.localGraph.restoreState(value);
     });
 
-    verifyOptionalObjectProperty(specification, SEGMENTS_JSON_KEY, segmentsValue => {
-      const {segmentEquivalences, visibleSegments} = this;
+    verifyOptionalObjectProperty(specification, SELECTED_SEGMENTS_JSON_KEY, segmentsValue => {
+      const {segmentEquivalences, selectedSegments} = this;
       parseArray(segmentsValue, value => {
         let id = Uint64.parseString(String(value), 10);
-        visibleSegments.add(segmentEquivalences.get(id));
+        selectedSegments.add(segmentEquivalences.get(id));
       });
     });
     verifyOptionalObjectProperty(
@@ -119,9 +137,9 @@ export class SegmentationUserLayerGroupState extends RefCounted implements Segme
   toJSON() {
     const x: any = {};
     x[HIDE_SEGMENT_ZERO_JSON_KEY] = this.hideSegmentZero.toJSON();
-    let {visibleSegments} = this;
-    if (visibleSegments.size > 0) {
-      x[SEGMENTS_JSON_KEY] = visibleSegments.toJSON();
+    let {selectedSegments} = this;
+    if (selectedSegments.size > 0) {
+      x[SELECTED_SEGMENTS_JSON_KEY] = this.selectedSegments.toJSON();
     }
     let {segmentEquivalences} = this;
     if (this.localSegmentEquivalences && segmentEquivalences.size > 0) {
@@ -134,12 +152,14 @@ export class SegmentationUserLayerGroupState extends RefCounted implements Segme
   assignFrom(other: SegmentationUserLayerGroupState) {
     this.maxIdLength.value = other.maxIdLength.value;
     this.hideSegmentZero.value = other.hideSegmentZero.value;
+    this.selectedSegments.assignFrom(other.selectedSegments);
     this.visibleSegments.assignFrom(other.visibleSegments);
     this.segmentEquivalences.assignFrom(other.segmentEquivalences);
   }
 
   localGraph = new LocalSegmentationGraphSource();
   visibleSegments = this.registerDisposer(Uint64Set.makeWithCounterpart(this.layer.manager.rpc));
+  selectedSegments = this.registerDisposer(Uint64Set.makeWithCounterpart(this.layer.manager.rpc));
   segmentPropertyMap = new WatchableValue<PreprocessedSegmentPropertyMap|undefined>(undefined);
   graph = new WatchableValue<SegmentationGraphSource|undefined>(undefined);
   segmentEquivalences = this.registerDisposer(SharedDisjointUint64Sets.makeWithCounterpart(
@@ -684,14 +704,14 @@ export class SegmentationUserLayer extends Base {
         const {segmentSelectionState} = this.displayState;
         if (segmentSelectionState.hasSelectedSegment) {
           const segment = segmentSelectionState.selectedSegment;
-          const {visibleSegments} = this.displayState.segmentationGroupState.value;
-          const newVisible = !visibleSegments.has(segment);
+          const {selectedSegments} = this.displayState.segmentationGroupState.value;
+          const newVisible = !selectedSegments.has(segment);
           if (newVisible || context.segmentationToggleSegmentState === undefined) {
             context.segmentationToggleSegmentState = newVisible;
           }
           context.defer(() => {
             if (context.segmentationToggleSegmentState === newVisible) {
-              visibleSegments.set(segment, newVisible);
+              selectedSegments.set(segment, newVisible);
             }
           });
         }

--- a/src/neuroglancer/ui/segment_list.ts
+++ b/src/neuroglancer/ui/segment_list.ts
@@ -82,8 +82,8 @@ class SegmentListSource extends RefCounted implements VirtualListSource {
     const splices: ArraySpliceOp[] = [];
     let changed = false;
     let matchStatusTextPrefix = '';
-    const {visibleSegments} = this.segmentationDisplayState.segmentationGroupState.value;
-    const visibleSegmentsGeneration = visibleSegments.changed.count;
+    const {selectedSegments} = this.segmentationDisplayState.segmentationGroupState.value;
+    const visibleSegmentsGeneration = selectedSegments.changed.count;
     const prevVisibleSegmentsGeneration = this.visibleSegmentsGeneration;
     const unconstrained = isQueryUnconstrained(queryResult.query);
     if (unconstrained) {
@@ -91,7 +91,7 @@ class SegmentListSource extends RefCounted implements VirtualListSource {
       if (prevVisibleSegmentsGeneration !== visibleSegmentsGeneration ||
           this.explicitSegments === undefined || !this.explicitSegmentsVisible) {
         this.visibleSegmentsGeneration = visibleSegmentsGeneration;
-        const newSortedVisibleSegments = Array.from(visibleSegments, x => x.clone());
+        const newSortedVisibleSegments = Array.from(selectedSegments, x => x.clone());
         newSortedVisibleSegments.sort(Uint64.compare);
         const {explicitSegments} = this;
         if (explicitSegments === undefined) {
@@ -150,7 +150,7 @@ class SegmentListSource extends RefCounted implements VirtualListSource {
       if (segmentPropertyMap !== undefined && queryResult.count > 0) {
         // Recompute selectedMatches.
         selectedMatches =
-            findQueryResultIntersectionSize(segmentPropertyMap, queryResult, visibleSegments);
+            findQueryResultIntersectionSize(segmentPropertyMap, queryResult, selectedSegments);
         statusText += ` (${selectedMatches} visible)`;
       }
       this.selectedMatches = selectedMatches;
@@ -175,8 +175,11 @@ class SegmentListSource extends RefCounted implements VirtualListSource {
     this.update();
 
     this.registerDisposer(
-        segmentationDisplayState.segmentationGroupState.value.visibleSegments.changed.add(
+        segmentationDisplayState.segmentationGroupState.value.selectedSegments.changed.add(
             this.debouncedUpdate));
+    this.registerDisposer(
+        segmentationDisplayState.segmentationGroupState.value.selectedSegments.changed.add(
+            () => { console.log('selectedSegments.changed');}));
     this.registerDisposer(query.changed.add(this.debouncedUpdate));
   }
 
@@ -872,9 +875,9 @@ export class SegmentDisplayTab extends Tab {
                   const selectionCopyButton = makeCopyButton({
                     title: 'Copy visible segment IDs',
                     onClick: () => {
-                      const visibleSegments = Array.from(group.visibleSegments, x => x.clone());
-                      visibleSegments.sort(Uint64.compare);
-                      setClipboard(visibleSegments.join(', '));
+                      const selectedSegments = Array.from(group.selectedSegments, x => x.clone());
+                      selectedSegments.sort(Uint64.compare);
+                      setClipboard(selectedSegments.join(', '));
                     },
                   });
                   const selectionStatusMessage = document.createElement('span');

--- a/src/neuroglancer/ui/segment_list.ts
+++ b/src/neuroglancer/ui/segment_list.ts
@@ -907,7 +907,7 @@ export class SegmentDisplayTab extends Tab {
                     listSource.debouncedUpdate.flush();
                     const queryResult = listSource.queryResult.value;
                     if (queryResult === undefined) return;
-                    const {visibleSegments} = group;
+                    const {selectedSegments} = group;
                     const {selectedMatches} = listSource;
                     const shouldSelect = (selectedMatches !== queryResult.count);
                     if (shouldSelect &&
@@ -922,7 +922,7 @@ export class SegmentDisplayTab extends Tab {
                       updateStatus();
                     }
                     forEachQueryResultSegmentId(segmentPropertyMap, queryResult, id => {
-                      visibleSegments.set(id, shouldSelect);
+                      selectedSegments.set(id, shouldSelect);
                     });
                     return true;
                   };

--- a/src/neuroglancer/ui/segment_select_tools.ts
+++ b/src/neuroglancer/ui/segment_select_tools.ts
@@ -90,13 +90,13 @@ export class SelectSegmentsTool extends Tool<SegmentationUserLayer> {
       const {segmentSelectionState} = layer.displayState;
       if (segmentSelectionState.hasSelectedSegment) {
         const segment = segmentSelectionState.selectedSegment;
-        const {visibleSegments} = layer.displayState.segmentationGroupState.value;
+        const {selectedSegments} = layer.displayState.segmentationGroupState.value;
         switch (currentState) {
           case ToolState.SELECT:
-            visibleSegments.add(segment);
+            selectedSegments.add(segment);
             break;
           case ToolState.DESELECT:
-            visibleSegments.delete(segment);
+            selectedSegments.delete(segment);
             break;
         }
       }


### PR DESCRIPTION
the checkbox now hides the visible segments but does not remove it from the list.

this is a rough version to gauge your thoughts on the feature/implementation. I threw in a random removal method: ctrl + left click.

I think a more proper implementation would make the visibleSegment act similar to a sql view on top of selected segments but still conform to the uint64S, and selectedSegments could be changed to be a Uint64Map: segment id -> visibility (0/1). Another option is to change selectedSegments to hiddenSegments. There are many ways the JSON state could work, obviously it must be backwards compatible.

I didn't touch the temporary sets but it seems it would justify another temporary set and useTemporaryVisibleSegments would enable both.