### PR TITLE
fix(uint64): avoid rounding errors in Uint64.toString with large high values

### DIFF
--- a/src/util/uint64.spec.ts
+++ b/src/util/uint64.spec.ts
@@ -41,6 +41,7 @@ describe("uint64", () => {
     expect(new Uint64(4294967295, 4294967295).toString(36)).toEqual(
       "3w5e11264sgsf",
     );
+    expect(new Uint64(0, 79741775).toString(29)).toEqual("s2276dsssss2");
   });
 
   it("conversion from string", () => {
@@ -110,7 +111,7 @@ describe("uint64", () => {
       expect(u.toString(13)).toEqual("153c9125c642b111b8");
       check(u, 13);
     }
-
+    check(new Uint64(0, 79741775), 29);
     for (let base = 2; base <= 36; ++base) {
       for (let i = 0; i < count; ++i) {
         check(Uint64.random(), base);

--- a/src/util/uint64.ts
+++ b/src/util/uint64.ts
@@ -105,7 +105,7 @@ export class Uint64 {
     vHigh *= trueBase;
     const { lowBase, lowDigits } = stringConversionData[base];
     const vHighExtra = vHigh % lowBase;
-    vHigh = Math.floor(vHigh / lowBase);
+    vHigh = Number(BigInt(vHigh) / BigInt(lowBase));
     vLow += vHighExtra;
     vHigh += Math.floor(vLow / lowBase);
     vLow = vLow % lowBase;


### PR DESCRIPTION
https://github.com/google/neuroglancer/blob/daf82f3ad4af2007e96faca35143cd5ec986bf60/src/util/uint64.ts#L105

if vHigh > `Number.MAX_SAFE_INTEGER / 0x100000000`
`vHigh *= trueBase;` will exceed Number.MAX_SAFE_INTEGER.
`Math.floor(vHigh / lowBase)` will then start to return whole numbers when the fraction is very close to 0 or 1. When it is due to it being 1, javascript rounds up which then causes the floor operation to fail. BigInt safely handle the division + floor operation.

For example:
base 3, low 0, high 92064593
92064593 * trueBase / 3486784401 = 113403746.99999998652053164327...
```
92064593 * trueBase / 3486784401 = 113403747 (in javascript)
Math.floor(92064593 * trueBase / lowBase) = 113403747
92064593 * trueBase % lowBase = 3486784382
```