### PR TITLE
feat(datasource/graphene) improved merge tool

### DIFF
--- a/src/neuroglancer/annotation/annotation_layer_state.ts
+++ b/src/neuroglancer/annotation/annotation_layer_state.ts
@@ -109,6 +109,7 @@ export class AnnotationDisplayState extends RefCounted {
   color = new TrackableRGB(vec3.fromValues(1, 1, 0));
   relationshipStates = this.registerDisposer(new WatchableAnnotationRelationshipStates());
   ignoreNullSegmentFilter = new TrackableBoolean(true);
+  disablePicking = new WatchableValue(false);
   displayUnfiltered = makeCachedLazyDerivedWatchableValue((map, ignoreNullSegmentFilter) => {
     for (const state of map.values()) {
       if (state.showMatches.value) {

--- a/src/neuroglancer/annotation/frontend_source.ts
+++ b/src/neuroglancer/annotation/frontend_source.ts
@@ -755,6 +755,7 @@ export class MultiscaleAnnotationSource extends SharedObject implements
   readonly = false;
   childAdded: Signal<(annotation: Annotation) => void>;
   childUpdated: Signal<(annotation: Annotation) => void>;
+  childCommitted: Signal<(annotationId: string) => void>;
   childDeleted: Signal<(annotationId: string) => void>;
 }
 

--- a/src/neuroglancer/datasource/graphene/frontend.ts
+++ b/src/neuroglancer/datasource/graphene/frontend.ts
@@ -1705,6 +1705,14 @@ export class MergeSegmentsPlaceLineTool extends PlaceLineTool {
   getBaseSegment = true;
   constructor(layer: SegmentationUserLayer, private annotationState: AnnotationLayerState) {
     super(layer, {});
+    const {inProgressAnnotation} = this;
+    const {displayState} = annotationState;
+    if (!displayState) return; // TODO, this happens when reloading the page when a toggle tool is up
+    const {disablePicking} = displayState;
+    this.registerDisposer(inProgressAnnotation.changed.add(() => {
+      disablePicking.value = inProgressAnnotation.value !== undefined;
+      console.log("set disablePicking", disablePicking.value)
+    }));
   }
   get annotationLayer() {
     return this.annotationState;

--- a/src/neuroglancer/datasource/graphene/graphene.css
+++ b/src/neuroglancer/datasource/graphene/graphene.css
@@ -35,13 +35,40 @@
   content: "Blue";
 }
 
+.graphene-merge-segments-merges {
+  display: flex;
+  flex-direction: column;
+}
+
+.graphene-merge-segments-submission {
+  display: flex;
+  gap: 10px;
+}
+
 .graphene-merge-segments-status {
   display: flex;
   gap: 10px;
+}
+
+.graphene-merge-segments-status .neuroglancer-icon {
+  height: 100%;
+}
+
+.graphene-merge-segments-status label {
+  display: grid;
+  grid-template-columns: min-content min-content;
+  white-space: nowrap;
+  justify-content: center;
+  align-content: center;
 }
 
 .graphene-merge-segments-point {
   display: flex;
   align-items: center;
   gap: 10px;
+}
+
+.graphene-merge-segments-point .neuroglancer-segment-list-entry-visible-checkbox,
+.graphene-merge-segments-point .neuroglancer-segment-list-entry-copy-container {
+  display: none;
 }

--- a/src/neuroglancer/ui/annotations.ts
+++ b/src/neuroglancer/ui/annotations.ts
@@ -776,7 +776,7 @@ export class AnnotationTab extends Tab {
   }
 }
 
-function getSelectedAssociatedSegments(annotationLayer: AnnotationLayerState) {
+function getSelectedAssociatedSegments(annotationLayer: AnnotationLayerState, getBase = false) {
   let segments: Uint64[][] = [];
   const {relationships} = annotationLayer.source;
   const {relationshipStates} = annotationLayer.displayState;
@@ -785,6 +785,9 @@ function getSelectedAssociatedSegments(annotationLayer: AnnotationLayerState) {
     if (segmentationState != null) {
       if (segmentationState.segmentSelectionState.hasSelectedSegment) {
         segments[i] = [segmentationState.segmentSelectionState.selectedSegment.clone()];
+        if (getBase) {
+          segments[i] = [...segments[i], segmentationState.segmentSelectionState.baseSelectedSegment.clone()];
+        }
         continue;
       }
     }
@@ -982,6 +985,8 @@ export class PlaceBoundingBoxTool extends PlaceTwoCornerAnnotationTool {
 PlaceBoundingBoxTool.prototype.annotationType = AnnotationType.AXIS_ALIGNED_BOUNDING_BOX;
 
 export class PlaceLineTool extends PlaceTwoCornerAnnotationTool {
+  getBaseSegment = false;
+
   get description() {
     return `annotate line`;
   }
@@ -992,7 +997,7 @@ export class PlaceLineTool extends PlaceTwoCornerAnnotationTool {
       Annotation {
     const result = super.getInitialAnnotation(mouseState, annotationLayer);
     this.initialRelationships = result.relatedSegments =
-        getSelectedAssociatedSegments(annotationLayer);
+        getSelectedAssociatedSegments(annotationLayer, this.getBaseSegment);
     return result;
   }
 
@@ -1001,7 +1006,7 @@ export class PlaceLineTool extends PlaceTwoCornerAnnotationTool {
       annotationLayer: AnnotationLayerState) {
     const result = super.getUpdatedAnnotation(oldAnnotation, mouseState, annotationLayer);
     const initialRelationships = this.initialRelationships;
-    const newRelationships = getSelectedAssociatedSegments(annotationLayer);
+    const newRelationships = getSelectedAssociatedSegments(annotationLayer, this.getBaseSegment);
     if (initialRelationships === undefined) {
       result.relatedSegments = newRelationships;
     } else {

--- a/src/neuroglancer/ui/segment_list.ts
+++ b/src/neuroglancer/ui/segment_list.ts
@@ -784,6 +784,7 @@ export class SegmentDisplayTab extends Tab {
                                   layer.displayState.segmentationGroupState.value.graph,
                                   (graph, parent, context) => {
                                     if (graph === undefined) return;
+                                    if (graph.tabContents) return
                                     const toolbox = document.createElement('div');
                                     toolbox.className = 'neuroglancer-segmentation-toolbox';
                                     toolbox.appendChild(makeToolButton(context, layer.toolBinder, {

--- a/src/neuroglancer/webgl/offscreen.ts
+++ b/src/neuroglancer/webgl/offscreen.ts
@@ -165,9 +165,9 @@ export class FramebufferConfiguration<
   colorBuffers: ColorBuffer[];
   framebuffer: Framebuffer;
   depthBuffer: DepthBuffer|undefined;
-  private fullAttachmentList = new Array<number>();
+  fullAttachmentList = new Array<number>();
   private attachmentVerified = false;
-  private singleAttachmentList = [this.gl.COLOR_ATTACHMENT0];
+  singleAttachmentList = [this.gl.COLOR_ATTACHMENT0];
 
   constructor(public gl: GL, configuration: {
     framebuffer?: Framebuffer, colorBuffers: ColorBuffer[],


### PR DESCRIPTION
Changes to merge tool:
* can now queue up multiple merges and bulk submit them
* pending merges are now better visualized as line segments

I also disabled the default graph tools in the segmentation tab if the graph source provides its own tab. That has tricked many of our users.

As you discussed with Sven, there was issues when adding a line segment in 3d. The easiest solution I could find was disabling the pick buffer by calling gl.drawBuffers before and after rendering an annotation layer though I am not so familiar with the nuts and bolts of open/webgl.

graphene prefers a base segment when submitting a merge so I made it available via the line segment by added a getBase option to getSelectedAssociatedSegments. It doesn't integrate as cleanly as I'd prefer.

