### PR TITLE
Update frontend.ts DOM text reinterpreted as HTML {Patch} 

### DIFF
--- a/src/datasource/graphene/frontend.ts
+++ b/src/datasource/graphene/frontend.ts
@@ -2180,7 +2180,7 @@ class MulticutSegmentsTool extends LayerTool<SegmentationUserLayer> {
     body.appendChild(submitIcon);
     const activeGroupIndicator = document.createElement("div");
     activeGroupIndicator.className = "activeGroupIndicator";
-    activeGroupIndicator.innerHTML = "Active Group: ";
+    activeGroupIndicator.innerText = "Active Group: ";
     body.appendChild(activeGroupIndicator);
 
     const { displayState } = this.layer;


### PR DESCRIPTION
By using innerText, it will avoid the risk of HTML injection, as these properties automatically escape any HTML special characters in the provided text. This helps prevent cross-site scripting (XSS) vulnerabilities by treating the input as plain text rather than interpreted HTML. Always be cautious when dealing with user input or dynamic content to prevent security risks