### PR TITLE
feat(datasource/graphene): add time tool for graphene segmentation

### DIFF
--- a/src/widget/datetime.ts
+++ b/src/widget/datetime.ts
@@ -1,0 +1,83 @@
+/**
+ * @license
+ * Copyright 2020 Google Inc.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { TrackableValueInterface } from "#src/trackable_value.js";
+import { RefCounted } from "#src/util/disposable.js";
+import { removeFromParent } from "#src/util/dom.js";
+
+function toDateTimeLocalString(date: Date) {
+  return new Date(date.getTime() - date.getTimezoneOffset() * 60000)
+    .toISOString()
+    .slice(0, -8);
+  // return date.toISOString().slice(0, -8);
+}
+
+export class DateTimeInputWidget extends RefCounted {
+  element = document.createElement("input");
+  constructor(
+    public model: TrackableValueInterface<number>,
+    minDate?: Date,
+    maxDate?: Date,
+  ) {
+    super();
+    this.registerDisposer(model.changed.add(() => this.updateView()));
+    const { element } = this;
+    element.type = "datetime-local";
+    if (minDate) {
+      this.setMin(minDate);
+    }
+    if (maxDate) {
+      this.setMax(maxDate);
+    }
+    this.registerEventListener(element, "change", () => this.updateModel());
+    this.updateView();
+  }
+
+  setMin(date: Date) {
+    const { element } = this;
+    element.min = toDateTimeLocalString(date);
+  }
+
+  setMax(date: Date) {
+    const { element } = this;
+    element.max = toDateTimeLocalString(date);
+  }
+
+  disposed() {
+    removeFromParent(this.element);
+  }
+
+  private updateView() {
+    if (this.model.value) {
+      this.element.value = toDateTimeLocalString(new Date(this.model.value));
+    } else {
+      this.element.value = "";
+    }
+  }
+
+  private updateModel() {
+    try {
+      if (this.element.value) {
+        this.model.restoreState(new Date(this.element.value).valueOf());
+      } else {
+        this.model.restoreState(0);
+      }
+    } catch {
+      // Ignore invalid input.
+    }
+    this.updateView();
+  }
+}


### PR DESCRIPTION
Separated into three commits

Before I created all the structure needed to be able to handle layers being able to control their own piece of the layer widget, I wanted to see the bare minimum to get it functional. Also, to get your opinion if we should use the layer widget for this ui. This indicates to the user that they are looking at a past/locked segmentation.

<img width="238" alt="Screenshot 2024-05-08 at 6 26 30 PM" src="https://github.com/google/neuroglancer/assets/188155/47ebd8e6-90cd-410c-893a-139b60d608e9">
