### PR TITLE
feat: adds hidden attribute to ScaleInfo for placeholder resolutions

### DIFF
--- a/src/neuroglancer/datasource/precomputed/frontend.ts
+++ b/src/neuroglancer/datasource/precomputed/frontend.ts
@@ -37,7 +37,7 @@ import {Borrowed} from 'neuroglancer/util/disposable';
 import {mat4, vec3} from 'neuroglancer/util/geom';
 import {completeHttpPath} from 'neuroglancer/util/http_path_completion';
 import {isNotFoundError, responseJson} from 'neuroglancer/util/http_request';
-import {parseArray, parseFixedLengthArray, parseQueryStringParameters, unparseQueryStringParameters, verifyEnumString, verifyFiniteFloat, verifyFinitePositiveFloat, verifyInt, verifyObject, verifyObjectProperty, verifyOptionalObjectProperty, verifyOptionalString, verifyPositiveInt, verifyString, verifyStringArray} from 'neuroglancer/util/json';
+import {parseArray, parseFixedLengthArray, parseQueryStringParameters, unparseQueryStringParameters, verifyEnumString, verifyFiniteFloat, verifyFinitePositiveFloat, verifyInt, verifyObject, verifyObjectProperty, verifyOptionalObjectProperty, verifyOptionalString, verifyPositiveInt, verifyString, verifyStringArray, verifyOptionalBoolean} from 'neuroglancer/util/json';
 import * as matrix from 'neuroglancer/util/matrix';
 import {getObjectId} from 'neuroglancer/util/object_id';
 import {cancellableFetchSpecialOk, parseSpecialUrl, SpecialProtocolCredentials, SpecialProtocolCredentialsProvider} from 'neuroglancer/util/special_protocol_request';
@@ -85,6 +85,7 @@ class ScaleInfo {
   chunkSizes: Uint32Array[];
   compressedSegmentationBlockSize: vec3|undefined;
   sharding: ShardingParameters|undefined;
+  hidden: boolean|undefined;
   constructor(obj: any, numChannels: number) {
     verifyObject(obj);
     const rank = (numChannels === 1) ? 3 : 4;
@@ -124,6 +125,7 @@ class ScaleInfo {
           x => parseFixedLengthArray(vec3.create(), x, verifyPositiveInt));
     }
     this.key = verifyObjectProperty(obj, 'key', verifyString);
+    this.hidden =  verifyObjectProperty(obj, 'hidden', verifyOptionalBoolean);
   }
 }
 
@@ -208,7 +210,7 @@ export class PrecomputedMultiscaleVolumeChunkSource extends MultiscaleVolumeChun
   getSources(volumeSourceOptions: VolumeSourceOptions) {
     const modelResolution = this.info.scales[0].resolution;
     const {rank} = this;
-    return transposeNestedArrays(this.info.scales.map(scaleInfo => {
+    return transposeNestedArrays(this.info.scales.filter(x => !x.hidden).map(scaleInfo => {
       const {resolution} = scaleInfo;
       const stride = rank + 1;
       const chunkToMultiscaleTransform = new Float32Array(stride * stride);

--- a/src/neuroglancer/datasource/precomputed/frontend.ts
+++ b/src/neuroglancer/datasource/precomputed/frontend.ts
@@ -85,7 +85,7 @@ class ScaleInfo {
   chunkSizes: Uint32Array[];
   compressedSegmentationBlockSize: vec3|undefined;
   sharding: ShardingParameters|undefined;
-  hidden: boolean|undefined;
+  hidden: boolean;
   constructor(obj: any, numChannels: number) {
     verifyObject(obj);
     const rank = (numChannels === 1) ? 3 : 4;
@@ -125,7 +125,7 @@ class ScaleInfo {
           x => parseFixedLengthArray(vec3.create(), x, verifyPositiveInt));
     }
     this.key = verifyObjectProperty(obj, 'key', verifyString);
-    this.hidden =  verifyObjectProperty(obj, 'hidden', verifyOptionalBoolean);
+    this.hidden =  verifyObjectProperty(obj, 'hidden', verifyOptionalBoolean) ?? false;
   }
 }
 

--- a/src/neuroglancer/datasource/precomputed/volume.md
+++ b/src/neuroglancer/datasource/precomputed/volume.md
@@ -56,6 +56,7 @@ The root value must be a JSON object with the following members:
     format](#sharded-chunk-storage).  Must be a [sharding specification](./sharded.md#sharding-specification).
     If the sharded format is used, the `"chunk_sizes"` member must specify only a single chunk size.
     If unspecified, the [unsharded format](#unsharded-chunk-storage) is used.
+  - `"hidden"`: Optional. If specified, must be a boolean value that indicates if the scale should be not rendered in the viewer. Defaults to `False`. 
 - `"mesh"`: May be optionally specified if `"volume_type"` is `"segmentation"`.  If specified, it
   must be a string value specifying the name of the subdirectory containing the [mesh
   data](./meshes.md).


### PR DESCRIPTION
Hi Jeremy, 

I've been following the thread between you and Chris on #446 and wanted to offer this PR as a potential solution to the placeholder issue we're having with the FAFB dataset. Feel free to disregard it if you have a better solution in mind!

This PR adds an optional boolean `hidden` attribute to the ScaleInfo. If a scale is hidden, it is filtered out when creating the nested arrays for `getSources`. However, the base resolution is still set on the first scale, regardless if it's hidden. It's similar to Chris's implementation of 'placeholder' on the seung-lab fork. 

Thank you for your time and consideration!
