### PR TITLE
Volume rendering fixes for max projection - picking, blending, and performance

### DIFF
--- a/python/neuroglancer/__init__.py
+++ b/python/neuroglancer/__init__.py
@@ -49,7 +49,7 @@ from .viewer_state import (
     PlaceEllipsoidTool,  # noqa: F401
     BlendTool,  # noqa: F401
     OpacityTool,  # noqa: F401
-    VolumeRenderingModeTool,  # noqa: F401
+    VolumeRenderingTool,  # noqa: F401
     VolumeRenderingGainTool,  # noqa: F401
     VolumeRenderingDepthSamplesTool,  # noqa: F401
     CrossSectionRenderScaleTool,  # noqa: F401

--- a/python/neuroglancer/viewer_state.py
+++ b/python/neuroglancer/viewer_state.py
@@ -165,9 +165,9 @@ class OpacityTool(Tool):
 
 
 @export_tool
-class VolumeRenderingModeTool(Tool):
+class VolumeRenderingTool(Tool):
     __slots__ = ()
-    TOOL_TYPE = "volumeRenderingMode"
+    TOOL_TYPE = "volumeRendering"
 
 
 @export_tool

--- a/src/perspective_view/panel.ts
+++ b/src/perspective_view/panel.ts
@@ -912,7 +912,6 @@ export class PerspectivePanel extends RenderedDataPanel {
     let hasMaxProjection = false;
 
     let hasAnnotation = false;
-    let nVolumeRenderingLayers = 0;
 
     // Draw fully-opaque layers first.
     for (const [renderLayer, attachment] of visibleLayers) {
@@ -929,7 +928,6 @@ export class PerspectivePanel extends RenderedDataPanel {
             hasMaxProjection ||
             isProjectionLayer(renderLayer as VolumeRenderingRenderLayer);
         }
-        nVolumeRenderingLayers++;
       }
     }
     this.drawSliceViews(renderContext);
@@ -1023,16 +1021,10 @@ export class PerspectivePanel extends RenderedDataPanel {
         WebGL2RenderingContext.ONE_MINUS_SRC_ALPHA,
       );
       renderContext.emitPickID = false;
-      let currentVolumeRenderingLayer = 0;
       for (const [renderLayer, attachment] of visibleLayers) {
         if (renderLayer.isTransparent) {
           renderContext.depthBufferTexture =
             this.offscreenFramebuffer.colorBuffers[OffscreenTextures.Z].texture;
-        }
-        if (renderLayer.isVolumeRendering) {
-          currentVolumeRenderingLayer++;
-          renderContext.volumePickID =
-            currentVolumeRenderingLayer / (nVolumeRenderingLayers + 1);
         }
         // Draw max projection layers
         if (

--- a/src/perspective_view/panel.ts
+++ b/src/perspective_view/panel.ts
@@ -153,18 +153,18 @@ export function perspectivePanelEmitOIT(builder: ShaderBuilder) {
 }
 
 export function maxProjectionEmit(builder: ShaderBuilder) {
-  builder.addOutputBuffer("vec4", "v4f_fragData0", 0);
-  builder.addOutputBuffer("highp vec4", "v4f_fragData1", 1);
-  builder.addOutputBuffer("highp vec4", "v4f_fragData2", 2);
-  builder.addOutputBuffer("highp vec4", "v4f_fragData3", 3);
+  builder.addOutputBuffer("vec4", "out_color", 0);
+  builder.addOutputBuffer("highp vec4", "out_z", 1);
+  builder.addOutputBuffer("highp vec4", "out_intensity", 2);
+  builder.addOutputBuffer("highp vec4", "out_pickId", 3);
   builder.addFragmentCode(`
 void emit(vec4 color, float depth, float intensity, highp uint pickId) {
   float pickIdFloat = float(pickId);
   float bufferDepth = 1.0 - depth;
-  v4f_fragData0 = color;
-  v4f_fragData1 = vec4(bufferDepth, bufferDepth, bufferDepth, 1.0);
-  v4f_fragData2 = vec4(intensity, intensity, intensity, 1.0);
-  v4f_fragData3 = vec4(pickIdFloat, pickIdFloat, pickIdFloat, 1.0);
+  out_color = color;
+  out_z = vec4(bufferDepth, bufferDepth, bufferDepth, 1.0);
+  out_intensity = vec4(intensity, intensity, intensity, 1.0);
+  out_pickId = vec4(pickIdFloat, pickIdFloat, pickIdFloat, 1.0);
 }`);
 }
 
@@ -203,13 +203,13 @@ emitAccumAndRevealage(accum, revealage, 0u);
 
 // Copy the max projection depth and pick values to the main buffer
 function defineMaxProjectionPickCopyShader(builder: ShaderBuilder) {
-  builder.addOutputBuffer("vec4", "v4f_fragData0", 0);
-  builder.addOutputBuffer("highp vec4", "v4f_fragData1", 1);
-  builder.addOutputBuffer("highp vec4", "v4f_fragData2", 2);
+  builder.addOutputBuffer("vec4", "out_color", 0);
+  builder.addOutputBuffer("highp vec4", "out_z", 1);
+  builder.addOutputBuffer("highp vec4", "out_pickId", 2);
   builder.setFragmentMain(`
-v4f_fragData0 = vec4(0.0);
-v4f_fragData1 = getValue0();
-v4f_fragData2 = getValue1();
+out_color = vec4(0.0);
+out_z = getValue0();
+out_pickId = getValue1();
 `);
 }
 
@@ -218,11 +218,11 @@ v4f_fragData2 = getValue1();
 // This is to combine max projection picking data via depth testing
 // on the maximum intensity value of the data.
 function defineMaxProjectionToPickCopyShader(builder: ShaderBuilder) {
-  builder.addOutputBuffer("highp vec4", "v4f_fragData0", 0);
-  builder.addOutputBuffer("highp vec4", "v4f_fragData1", 1);
+  builder.addOutputBuffer("highp vec4", "out_z", 0);
+  builder.addOutputBuffer("highp vec4", "out_pickId", 1);
   builder.setFragmentMain(`
-v4f_fragData0 = getValue0();
-v4f_fragData1 = getValue2();
+out_z = getValue0();
+out_pickId = getValue2();
 gl_FragDepth = getValue1().r;
 `);
 }

--- a/src/perspective_view/panel.ts
+++ b/src/perspective_view/panel.ts
@@ -1038,7 +1038,7 @@ export class PerspectivePanel extends RenderedDataPanel {
             this.maxProjectionConfiguration.colorBuffers[2 /*pick*/].texture,
           );
 
-          // Copy max projection color result to color only buffer
+          // Copy max projection color result to the transparent buffer with OIT
           // Depth testing off to combine max layers into one color via blend
           renderContext.bindFramebuffer();
           gl.depthMask(false);

--- a/src/perspective_view/panel.ts
+++ b/src/perspective_view/panel.ts
@@ -159,11 +159,12 @@ export function maxProjectionEmit(builder: ShaderBuilder) {
   builder.addOutputBuffer("highp vec4", "v4f_fragData2", 2);
   builder.addOutputBuffer("highp vec4", "v4f_fragData3", 3);
   builder.addFragmentCode(`
-void emit(vec4 color, float depth, float intensity, float pickId) {
+void emit(vec4 color, float depth, float intensity, highp uint pickId) {
   v4f_fragData0 = color;
   v4f_fragData1 = vec4(1.0 - depth, 1.0 - depth, 1.0 - depth, 1.0);
   v4f_fragData2 = vec4(intensity, intensity, intensity, 1.0);
-  v4f_fragData3 = vec4(pickId, pickId, pickId, 1.0);
+  float pickIdFloat = float(pickId);
+  v4f_fragData3 = vec4(pickIdFloat, pickIdFloat, pickIdFloat, 1.0);
 }`);
 }
 

--- a/src/perspective_view/panel.ts
+++ b/src/perspective_view/panel.ts
@@ -1136,27 +1136,21 @@ export class PerspectivePanel extends RenderedDataPanel {
         /*dppass=*/ WebGL2RenderingContext.REPLACE,
       );
       gl.stencilMask(2);
+      if (hasMaxProjection) {
+        this.maxProjectionPickCopyHelper.draw(
+          this.maxProjectionPickConfiguration.colorBuffers[0].texture /*depth*/,
+          this.maxProjectionPickConfiguration.colorBuffers[1].texture /*pick*/,
+        );
+      }
       for (const [renderLayer, attachment] of visibleLayers) {
-        if (!renderLayer.isTransparent || !renderLayer.transparentPickEnabled) {
+        if (
+          !renderLayer.isTransparent ||
+          !renderLayer.transparentPickEnabled ||
+          renderLayer.isVolumeRendering
+        ) {
+          // Skip non-transparent layers and transparent layers with transparentPickEnabled=false.
+          // Volume rendering layers are handled separately and are combined in a pick buffer
           continue;
-        }
-        // For max projection layers, can copy over the pick buffer directly.
-        if (renderLayer.isVolumeRendering) {
-          if (isProjectionLayer(renderLayer as VolumeRenderingRenderLayer)) {
-            this.maxProjectionPickCopyHelper.draw(
-              this.maxProjectionPickConfiguration.colorBuffers[0]
-                .texture /*depth*/,
-              this.maxProjectionPickConfiguration.colorBuffers[1]
-                .texture /*pick*/,
-            );
-          }
-          // Draw picking for non min/max volume rendering layers
-          else {
-            // Currently volume rendering layers have no picking support
-            // Outside of min/max mode
-            continue;
-          }
-          // other transparent layers are drawn as usual
         } else {
           renderLayer.draw(renderContext, attachment);
         }

--- a/src/perspective_view/panel.ts
+++ b/src/perspective_view/panel.ts
@@ -1018,6 +1018,7 @@ export class PerspectivePanel extends RenderedDataPanel {
           renderContext.depthBufferTexture =
             this.offscreenFramebuffer.colorBuffers[OffscreenTextures.Z].texture;
         }
+        // Draw max projection layers
         if (
           renderLayer.isVolumeRendering &&
           isProjectionLayer(renderLayer as VolumeRenderingRenderLayer)
@@ -1075,7 +1076,11 @@ export class PerspectivePanel extends RenderedDataPanel {
           renderContext.bindFramebuffer();
           continue;
         }
-        renderLayer.draw(renderContext, attachment);
+        // Draw regular transparent layers
+        else if (renderLayer.isTransparent) {
+          renderLayer.draw(renderContext, attachment);
+          console.log("drawing", renderLayer);
+        }
       }
       // Copy transparent rendering result back to primary buffer.
       gl.disable(WebGL2RenderingContext.DEPTH_TEST);

--- a/src/perspective_view/panel.ts
+++ b/src/perspective_view/panel.ts
@@ -1079,7 +1079,6 @@ export class PerspectivePanel extends RenderedDataPanel {
         // Draw regular transparent layers
         else if (renderLayer.isTransparent) {
           renderLayer.draw(renderContext, attachment);
-          console.log("drawing", renderLayer);
         }
       }
       // Copy transparent rendering result back to primary buffer.

--- a/src/perspective_view/panel.ts
+++ b/src/perspective_view/panel.ts
@@ -1074,7 +1074,6 @@ export class PerspectivePanel extends RenderedDataPanel {
           gl.depthFunc(WebGL2RenderingContext.LESS);
           renderContext.emitter = perspectivePanelEmitOIT;
           renderContext.bindFramebuffer();
-          continue;
         }
         // Draw regular transparent layers
         else if (renderLayer.isTransparent) {

--- a/src/perspective_view/panel.ts
+++ b/src/perspective_view/panel.ts
@@ -152,15 +152,17 @@ export function perspectivePanelEmitOIT(builder: ShaderBuilder) {
   builder.addFragmentCode(glsl_perspectivePanelEmitOIT);
 }
 
+// Keep the pick value here below 1 to avoid conflicts with the pick IDs used by uint annotations.
 export function maxProjectionEmit(builder: ShaderBuilder) {
   builder.addOutputBuffer("vec4", "v4f_fragData0", 0);
   builder.addOutputBuffer("highp vec4", "v4f_fragData1", 1);
   builder.addOutputBuffer("highp vec4", "v4f_fragData2", 2);
   builder.addFragmentCode(`
 void emit(vec4 color, float depth, float pick) {
+  float pickToEmit = pick * 0.99;
   v4f_fragData0 = color;
   v4f_fragData1 = vec4(1.0 - depth, 1.0 - depth, 1.0 - depth, 1.0);
-  v4f_fragData2 = vec4(pick, pick, pick, 1.0);
+  v4f_fragData2 = vec4(pickToEmit, pickToEmit, pickToEmit, 1.0);
 }`);
 }
 

--- a/src/perspective_view/render_layer.ts
+++ b/src/perspective_view/render_layer.ts
@@ -55,11 +55,6 @@ export interface PerspectiveViewRenderContext
    * Specifies the ID of the depth frame buffer texture to query during rendering.
    */
   depthBufferTexture?: WebGLTexture | null;
-
-  /**
-   * Specifies the ID to use for the pick ID in volume rendering.
-   */
-  volumePickID?: number;
 }
 
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging

--- a/src/perspective_view/render_layer.ts
+++ b/src/perspective_view/render_layer.ts
@@ -55,6 +55,11 @@ export interface PerspectiveViewRenderContext
    * Specifies the ID of the depth frame buffer texture to query during rendering.
    */
   depthBufferTexture?: WebGLTexture | null;
+
+  /**
+   * Specifies the ID to use for the pick ID in volume rendering.
+   */
+  volumePickID?: number;
 }
 
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging

--- a/src/volume_rendering/volume_render_layer.ts
+++ b/src/volume_rendering/volume_render_layer.ts
@@ -283,7 +283,7 @@ void emitRGBA(vec4 rgba) {
   savedIntensity = intensityChanged ? newIntensity : savedIntensity; 
   savedDepth = intensityChanged ? depthAtRayPosition : savedDepth;
   outputColor = intensityChanged ? newColor : outputColor;
-  emit(outputColor, savedDepth, savedIntensity);
+  emit(outputColor, savedDepth, savedIntensity, pickId);
   defaultMaxProjectionIntensity = 0.0;
   userEmittedIntensity = -100.0;
 `;
@@ -311,6 +311,7 @@ void emitRGBA(vec4 rgba) {
 
           builder.addUniform("highp float", "uBrightnessFactor");
           builder.addUniform("highp float", "uGain");
+          builder.addUniform("highp float", "pickId");
           builder.addVarying("highp vec4", "vNormalizedPosition");
           builder.addTextureSampler(
             "sampler2D",
@@ -368,7 +369,7 @@ vec2 computeUVFromClipSpace(vec4 clipSpacePosition) {
 `;
             if (isProjectionMode(shaderParametersState.mode)) {
               glsl_emitWireframe = `
-  emit(outputColor, 1.0, uChunkNumber);
+  emit(outputColor, 1.0, uChunkNumber, pickId);
             `;
             }
             builder.setFragmentMainFunction(`
@@ -801,6 +802,10 @@ void main() {
           }
           newSource = false;
           gl.uniform3fv(shader.uniform("uTranslation"), chunkPosition);
+          const pickId = renderContext.volumePickID
+            ? renderContext.volumePickID
+            : 0.99;
+          gl.uniform1f(shader.uniform("pickId"), pickId);
           drawBoxes(gl, 1, 1);
           ++presentCount;
         } else {

--- a/src/volume_rendering/volume_render_layer.ts
+++ b/src/volume_rendering/volume_render_layer.ts
@@ -311,7 +311,7 @@ void emitRGBA(vec4 rgba) {
 
           builder.addUniform("highp float", "uBrightnessFactor");
           builder.addUniform("highp float", "uGain");
-          builder.addUniform("highp float", "uPickId");
+          builder.addUniform("highp uint", "uPickId");
           builder.addVarying("highp vec4", "vNormalizedPosition");
           builder.addTextureSampler(
             "sampler2D",
@@ -625,6 +625,9 @@ void main() {
     gl.enable(WebGL2RenderingContext.CULL_FACE);
     gl.cullFace(WebGL2RenderingContext.FRONT);
 
+    const pickId = isProjectionMode(this.mode.value)
+      ? renderContext.pickIDs.register(this)
+      : 0;
     forEachVisibleVolumeRenderingChunk(
       renderContext.projectionParameters,
       this.localPosition.value,
@@ -802,10 +805,7 @@ void main() {
           }
           newSource = false;
           gl.uniform3fv(shader.uniform("uTranslation"), chunkPosition);
-          const pickId = renderContext.volumePickID
-            ? renderContext.volumePickID
-            : 0.99;
-          gl.uniform1f(shader.uniform("uPickId"), pickId);
+          gl.uniform1ui(shader.uniform("uPickId"), pickId);
           drawBoxes(gl, 1, 1);
           ++presentCount;
         } else {

--- a/src/volume_rendering/volume_render_layer.ts
+++ b/src/volume_rendering/volume_render_layer.ts
@@ -283,7 +283,7 @@ void emitRGBA(vec4 rgba) {
   savedIntensity = intensityChanged ? newIntensity : savedIntensity; 
   savedDepth = intensityChanged ? depthAtRayPosition : savedDepth;
   outputColor = intensityChanged ? newColor : outputColor;
-  emit(outputColor, savedDepth, savedIntensity, pickId);
+  emit(outputColor, savedDepth, savedIntensity, uPickId);
   defaultMaxProjectionIntensity = 0.0;
   userEmittedIntensity = -100.0;
 `;
@@ -311,7 +311,7 @@ void emitRGBA(vec4 rgba) {
 
           builder.addUniform("highp float", "uBrightnessFactor");
           builder.addUniform("highp float", "uGain");
-          builder.addUniform("highp float", "pickId");
+          builder.addUniform("highp float", "uPickId");
           builder.addVarying("highp vec4", "vNormalizedPosition");
           builder.addTextureSampler(
             "sampler2D",
@@ -369,7 +369,7 @@ vec2 computeUVFromClipSpace(vec4 clipSpacePosition) {
 `;
             if (isProjectionMode(shaderParametersState.mode)) {
               glsl_emitWireframe = `
-  emit(outputColor, 1.0, uChunkNumber, pickId);
+  emit(outputColor, 1.0, uChunkNumber, uPickId);
             `;
             }
             builder.setFragmentMainFunction(`
@@ -805,7 +805,7 @@ void main() {
           const pickId = renderContext.volumePickID
             ? renderContext.volumePickID
             : 0.99;
-          gl.uniform1f(shader.uniform("pickId"), pickId);
+          gl.uniform1f(shader.uniform("uPickId"), pickId);
           drawBoxes(gl, 1, 1);
           ++presentCount;
         } else {

--- a/src/volume_rendering/volume_render_layer.ts
+++ b/src/volume_rendering/volume_render_layer.ts
@@ -254,16 +254,18 @@ void emitIntensity(float value) {
 float savedDepth = 0.0;
 float savedIntensity = 0.0;
 vec4 newColor = vec4(0.0);
+float userEmittedIntensity = -100.0;
 `);
             glsl_emitIntensity = `
 float convertIntensity(float value) {
   return clamp(${glsl_intensityConversion}, 0.0, 1.0);
 }
 void emitIntensity(float value) {
-  defaultMaxProjectionIntensity = value;
+  userEmittedIntensity = value;
 }
 float getIntensity() {
-  return convertIntensity(defaultMaxProjectionIntensity);
+  float intensity = userEmittedIntensity > -100.0 ? userEmittedIntensity : defaultMaxProjectionIntensity;
+  return convertIntensity(intensity);
 }
 `;
             glsl_rgbaEmit = `
@@ -283,6 +285,7 @@ void emitRGBA(vec4 rgba) {
   outputColor = intensityChanged ? newColor : outputColor;
   emit(outputColor, savedDepth, savedIntensity);
   defaultMaxProjectionIntensity = 0.0;
+  userEmittedIntensity = -100.0;
 `;
           }
           emitter(builder);


### PR DESCRIPTION
Fixes:
1. Picking layer from VR max projection set to `< 1` so as not to interfere with a real annotation with value `1`.
2. Max projection layer uses OIT blending so as not to be layer-order dependent with multiple max-projection layers.
3. Calling `emitIntensity` always overwrites the intensity.
4. Accidental redraw of opaque layers removed.