### PR TITLE
fix(annotation): fully deleting old relationships to allow displayUnfiltered to update properly

### DIFF
--- a/src/neuroglancer/annotation/user_layer.ts
+++ b/src/neuroglancer/annotation/user_layer.ts
@@ -135,9 +135,11 @@ class LinkedSegmentationLayers extends RefCounted {
       state.seenGeneration = generation;
     }
     if (!isLoading) {
+      const {relationshipStates} = this.annotationDisplayState;
       for (const [relationship, state] of map) {
         if (state.seenGeneration !== generation) {
           map.delete(relationship);
+          relationshipStates.delete(relationship);
           changed = true;
         }
       }


### PR DESCRIPTION
after changing a layer source for a layer that has an actively linked relationship. This prevented it from showing the spatial index for the new source until the page was refreshed.

Example:
https://cj-cave-anno-share-dot-neuroglancer-dot-seung-lab.appspot.com/#!middleauth+https://global.daf-apis.com/nglstate/api/v1/6105906074877952

Go to the source tab on the active layer, replace the source with `cave://middleauth+https://minnie.microns-daf.com/materialize/api/v3/datastack/minnie65_phase3_v1/table/column_atype`. Wait a few seconds and nothing will appear. Refresh the page and the `column_atype` data will appear.

This is just one solution and it does have the drawback that you lose the relationship state for a layer if you want to return to it.