### PR TITLE
N5 datasource docs JSON fix

### DIFF
--- a/src/neuroglancer/datasource/n5/README.md
+++ b/src/neuroglancer/datasource/n5/README.md
@@ -26,7 +26,7 @@ specifying the coordinate labels starting at 0.  For example:
   "compression": {"type": "raw"},
   "axes": ["x", "y", "c"],
   "coordinateArrays": {
-    "c": ["A", "B', "C', "D', "E"]
+    "c": ["A", "B", "C", "D", "E"]
   }
 }
 ```


### PR DESCRIPTION
This README is the best documentation of the BDV / N5viewer metadata I keep referring to, so I thought I'd help get rid of some red squigglies.