### PR TITLE
Update write_annotations.py

### DIFF
--- a/python/neuroglancer/write_annotations.py
+++ b/python/neuroglancer/write_annotations.py
@@ -16,6 +16,7 @@ amount of annotation data:
 
 from . import coordinate_space
 from typing import List, Sequence, NamedTuple, Optional
+from typing_exceptions import Literal
 from . import viewer_state
 import numbers
 import io
@@ -24,10 +25,6 @@ import os
 import numpy as np
 import struct
 
-try:
-    from typing import Literal
-except:
-    from typing_excpetions import Literal
 
 class Annotation(NamedTuple):
     id: int

--- a/python/neuroglancer/write_annotations.py
+++ b/python/neuroglancer/write_annotations.py
@@ -15,7 +15,7 @@ amount of annotation data:
 """
 
 from . import coordinate_space
-from typing import List, Sequence, NamedTuple, Literal, Optional
+from typing import List, Sequence, NamedTuple, Optional
 from . import viewer_state
 import numbers
 import io
@@ -24,6 +24,10 @@ import os
 import numpy as np
 import struct
 
+try:
+    from typing import Literal
+except:
+    from typing_excpetions import Literal
 
 class Annotation(NamedTuple):
     id: int

--- a/setup.py
+++ b/setup.py
@@ -245,7 +245,8 @@ setuptools.setup(
         'six',
         'google-apitools',
         'google-auth',
-        'atomicwrites'
+        'atomicwrites',
+        'typing_exceptions',
     ],
     extras_require={
         'test': [


### PR DESCRIPTION
Update to allow this module to be compatible with python versions < 3.8. This is important because Colab runs python 3.7.