### PR TITLE
fix(state_share): new method to include credentials for state sharing

### DIFF
--- a/src/neuroglancer/datasource/state_share.ts
+++ b/src/neuroglancer/datasource/state_share.ts
@@ -72,10 +72,9 @@ export class StateShare extends RefCounted { // call it a widget? no because it 
               body: JSON.stringify(viewer.state.toJSON())
             }, responseJson)
           .then((res) => {
-            const stateUrl = new URL(res);
-            const stateUrlWithoutProtocol = stateUrl.toString().split(stateUrl.protocol)[1];
-            const stateUrlWithCredentialsProtocol = `${protocol}${stateUrlWithoutProtocol}`;
-            const link = `${window.location.origin}/#!${stateUrlWithCredentialsProtocol}`;
+            const stateUrlProtcol = new URL(res).protocol;
+            const stateUrlWithoutProtocol = res.substring(stateUrlProtcol.length);
+            const link = `${window.location.origin}/#!${protocol}${stateUrlWithoutProtocol}`;
             navigator.clipboard.writeText(link).then(() => {
               StatusMessage.showTemporaryMessage('Share link copied to clipboard');
             });

--- a/src/neuroglancer/datasource/state_share.ts
+++ b/src/neuroglancer/datasource/state_share.ts
@@ -73,8 +73,9 @@ export class StateShare extends RefCounted { // call it a widget? no because it 
             }, responseJson)
           .then((res) => {
             const stateUrl = new URL(res);
-            stateUrl.protocol = protocol; // copy protocol in case it contains authentication type
-            const link = `${window.location.origin}/#!${stateUrl}`;
+            const stateUrlWithoutProtocol = stateUrl.toString().split(stateUrl.protocol)[1];
+            const stateUrlWithCredentialsProtocol = `${protocol}${stateUrlWithoutProtocol}`;
+            const link = `${window.location.origin}/#!${stateUrlWithCredentialsProtocol}`;
             navigator.clipboard.writeText(link).then(() => {
               StatusMessage.showTemporaryMessage('Share link copied to clipboard');
             });


### PR DESCRIPTION
due to chrome introducing restrictions on setting protocols using the URL API

```ts
const x = new URL('http://google.com');
x.protocol = 'middleauth+https:';
```

The second line is silently rejected in chrome 118.
