### PR TITLE
fix(ui/side_panel) biome linter broke drag end handler

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -59,6 +59,9 @@
       "correctness": {
         "useYield": "off",
         "noUnsafeFinally": "off"
+      },
+      "performance": {
+        "noDelete": "off"
       }
     }
   }

--- a/src/ui/side_panel.ts
+++ b/src/ui/side_panel.ts
@@ -280,7 +280,7 @@ export class SidePanelManager extends RefCounted {
   }
 
   endDrag() {
-    this.element.dataset.neuroglancerSidePanelDrag = undefined;
+    delete this.element.dataset.neuroglancerSidePanelDrag;
     this.dragSource = undefined;
   }
 


### PR DESCRIPTION
```
  ✖ Avoid the delete operator which can impact performance.
  
    282 │   endDrag() {
  > 283 │     delete this.element.dataset.neuroglancerSidePanelDrag;
        │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    284 │     this.dragSource = undefined;
    285 │   }
  
  ℹ Unsafe fix: Use an undefined assignment instead.
  
    281 281 │   
    282 282 │     endDrag() {
    283     │ - ····delete·this.element.dataset.neuroglancerSidePanelDrag;
        283 │ + ····this.element.dataset.neuroglancerSidePanelDrag·=·undefined;
    284 284 │       this.dragSource = undefined;
    285 285 │     }

```

Using undefined causes the data attribute to remain as ```data-neuroglancer-side-panel-drag="undefined"``` which still triggers the [data-neuroglancer-side-panel-drag] css property which makes the neuroglancer-side-panel-drop-zone block pointer events.

I created an issue on biome https://github.com/biomejs/biome/issues/1765 We could disable noDelete for now or change the code to `this.element.removeAttribute('data-neuroglancer-side-panel-drag');`


Side note, I added a comment to my AnnotationLayerView PR that might have been unnoticed (in code comment thread) https://github.com/google/neuroglancer/pull/504#discussion_r1474836341   