### PR TITLE
feat(datasource/graphene) auto reloading graphene manifest after an edit

### DIFF
--- a/src/neuroglancer/chunk_manager/frontend.ts
+++ b/src/neuroglancer/chunk_manager/frontend.ts
@@ -224,9 +224,10 @@ export class ChunkQueueManager extends SharedObject {
         if (newState !== oldState) {
           switch (newState) {
             case ChunkState.GPU_MEMORY:
-              // console.log("Copying to GPU", chunk);
               chunk.copyToGPU(this.gl);
-              visibleChunksChanged = true;
+              if (chunk.constructor.name !== "ManifestChunk") {
+                visibleChunksChanged = true;
+              }
               break;
             case ChunkState.SYSTEM_MEMORY:
               chunk.freeGPUMemory(this.gl);

--- a/src/neuroglancer/chunk_manager/frontend.ts
+++ b/src/neuroglancer/chunk_manager/frontend.ts
@@ -224,10 +224,9 @@ export class ChunkQueueManager extends SharedObject {
         if (newState !== oldState) {
           switch (newState) {
             case ChunkState.GPU_MEMORY:
+              // console.log("Copying to GPU", chunk);
               chunk.copyToGPU(this.gl);
-              if (chunk.constructor.name !== "ManifestChunk") {
-                visibleChunksChanged = true;
-              }
+              visibleChunksChanged = true;
               break;
             case ChunkState.SYSTEM_MEMORY:
               chunk.freeGPUMemory(this.gl);

--- a/src/neuroglancer/datasource/graphene/backend.ts
+++ b/src/neuroglancer/datasource/graphene/backend.ts
@@ -113,7 +113,6 @@ async function decodeDracoFragmentChunk(
     }
     const url = `${parameters.manifestUrl}/manifest`;
     const manifestUrl = `${url}/${chunk.objectId}:${parameters.lod}?verify=1&prepend_seg_ids=1`;
-    console.log("DOWNLOAD MANIFEST", chunk.objectId, parameters.lod);
     await cancellableFetchSpecialOk(this.credentialsProvider, manifestUrl, {}, responseJson, cancellationToken)
         .then(response => {
           const chunkIdentifier = manifestUrl;
@@ -121,7 +120,6 @@ async function decodeDracoFragmentChunk(
             const requestCount = (manifestRequestCount.get(chunkIdentifier) || 0) + 1;
             manifestRequestCount.set(chunkIdentifier, requestCount);
             setTimeout(() => {
-              console.log("RETRY CAUSE STILL NEW", chunk.objectId, requestCount);
               this.chunkManager.queueManager.updateChunkState(chunk, ChunkState.QUEUED);
             }, Math.pow(2, requestCount) * 1000);
           } else {
@@ -440,7 +438,6 @@ registerRPC(CHUNKED_GRAPH_RENDER_LAYER_UPDATE_SOURCES_RPC_ID, function(x) {
 });
 
 registerRPC(GRAPHENE_MESH_NEW_SEGMENT_RPC_ID, function(x) {
-  console.log('adding new segment', x.segment);
-  let obj = <GrapheneMeshSource>this.get(x.rpcId);
+  const obj = <GrapheneMeshSource>this.get(x.rpcId);
   obj.addNewSegment(Uint64.parseString(x.segment));
 });

--- a/src/neuroglancer/datasource/graphene/backend.ts
+++ b/src/neuroglancer/datasource/graphene/backend.ts
@@ -17,9 +17,9 @@
 import {WithParameters} from 'neuroglancer/chunk_manager/backend';
 import {WithSharedCredentialsProviderCounterpart} from 'neuroglancer/credentials_provider/shared_counterpart';
 import {assignMeshFragmentData, FragmentChunk, ManifestChunk, MeshSource} from 'neuroglancer/mesh/backend';
-import {getGrapheneFragmentKey, responseIdentity} from 'neuroglancer/datasource/graphene/base';
+import {getGrapheneFragmentKey, GRAPHENE_MESH_NEW_SEGMENT_RPC_ID, responseIdentity} from 'neuroglancer/datasource/graphene/base';
 import {CancellationToken} from 'neuroglancer/util/cancellation';
-import {isNotFoundError, responseArrayBuffer, responseJson} from 'neuroglancer/util/http_request';
+import {responseArrayBuffer, responseJson} from 'neuroglancer/util/http_request';
 import {cancellableFetchSpecialOk, SpecialProtocolCredentials, SpecialProtocolCredentialsProvider} from 'neuroglancer/util/special_protocol_request';
 import {Uint64} from 'neuroglancer/util/uint64';
 import {registerSharedObject} from 'neuroglancer/worker_rpc';
@@ -94,31 +94,48 @@ async function decodeDracoFragmentChunk(
 
 @registerSharedObject() export class GrapheneMeshSource extends
 (WithParameters(WithSharedCredentialsProviderCounterpart<SpecialProtocolCredentials>()(MeshSource), MeshSourceParameters)) {
+  manifestRequestCount = new Map<string, number>();
+  newSegments = new Uint64Set();
+
+  addNewSegment(segment: Uint64) {
+    const {newSegments} = this;
+    newSegments.add(segment);
+    const TEN_MINUTES = 1000 * 60 * 10;
+    setTimeout(() => {
+      newSegments.delete(segment);
+    }, TEN_MINUTES);
+  }
+
   async download(chunk: ManifestChunk, cancellationToken: CancellationToken) {
-    const {parameters} = this;
+    const {parameters, newSegments, manifestRequestCount} = this;
     if (isBaseSegmentId(chunk.objectId, parameters.nBitsForLayerId)) {
       return decodeManifestChunk(chunk, {fragments: []});
     }
-    let url = `${parameters.manifestUrl}/manifest`;
-    let manifestUrl = `${url}/${chunk.objectId}:${parameters.lod}?verify=1&prepend_seg_ids=1`;
-
+    const url = `${parameters.manifestUrl}/manifest`;
+    const manifestUrl = `${url}/${chunk.objectId}:${parameters.lod}?verify=1&prepend_seg_ids=1`;
+    console.log("DOWNLOAD MANIFEST", chunk.objectId, parameters.lod);
     await cancellableFetchSpecialOk(this.credentialsProvider, manifestUrl, {}, responseJson, cancellationToken)
-        .then(response => decodeManifestChunk(chunk, response));
+        .then(response => {
+          const chunkIdentifier = manifestUrl;
+          if (newSegments.has(chunk.objectId)) {
+            const requestCount = (manifestRequestCount.get(chunkIdentifier) || 0) + 1;
+            manifestRequestCount.set(chunkIdentifier, requestCount);
+            setTimeout(() => {
+              console.log("RETRY CAUSE STILL NEW", chunk.objectId, requestCount);
+              this.chunkManager.queueManager.updateChunkState(chunk, ChunkState.QUEUED);
+            }, Math.pow(2, requestCount) * 1000);
+          } else {
+            manifestRequestCount.delete(chunkIdentifier);
+          }
+          return decodeManifestChunk(chunk, response);
+        });
   }
 
   async downloadFragment(chunk: FragmentChunk, cancellationToken: CancellationToken) {
     const {parameters} = this;
-
-    try {
-      const response = await getFragmentDownloadPromise(
+    const response = await getFragmentDownloadPromise(
         undefined, chunk, parameters, cancellationToken);
       await decodeDracoFragmentChunk(chunk, response);
-    } catch (e) {
-      if (isNotFoundError(e)) {
-        chunk.source!.removeChunk(chunk);
-      }
-      Promise.reject(e);
-    }
   }
 
   getFragmentKey(objectKey: string|null, fragmentId: string) {
@@ -420,4 +437,10 @@ registerRPC(CHUNKED_GRAPH_RENDER_LAYER_UPDATE_SOURCES_RPC_ID, function(x) {
       ChunkedGraphLayer, GrapheneChunkedGraphChunkSource>;
   attachment.state!.displayDimensionRenderInfo = x.displayDimensionRenderInfo;
   layer.chunkManager.scheduleUpdateChunkPriorities();
+});
+
+registerRPC(GRAPHENE_MESH_NEW_SEGMENT_RPC_ID, function(x) {
+  console.log('adding new segment', x.segment);
+  let obj = <GrapheneMeshSource>this.get(x.rpcId);
+  obj.addNewSegment(Uint64.parseString(x.segment));
 });

--- a/src/neuroglancer/datasource/graphene/base.ts
+++ b/src/neuroglancer/datasource/graphene/base.ts
@@ -20,6 +20,7 @@ import {ChunkLayoutOptions, makeSliceViewChunkSpecification, SliceViewChunkSourc
 import {DataType} from 'neuroglancer/sliceview/base';
 
 export const PYCG_APP_VERSION = 1;
+export const GRAPHENE_MESH_NEW_SEGMENT_RPC_ID = 'GrapheneMeshSource:NewSegment';
 
 export enum VolumeChunkEncoding {
   RAW,


### PR DESCRIPTION
Replaces https://github.com/google/neuroglancer/pull/450

With our current infrastructure, the only way for us to get mesh updates is to continuously poll the manifest endpoint to see if it changes, we can't rely on 404 responses as previously thought. Eventually we want to get push messages on the client to replace this logic.

I was asked to try to reduce the flicker that occurs when we change the manifest of an existing cell. I have partial "fix" with this commit 80d95e103c3a03bc04e338371455939dfb233cab. The issue is that the ManifestChunk arrives before the first FragmentChunk.

The easiest solution that mostly works is to prevent ManifestChunks from triggering redraws. I was surprised that ManfestChunk gets a GPU_MEMORY state. It still can cause issues.

Do you have any suggestions on how we could make it smoother. I was asked to go even further by keeping existing fragments from previous cells around until the new cell is at least partially meshed. For example, with a merge, it is very easy to just combine the fragments from each segment.