### PR TITLE
Choose best available BossDB requested encoding

### DIFF
--- a/src/neuroglancer/datasource/boss/frontend.ts
+++ b/src/neuroglancer/datasource/boss/frontend.ts
@@ -300,7 +300,8 @@ export class BossMultiscaleVolumeChunkSource extends MultiscaleVolumeChunkSource
 
     let encoding = verifyOptionalString(parameters['encoding']);
     if (encoding === undefined) {
-      encoding = this.volumeType === VolumeType.IMAGE ? 'jpeg' : 'npz';
+      // 8-bit image encoded in JPEG filmstrips. 
+      encoding = this.dataType === DataType.UINT8 ? 'jpeg' : 'npz';
     } else {
       if (!VALID_ENCODINGS.has(encoding)) {
         throw new Error(`Invalid encoding: ${JSON.stringify(encoding)}.`);


### PR DESCRIPTION
BossDB can render u8 imagery as JPEG filmstrips, which saves ~50% on egress filesize. All other datatypes should be returned as npygz.

This also adds support for non-u8 imagery :)

> cc @BrockWester @dxenes1 @hannahgooden 