### PR TITLE
feat(annotation): AnnotationLayerView now shows currently displayed annotations in MultiscaleAnnotationSource

### DIFF
--- a/src/neuroglancer/annotation/annotation_layer_state.ts
+++ b/src/neuroglancer/annotation/annotation_layer_state.ts
@@ -55,14 +55,7 @@ export class WatchableAnnotationRelationshipStates extends
         nestedContext.registerDisposer(segmentationGroupState.changed.add(this.changed.dispatch));
         nestedContext.registerDisposer(registerNested((groupContext, groupState) => {
           const {visibleSegments} = groupState;
-          let wasEmpty = visibleSegments.size === 0;
-          groupContext.registerDisposer(visibleSegments.changed.add(() => {
-            const isEmpty = visibleSegments.size === 0;
-            if (isEmpty !== wasEmpty) {
-              wasEmpty = isEmpty;
-              this.changed.dispatch();
-            }
-          }));
+          groupContext.registerDisposer(visibleSegments.changed.add(this.changed.dispatch));
         }, segmentationGroupState));
       }, segmentationState));
     });


### PR DESCRIPTION
Breaking apart https://github.com/google/neuroglancer/pull/493

 I left out the sorting by distance from because we don't want it for the cave datasource, would a boolean `sortByDistance` property on MultiscaleAnnotationSource be reasonable?

I left some comments in the code about the arguments to `this.virtualListSource.changed!.dispatch`.

I could do a diff between the old and new list to see which elements are identical to get a proper retainCount but I'm not sure what effect it would have.