### PR TITLE
fix(datasource/graphene): closing graphene merge on submission

### DIFF
--- a/src/neuroglancer/datasource/graphene/frontend.ts
+++ b/src/neuroglancer/datasource/graphene/frontend.ts
@@ -1396,13 +1396,13 @@ class MergeSegmentsTool extends Tool<SegmentationUserLayer> {
             setSource(selection.rootId);
             const loadedSubsource = getGraphLoadedSubsource(this.layer)!;
             const annotationToNanometers = loadedSubsource.loadedDataSource.transform.inputSpace.value.scales.map(x => x / 1e-9);
+            activation.cancel();
             const mergedRoot = await graph.graphServer.mergeSegments(lastSegmentSelection, selection, annotationToNanometers);
             const {visibleSegments} = segmentationGroupState;
             visibleSegments.delete(lastSegmentSelection.rootId);
             visibleSegments.delete(selection.rootId);
             visibleSegments.add(mergedRoot);
             this.lastAnchorSelection.value = undefined;
-            activation.cancel();
           }
         }
       })()


### PR DESCRIPTION
rather than waiting for response to return full mouse control to the user