### PR TITLE
switching to f strings for ruff formatting error

### DIFF
--- a/python/neuroglancer/skeleton.py
+++ b/python/neuroglancer/skeleton.py
@@ -50,8 +50,7 @@ class Skeleton:
                     expected_shape
                 ):
                     raise ValueError(
-                        "Expected attribute {!r} to have shape {!r}, but was: {!r}".format(
-                            name, expected_shape, attribute.shape
+                        f"Expected attribute {name!r} to have shape {expected_shape!r}, but was: {attribute.shape!r}"
                         )
                     )
                 result.write(attribute.tobytes())

--- a/python/neuroglancer/viewer_state.py
+++ b/python/neuroglancer/viewer_state.py
@@ -1138,9 +1138,9 @@ class ManagedLayer(JsonObjectWrapper):
             return setattr(self.layer, key, value)
 
     def __repr__(self):
-        return "ManagedLayer({},{})".format(
-            encode_json_for_repr(self.name),
-            encode_json_for_repr(self.to_json()),
+        return (
+            f"ManagedLayer({encode_json_for_repr(self.name)},"
+            f"{encode_json_for_repr(self.to_json())})"
         )
 
     def to_json(self):

--- a/setup.py
+++ b/setup.py
@@ -221,9 +221,7 @@ class BundleClientCommand(
             html_path = os.path.join(output_dir, "index.html")
             if os.path.exists(html_path):
                 print(
-                    "Skipping rebuild of client bundle since {} already exists".format(
-                        html_path
-                    )
+                    f"Skipping rebuild of client bundle since {html_path} already exists"
                 )
                 return
 


### PR DESCRIPTION
Python tests were failing ruff due to errors in using format rather then f strings.