### PR TITLE
Annotation features mostly related to MultiscaleAnnotationSource

### DIFF
--- a/src/neuroglancer/annotation/annotation_layer_state.ts
+++ b/src/neuroglancer/annotation/annotation_layer_state.ts
@@ -55,14 +55,7 @@ export class WatchableAnnotationRelationshipStates extends
         nestedContext.registerDisposer(segmentationGroupState.changed.add(this.changed.dispatch));
         nestedContext.registerDisposer(registerNested((groupContext, groupState) => {
           const {visibleSegments} = groupState;
-          let wasEmpty = visibleSegments.size === 0;
-          groupContext.registerDisposer(visibleSegments.changed.add(() => {
-            const isEmpty = visibleSegments.size === 0;
-            if (isEmpty !== wasEmpty) {
-              wasEmpty = isEmpty;
-              this.changed.dispatch();
-            }
-          }));
+          groupContext.registerDisposer(visibleSegments.changed.add(this.changed.dispatch));
         }, segmentationGroupState));
       }, segmentationState));
     });

--- a/src/neuroglancer/annotation/type_handler.ts
+++ b/src/neuroglancer/annotation/type_handler.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {Annotation, AnnotationPropertySpec, AnnotationType, annotationTypeHandlers, getPropertyOffsets, propertyTypeDataType} from 'neuroglancer/annotation';
+import {Annotation, AnnotationNumericPropertySpec, AnnotationPropertySpec, AnnotationType, annotationTypeHandlers, getPropertyOffsets, propertyTypeDataType} from 'neuroglancer/annotation';
 import {AnnotationLayer} from 'neuroglancer/annotation/renderlayer';
 import {PerspectiveViewRenderContext} from 'neuroglancer/perspective_view/render_layer';
 import {ChunkDisplayTransformParameters} from 'neuroglancer/render_coordinate_transform';
@@ -29,6 +29,7 @@ import {ParameterizedContextDependentShaderGetter, parameterizedEmitterDependent
 import {defineInvlerpShaderFunction, enableLerpShaderFunction} from 'neuroglancer/webgl/lerp';
 import {ShaderBuilder, ShaderModule, ShaderProgram} from 'neuroglancer/webgl/shader';
 import {addControlsToBuilder, setControlsInShader, ShaderControlsBuilderState, ShaderControlState} from 'neuroglancer/webgl/shader_ui_controls';
+import {BasicHashColorShaderManager} from 'neuroglancer/segment_color';
 
 const DEBUG_HISTOGRAMS = false;
 
@@ -197,6 +198,8 @@ export abstract class AnnotationRenderHelper extends AnnotationRenderHelperBase 
   pickIdsPerInstance: number;
   targetIsSliceView: boolean;
 
+  protected hashColorShaderManager = new BasicHashColorShaderManager('hashColor');
+
   constructor(
       gl: GL, annotationType: AnnotationType, rank: number,
       properties: readonly Readonly<AnnotationPropertySpec>[],
@@ -225,8 +228,14 @@ export abstract class AnnotationRenderHelper extends AnnotationRenderHelperBase 
         const referencedProperties: number[] = [];
         const controlsReferencedProperties = parameters.referencedProperties;
         const processedCode = parameters.parseResult.code;
+        this.hashColorShaderManager.defineShader(builder);
         for (let i = 0, numProperties = properties.length; i < numProperties; ++i) {
           const property = properties[i];
+          const enumLabels = (property as AnnotationNumericPropertySpec).enumLabels || [];
+          const enumValues = (property as AnnotationNumericPropertySpec).enumValues || [];
+          for (let i = 0; i < enumLabels.length && i < enumValues.length; i++) {
+            builder.addVertexCode(`#define prop_${property.identifier}_${enumLabels[i]} uint(${enumValues[i]})\n`);
+          }
           const functionName = `prop_${property.identifier}`;
           if (!controlsReferencedProperties.includes(property.identifier) &&
               !processedCode.match(new RegExp(`\\b${functionName}\\b`))) {

--- a/src/neuroglancer/annotation/user_layer.css
+++ b/src/neuroglancer/annotation/user_layer.css
@@ -50,3 +50,19 @@
   content: "()";
   color: #999;
 }
+
+.neuroglancer-annotation-shader-property-type:hover > .neuroglancer-annotation-shader-property-enum-labels,
+.neuroglancer-annotation-shader-property-enum-labels:hover {
+  display: initial;
+}
+
+.neuroglancer-annotation-shader-property-enum-labels {
+    z-index: 100;
+    position: absolute;
+    background: black;
+    display: none;
+    user-select: text;
+    padding: 2px;
+    border: 1px solid white;
+    color: deepskyblue;
+}

--- a/src/neuroglancer/ui/default_input_event_bindings.ts
+++ b/src/neuroglancer/ui/default_input_event_bindings.ts
@@ -68,6 +68,8 @@ export function getDefaultAnnotationListBindings() {
         {
           'click0': 'pin-annotation',
           'mousedown2': 'move-to-annotation',
+          'arrowup': 'select-previous-annotation',
+          'arrowdown': 'select-next-annotation',
         },
         {parents: [[getDefaultSelectBindings(), 0]]});
   }


### PR DESCRIPTION
All of these were developed for our cave annotation datasource. I could add the cave datasource here or keep it a separate PR, whichever you prefer.

Each of these features still needs discussion.

53821ff246731b2a26cea19340ec5c5c7ec17f62

Mostly happy with this but I left out sorting. We don't always want to sort annotations by distance, we often want the order from the server response. We also are only using 1 chunk the size of the dataset for annotations.

cee014674ee86dfb547b12f3e90d84f520c45229

This feature makes it easier to quickly glance at the annotations, more useful when the segment list is small. Because there can be multiple annotation lists visible at a time, I'm currently relying on tabIndex to make it focusable so I can listen to key events directly on that element. It isn't ideal but it's robust.

8398ac52e85f5f7bb36d0a7c542f55ab135589d9
<img width="645" alt="Screen Shot 2023-09-28 at 6 52 12 PM" src="https://github.com/google/neuroglancer/assets/188155/822e623c-794e-41de-9489-ff827da3e2be">

A list of enum values colored by a default hash function (exposed in the shader as `hashColor`) appears when hovering over `enum` in the `neuroglancer-annotation-shader-property-list`.

The hashColor function is really nice for quickly making a useful annotation shader. I could add a seed argument. The list element would no longer match unless we started to parse the shader for that which is probably something to avoid.

If I change the shader prop code so that it supports `prop_cell_type == prop_cell_type("b")` instead as you suggested https://github.com/google/neuroglancer/discussions/481#discussioncomment-6795461 Does glsl allow prop_cell_type to be both a value and a function or would it be a pre-compilation step?