### PR TITLE
annotation: add missing overload for setPointMarkerColor(vec3)

### DIFF
--- a/src/neuroglancer/annotation/type_handler.ts
+++ b/src/neuroglancer/annotation/type_handler.ts
@@ -326,6 +326,7 @@ void setEndpointMarkerSize(float startSize, float endSize);
 void setEndpointMarkerBorderWidth(float startSize, float endSize);
 
 void setPointMarkerColor(vec4 color);
+void setPointMarkerColor(vec3 color) { setPointMarkerColor(vec4(color, 1.0)); }
 void setPointMarkerBorderColor(vec4 color);
 void setPointMarkerSize(float size);
 void setPointMarkerBorderWidth(float size);


### PR DESCRIPTION
It's listed in [the docs](https://github.com/google/neuroglancer/blob/master/src/neuroglancer/annotation/rendering.md#point-annotations), but was missing from the overload set.