### PR TITLE
feat(segmentation_user_layer) implemented getObjectPosition for MeshLayer

### DIFF
--- a/src/mesh/frontend.ts
+++ b/src/mesh/frontend.ts
@@ -589,7 +589,8 @@ export class MeshLayer extends PerspectiveViewRenderLayer<ThreeDimensionalRender
   ): Float32Array | undefined {
     const transform = this.displayState.transform.value;
     if (transform.error !== undefined) return undefined;
-    const chunk = this.source.chunks.get(getObjectKey(id));
+    const key = getObjectKey(id);
+    const chunk = this.source.chunks.get(key);
     if (chunk === undefined) return undefined;
     const { rank } = transform;
     const inverseModelToRenderLayerTransform = new Float32Array(
@@ -614,7 +615,8 @@ export class MeshLayer extends PerspectiveViewRenderLayer<ThreeDimensionalRender
     const closestVertex = new Float32Array(rank);
     let closestDistanceSq = Number.POSITIVE_INFINITY;
     for (const fragmentId of fragmentIds) {
-      const fragmentChunk = this.source.fragmentSource.chunks.get(fragmentId);
+      const { key: fragmentKey } = this.source.getFragmentKey(key, fragmentId);
+      const fragmentChunk = this.source.fragmentSource.chunks.get(fragmentKey);
       if (fragmentChunk === undefined) continue;
       const { state, meshData } = fragmentChunk;
       if (
@@ -628,10 +630,8 @@ export class MeshLayer extends PerspectiveViewRenderLayer<ThreeDimensionalRender
       for (let i = 0; i < vertexPositions.length; i += rank) {
         let distanceSq = 0;
         for (let j = 0; j < rank; j++) {
-          distanceSq += Math.pow(
-            vertexPositions[i + j] - nearestPositionInModal[j],
-            2,
-          );
+          distanceSq +=
+            (vertexPositions[i + j] - nearestPositionInModal[j]) ** 2;
         }
         if (distanceSq < closestDistanceSq) {
           closestDistanceSq = distanceSq;


### PR DESCRIPTION
finds the closest loaded associated mesh vertex to the global position

I also did an implementation that just returns the first vertex (in the order that I iterate through them here) and one where it finds the vertex closest to the mean vertex position. I still need to get some feedback to confirm if this is preferred but this seems to be ideal as it minimizes movement.

I might be making an assumption on using vertexPositions. The type is `EncodedVertexPositions` but it seems to be work without any kind of decoding.

I'm not using localPosition when comparing the globalPosition with the vertexPositions, only globalToRenderLayerDimensions and transform.modelToRenderLayerTransform. I tried to do the inverse of how globalPosition is modified in moveToSegment but I am a little confused why I don't see how localPosition comes into play.