### PR TITLE
feat(datasource/graphene) added refresh meshes tool

### DIFF
--- a/src/neuroglancer/datasource/graphene/backend.ts
+++ b/src/neuroglancer/datasource/graphene/backend.ts
@@ -17,7 +17,7 @@
 import {WithParameters} from 'neuroglancer/chunk_manager/backend';
 import {WithSharedCredentialsProviderCounterpart} from 'neuroglancer/credentials_provider/shared_counterpart';
 import {assignMeshFragmentData, FragmentChunk, ManifestChunk, MeshSource} from 'neuroglancer/mesh/backend';
-import {getGrapheneFragmentKey, responseIdentity} from 'neuroglancer/datasource/graphene/base';
+import {getGrapheneFragmentKey, GRAPHENE_REFRESH_MESH_RPC_ID, responseIdentity} from 'neuroglancer/datasource/graphene/base';
 import {CancellationToken} from 'neuroglancer/util/cancellation';
 import {isNotFoundError, responseArrayBuffer, responseJson} from 'neuroglancer/util/http_request';
 import {cancellableFetchSpecialOk, SpecialProtocolCredentials, SpecialProtocolCredentialsProvider} from 'neuroglancer/util/special_protocol_request';
@@ -94,6 +94,17 @@ async function decodeDracoFragmentChunk(
 
 @registerSharedObject() export class GrapheneMeshSource extends
 (WithParameters(WithSharedCredentialsProviderCounterpart<SpecialProtocolCredentials>()(MeshSource), MeshSourceParameters)) {
+  chunksNotFound = new Map<string, FragmentChunk[]>();
+
+  redownload(segment: Uint64) {
+    const segmentString = segment.toJSON();
+    const segmentChunks = this.chunksNotFound.get(segmentString) || [];
+    this.chunksNotFound.delete(segmentString);
+    for (let chunk of segmentChunks) {
+      this.chunkManager.queueManager.updateChunkState(chunk, ChunkState.QUEUED);
+    }
+  }
+
   async download(chunk: ManifestChunk, cancellationToken: CancellationToken) {
     const {parameters} = this;
     if (isBaseSegmentId(chunk.objectId, parameters.nBitsForLayerId)) {
@@ -115,9 +126,13 @@ async function decodeDracoFragmentChunk(
       await decodeDracoFragmentChunk(chunk, response);
     } catch (e) {
       if (isNotFoundError(e)) {
-        chunk.source!.removeChunk(chunk);
+        const segmentString = chunk.manifestChunk?.objectId?.toJSON();
+        if (segmentString) {
+          this.chunksNotFound.set(segmentString, this.chunksNotFound.get(segmentString) || []);
+          this.chunksNotFound.get(segmentString)!.push(chunk);
+        }
       }
-      Promise.reject(e);
+      throw e;
     }
   }
 
@@ -420,4 +435,9 @@ registerRPC(CHUNKED_GRAPH_RENDER_LAYER_UPDATE_SOURCES_RPC_ID, function(x) {
       ChunkedGraphLayer, GrapheneChunkedGraphChunkSource>;
   attachment.state!.displayDimensionRenderInfo = x.displayDimensionRenderInfo;
   layer.chunkManager.scheduleUpdateChunkPriorities();
+});
+
+registerRPC(GRAPHENE_REFRESH_MESH_RPC_ID, function(x) {
+  let obj = <GrapheneMeshSource>this.get(x.rpcId);
+  obj.redownload(Uint64.parseString(x.segment));
 });

--- a/src/neuroglancer/datasource/graphene/base.ts
+++ b/src/neuroglancer/datasource/graphene/base.ts
@@ -20,6 +20,7 @@ import {ChunkLayoutOptions, makeSliceViewChunkSpecification, SliceViewChunkSourc
 import {DataType} from 'neuroglancer/sliceview/base';
 
 export const PYCG_APP_VERSION = 1;
+export const GRAPHENE_REFRESH_MESH_RPC_ID = 'GrapheneMeshSource:RefreshMesh';
 
 export enum VolumeChunkEncoding {
   RAW,


### PR DESCRIPTION
It would be nice to clear out GrapheneMeshSource.chunksNotFound when hiding a mesh to prevent memory growth. Any suggestion on how you would do that since MeshSource doesn't have access to visibleSegments?