### PR TITLE
feature: add annotation ID and make properties selectable

### DIFF
--- a/src/ui/annotations.css
+++ b/src/ui/annotations.css
@@ -250,6 +250,7 @@ div.neuroglancer-annotation-details-description {
   flex-direction: row;
   font-family: sans-serif;
   font-size: small;
+  user-select: text;
 }
 
 .neuroglancer-annotation-property-label {

--- a/src/ui/annotations.ts
+++ b/src/ui/annotations.ts
@@ -1850,6 +1850,23 @@ export function UserLayerWithAnnotationsMixin<
 
                 const { relationships, properties } = annotationLayer.source;
                 const sourceReadonly = annotationLayer.source.readonly;
+                
+                // Add the ID to the annotation details.
+                const label = document.createElement("label");
+                label.classList.add("neuroglancer-annotation-property");
+                const idElement = document.createElement("span");
+                idElement.classList.add(
+                  "neuroglancer-annotation-property-label",
+                );
+                idElement.textContent = "ID";
+                label.appendChild(idElement);
+                const valueElement = document.createElement("span");
+                valueElement.classList.add(
+                  "neuroglancer-annotation-property-value",
+                );
+                valueElement.textContent = reference.id;
+                label.appendChild(valueElement);
+                parent.appendChild(label);
 
                 for (let i = 0, count = properties.length; i < count; ++i) {
                   const property = properties[i];

--- a/src/ui/annotations.ts
+++ b/src/ui/annotations.ts
@@ -1850,7 +1850,7 @@ export function UserLayerWithAnnotationsMixin<
 
                 const { relationships, properties } = annotationLayer.source;
                 const sourceReadonly = annotationLayer.source.readonly;
-                
+
                 // Add the ID to the annotation details.
                 const label = document.createElement("label");
                 label.classList.add("neuroglancer-annotation-property");


### PR DESCRIPTION
In trying to use neuroglancer to browse precomputed annotations I often want to see what the annotation is that I'm mousing over, and perhaps grab its ID or other metadata that is displayed to my clipboard. 

This PR adds the annotation ID to the list of properties that are displayed and modifies the CSS to make neuroglancer-properties selectable by users so that users can copy/paste properties to their clipboard. 