### PR TITLE
Feature - adaptive downsampling of volume rendering based on framerate

### DIFF
--- a/python/neuroglancer/viewer_state.py
+++ b/python/neuroglancer/viewer_state.py
@@ -1668,6 +1668,7 @@ class ViewerState(JsonObjectWrapper):
     show_axis_lines = showAxisLines = wrapped_property(
         "showAxisLines", optional(bool, True)
     )
+    wire_frame = wireFrame = wrapped_property("wireFrame", optional(bool, False))
     enable_adaptive_downsampling = enableAdaptiveDownsampling = wrapped_property(
         "enableAdaptiveDownsampling", optional(bool, True)
     )

--- a/python/neuroglancer/viewer_state.py
+++ b/python/neuroglancer/viewer_state.py
@@ -1668,6 +1668,9 @@ class ViewerState(JsonObjectWrapper):
     show_axis_lines = showAxisLines = wrapped_property(
         "showAxisLines", optional(bool, True)
     )
+    enable_adaptive_downsampling = enableAdaptiveDownsampling = wrapped_property(
+        "enableAdaptiveDownsampling", optional(bool, True)
+    )
     show_scale_bar = showScaleBar = wrapped_property(
         "showScaleBar", optional(bool, True)
     )

--- a/src/data_panel_layout.ts
+++ b/src/data_panel_layout.ts
@@ -92,6 +92,7 @@ export interface ViewerUIState
   showPerspectiveSliceViews: TrackableBoolean;
   showAxisLines: TrackableBoolean;
   wireFrame: TrackableBoolean;
+  adaptiveDownsampling: TrackableBoolean;
   showScaleBar: TrackableBoolean;
   scaleBarOptions: TrackableValue<ScaleBarOptions>;
   visibleLayerRoles: WatchableSet<RenderLayerRole>;
@@ -174,6 +175,7 @@ export function getCommonViewerState(viewer: ViewerUIState) {
     layerManager: viewer.layerManager,
     showAxisLines: viewer.showAxisLines,
     wireFrame: viewer.wireFrame,
+    adaptiveDownsampling: viewer.adaptiveDownsampling,
     visibleLayerRoles: viewer.visibleLayerRoles,
     selectedLayer: viewer.selectedLayer,
     visibility: viewer.visibility,

--- a/src/data_panel_layout.ts
+++ b/src/data_panel_layout.ts
@@ -92,7 +92,7 @@ export interface ViewerUIState
   showPerspectiveSliceViews: TrackableBoolean;
   showAxisLines: TrackableBoolean;
   wireFrame: TrackableBoolean;
-  adaptiveDownsampling: TrackableBoolean;
+  enableAdaptiveDownsampling: TrackableBoolean;
   showScaleBar: TrackableBoolean;
   scaleBarOptions: TrackableValue<ScaleBarOptions>;
   visibleLayerRoles: WatchableSet<RenderLayerRole>;
@@ -175,7 +175,7 @@ export function getCommonViewerState(viewer: ViewerUIState) {
     layerManager: viewer.layerManager,
     showAxisLines: viewer.showAxisLines,
     wireFrame: viewer.wireFrame,
-    adaptiveDownsampling: viewer.adaptiveDownsampling,
+    enableAdaptiveDownsampling: viewer.enableAdaptiveDownsampling,
     visibleLayerRoles: viewer.visibleLayerRoles,
     selectedLayer: viewer.selectedLayer,
     visibility: viewer.visibility,

--- a/src/display_context.ts
+++ b/src/display_context.ts
@@ -19,6 +19,7 @@ import { TrackableValue } from "#src/trackable_value.js";
 import { animationFrameDebounce } from "#src/util/animation_frame_debounce.js";
 import type { Borrowed } from "#src/util/disposable.js";
 import { RefCounted } from "#src/util/disposable.js";
+import { FramerateMonitor } from "#src/util/framerate.js";
 import type { mat4 } from "#src/util/geom.js";
 import { parseFixedLengthArray, verifyFloat01 } from "#src/util/json.js";
 import { NullarySignal } from "#src/util/signal.js";
@@ -396,6 +397,7 @@ export class DisplayContext extends RefCounted implements FrameNumberCounter {
   rootRect: DOMRect | undefined;
   resizeGeneration = 0;
   boundsGeneration = -1;
+  private framerateMonitor = new FramerateMonitor();
 
   // Panels ordered by `drawOrder`.  If length is 0, needs to be recomputed.
   private orderedPanels: RenderedPanel[] = [];
@@ -557,6 +559,8 @@ export class DisplayContext extends RefCounted implements FrameNumberCounter {
     ++this.frameNumber;
     this.updateStarted.dispatch();
     const gl = this.gl;
+    const ext = this.framerateMonitor.getTimingExtension(gl);
+    const query = this.framerateMonitor.startFrameTimeQuery(gl, ext);
     this.ensureBoundsUpdated();
     this.gl.clearColor(0.0, 0.0, 0.0, 0.0);
     gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT);
@@ -580,6 +584,7 @@ export class DisplayContext extends RefCounted implements FrameNumberCounter {
     gl.clear(gl.COLOR_BUFFER_BIT);
     this.gl.colorMask(true, true, true, true);
     this.updateFinished.dispatch();
+    this.framerateMonitor.endFrameTimeQuery(gl, ext, query);
   }
 
   getDepthArray(): Float32Array {
@@ -606,5 +611,9 @@ export class DisplayContext extends RefCounted implements FrameNumberCounter {
       }
     }
     return depthArray;
+  }
+
+  getLastFrameTimesInMs(numberOfFrames: number = 5) {
+    return this.framerateMonitor.getLastFrameTimesInMs(this.gl, numberOfFrames);
   }
 }

--- a/src/display_context.ts
+++ b/src/display_context.ts
@@ -394,6 +394,7 @@ export class DisplayContext extends RefCounted implements FrameNumberCounter {
   gl: GL;
   updateStarted = new NullarySignal();
   updateFinished = new NullarySignal();
+  continuousCameraMotionStarted = new NullarySignal();
   continuousCameraMotionFinished = new NullarySignal();
   changed = this.updateFinished;
   panels = new Set<RenderedPanel>();
@@ -462,6 +463,9 @@ export class DisplayContext extends RefCounted implements FrameNumberCounter {
   );
 
   flagContinuousCameraMotion() {
+    if (!this.continuousCameraMotionInProgress) {
+      this.continuousCameraMotionStarted.dispatch();
+    }
     this.continuousCameraMotionInProgress = true;
     this.debouncedEndContinuousCameraMotion();
   }

--- a/src/display_context.ts
+++ b/src/display_context.ts
@@ -21,6 +21,7 @@ import { TrackableValue } from "#src/trackable_value.js";
 import { animationFrameDebounce } from "#src/util/animation_frame_debounce.js";
 import type { Borrowed } from "#src/util/disposable.js";
 import { RefCounted } from "#src/util/disposable.js";
+import { FramerateMonitor } from "#src/util/framerate.js";
 import type { mat4 } from "#src/util/geom.js";
 import { parseFixedLengthArray, verifyFloat01 } from "#src/util/json.js";
 import { NullarySignal } from "#src/util/signal.js";
@@ -402,6 +403,7 @@ export class DisplayContext extends RefCounted implements FrameNumberCounter {
   rootRect: DOMRect | undefined;
   resizeGeneration = 0;
   boundsGeneration = -1;
+  private framerateMonitor = new FramerateMonitor();
 
   private continuousCameraMotionInProgress = false;
 
@@ -584,6 +586,8 @@ export class DisplayContext extends RefCounted implements FrameNumberCounter {
     ++this.frameNumber;
     this.updateStarted.dispatch();
     const gl = this.gl;
+    const ext = this.framerateMonitor.getTimingExtension(gl);
+    const query = this.framerateMonitor.startFrameTimeQuery(gl, ext);
     this.ensureBoundsUpdated();
     this.gl.clearColor(0.0, 0.0, 0.0, 0.0);
     gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT);
@@ -607,6 +611,8 @@ export class DisplayContext extends RefCounted implements FrameNumberCounter {
     gl.clear(gl.COLOR_BUFFER_BIT);
     this.gl.colorMask(true, true, true, true);
     this.updateFinished.dispatch();
+    this.framerateMonitor.endFrameTimeQuery(gl, ext, query);
+    this.framerateMonitor.grabAnyFinishedQueryResults(gl);
   }
 
   getDepthArray(): Float32Array {
@@ -633,5 +639,9 @@ export class DisplayContext extends RefCounted implements FrameNumberCounter {
       }
     }
     return depthArray;
+  }
+
+  getLastFrameTimesInMs(numberOfFrames: number = 10) {
+    return this.framerateMonitor.getLastFrameTimesInMs(numberOfFrames);
   }
 }

--- a/src/display_context.ts
+++ b/src/display_context.ts
@@ -19,7 +19,6 @@ import { TrackableValue } from "#src/trackable_value.js";
 import { animationFrameDebounce } from "#src/util/animation_frame_debounce.js";
 import type { Borrowed } from "#src/util/disposable.js";
 import { RefCounted } from "#src/util/disposable.js";
-import { FramerateMonitor } from "#src/util/framerate.js";
 import type { mat4 } from "#src/util/geom.js";
 import { parseFixedLengthArray, verifyFloat01 } from "#src/util/json.js";
 import { NullarySignal } from "#src/util/signal.js";
@@ -397,7 +396,6 @@ export class DisplayContext extends RefCounted implements FrameNumberCounter {
   rootRect: DOMRect | undefined;
   resizeGeneration = 0;
   boundsGeneration = -1;
-  private framerateMonitor = new FramerateMonitor();
 
   // Panels ordered by `drawOrder`.  If length is 0, needs to be recomputed.
   private orderedPanels: RenderedPanel[] = [];
@@ -559,8 +557,6 @@ export class DisplayContext extends RefCounted implements FrameNumberCounter {
     ++this.frameNumber;
     this.updateStarted.dispatch();
     const gl = this.gl;
-    const ext = this.framerateMonitor.getTimingExtension(gl);
-    const query = this.framerateMonitor.startFrameTimeQuery(gl, ext);
     this.ensureBoundsUpdated();
     this.gl.clearColor(0.0, 0.0, 0.0, 0.0);
     gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT);
@@ -584,7 +580,6 @@ export class DisplayContext extends RefCounted implements FrameNumberCounter {
     gl.clear(gl.COLOR_BUFFER_BIT);
     this.gl.colorMask(true, true, true, true);
     this.updateFinished.dispatch();
-    this.framerateMonitor.endFrameTimeQuery(gl, ext, query);
   }
 
   getDepthArray(): Float32Array {
@@ -611,9 +606,5 @@ export class DisplayContext extends RefCounted implements FrameNumberCounter {
       }
     }
     return depthArray;
-  }
-
-  getLastFrameTimesInMs(numberOfFrames: number = 5) {
-    return this.framerateMonitor.getLastFrameTimesInMs(this.gl, numberOfFrames);
   }
 }

--- a/src/layer_group_viewer.ts
+++ b/src/layer_group_viewer.ts
@@ -94,6 +94,7 @@ export interface LayerGroupViewerState {
   mouseState: MouseSelectionState;
   showAxisLines: TrackableBoolean;
   wireFrame: TrackableBoolean;
+  adaptiveDownsampling: TrackableBoolean;
   showScaleBar: TrackableBoolean;
   scaleBarOptions: TrackableScaleBarOptions;
   showPerspectiveSliceViews: TrackableBoolean;
@@ -355,6 +356,9 @@ export class LayerGroupViewer extends RefCounted {
   }
   get wireFrame() {
     return this.viewerState.wireFrame;
+  }
+  get adaptiveDownsampling() {
+    return this.viewerState.adaptiveDownsampling;
   }
   get showScaleBar() {
     return this.viewerState.showScaleBar;

--- a/src/layer_group_viewer.ts
+++ b/src/layer_group_viewer.ts
@@ -94,7 +94,7 @@ export interface LayerGroupViewerState {
   mouseState: MouseSelectionState;
   showAxisLines: TrackableBoolean;
   wireFrame: TrackableBoolean;
-  adaptiveDownsampling: TrackableBoolean;
+  enableAdaptiveDownsampling: TrackableBoolean;
   showScaleBar: TrackableBoolean;
   scaleBarOptions: TrackableScaleBarOptions;
   showPerspectiveSliceViews: TrackableBoolean;
@@ -357,8 +357,8 @@ export class LayerGroupViewer extends RefCounted {
   get wireFrame() {
     return this.viewerState.wireFrame;
   }
-  get adaptiveDownsampling() {
-    return this.viewerState.adaptiveDownsampling;
+  get enableAdaptiveDownsampling() {
+    return this.viewerState.enableAdaptiveDownsampling;
   }
   get showScaleBar() {
     return this.viewerState.showScaleBar;

--- a/src/layer_groups_layout.ts
+++ b/src/layer_groups_layout.ts
@@ -407,7 +407,7 @@ function getCommonViewerState(viewer: Viewer) {
     mouseState: viewer.mouseState,
     showAxisLines: viewer.showAxisLines,
     wireFrame: viewer.wireFrame,
-    adaptiveDownsampling: viewer.adaptiveDownsampling,
+    enableAdaptiveDownsampling: viewer.enableAdaptiveDownsampling,
     showScaleBar: viewer.showScaleBar,
     scaleBarOptions: viewer.scaleBarOptions,
     showPerspectiveSliceViews: viewer.showPerspectiveSliceViews,

--- a/src/layer_groups_layout.ts
+++ b/src/layer_groups_layout.ts
@@ -407,6 +407,7 @@ function getCommonViewerState(viewer: Viewer) {
     mouseState: viewer.mouseState,
     showAxisLines: viewer.showAxisLines,
     wireFrame: viewer.wireFrame,
+    adaptiveDownsampling: viewer.adaptiveDownsampling,
     showScaleBar: viewer.showScaleBar,
     scaleBarOptions: viewer.scaleBarOptions,
     showPerspectiveSliceViews: viewer.showPerspectiveSliceViews,

--- a/src/perspective_view/panel.ts
+++ b/src/perspective_view/panel.ts
@@ -288,7 +288,7 @@ export class PerspectivePanel extends RenderedDataPanel {
   // if a high downsample rate is applied, it persists for a few frames
   // to avoid flickering when the camera is moving
   private frameRateCalculator = new DownsamplingBasedOnFrameRateCalculator(
-    10 /* numberOfStoredFrameDeltas */,
+    6 /* numberOfStoredFrameDeltas */,
     8 /* maxDownsamplingFactor */,
     16 /* desiredFrameTimingMs */,
     60 /* downsamplingPersistenceDurationInFrames */,

--- a/src/perspective_view/panel.ts
+++ b/src/perspective_view/panel.ts
@@ -85,8 +85,6 @@ import { MultipleScaleBarTextures } from "#src/widget/scale_bar.js";
 import type { RPC } from "#src/worker_rpc.js";
 import { SharedObject } from "#src/worker_rpc.js";
 
-const REDRAW_DELAY_AFTER_CAMERA_MOVE = 300;
-
 export interface PerspectiveViewerState extends RenderedDataViewerState {
   wireFrame: WatchableValueInterface<boolean>;
   enableAdaptiveDownsampling: WatchableValueInterface<boolean>;

--- a/src/perspective_view/panel.ts
+++ b/src/perspective_view/panel.ts
@@ -109,7 +109,6 @@ enum TransparentRenderingState {
   Transparent = 0,
   VOLUME_RENDERING = 1,
   MAX_PROJECTION = 2,
-  UNSET = 3,
 }
 
 export const glsl_perspectivePanelEmit = `
@@ -1168,7 +1167,7 @@ export class PerspectivePanel extends RenderedDataPanel {
         WebGL2RenderingContext.ONE_MINUS_SRC_ALPHA,
       );
       renderContext.emitPickID = false;
-      let currentTransparentRenderingState = TransparentRenderingState.UNSET;
+      let currentTransparentRenderingState = TransparentRenderingState.Transparent;
       for (const [renderLayer, attachment] of visibleLayers) {
         if (renderLayer.isTransparent) {
           renderContext.depthBufferTexture =

--- a/src/perspective_view/panel.ts
+++ b/src/perspective_view/panel.ts
@@ -89,7 +89,7 @@ const REDRAW_DELAY_AFTER_CAMERA_MOVE = 300;
 
 export interface PerspectiveViewerState extends RenderedDataViewerState {
   wireFrame: WatchableValueInterface<boolean>;
-  adaptiveDownsampling: WatchableValueInterface<boolean>;
+  enableAdaptiveDownsampling: WatchableValueInterface<boolean>;
   orthographicProjection: TrackableBoolean;
   showSliceViews: TrackableBoolean;
   showScaleBar: TrackableBoolean;
@@ -443,7 +443,7 @@ export class PerspectivePanel extends RenderedDataPanel {
       }),
     );
     this.projectionParameters.changed.add(() => this.context.scheduleRedraw());
-    this.viewer.adaptiveDownsampling.changed.add(() => {
+    this.viewer.enableAdaptiveDownsampling.changed.add(() => {
       this.frameRateCalculator.resetLastFrameTime();
     });
 
@@ -848,7 +848,7 @@ export class PerspectivePanel extends RenderedDataPanel {
     if (!this.navigationState.valid) {
       return false;
     }
-    if (this.viewer.adaptiveDownsampling.value && this.isCameraMoving) {
+    if (this.viewer.enableAdaptiveDownsampling.value && this.isCameraMoving) {
       this.frameRateCalculator.addFrame();
     }
     const { width, height } = this.renderViewport;
@@ -1043,7 +1043,7 @@ export class PerspectivePanel extends RenderedDataPanel {
       let volumeRenderingBufferWidth = width;
       let volumeRenderingBufferHeight = height;
 
-      if (this.viewer.adaptiveDownsampling.value && this.isCameraMoving) {
+      if (this.viewer.enableAdaptiveDownsampling.value && this.isCameraMoving) {
         const downsamplingFactor =
           this.frameRateCalculator.calculateDownsamplingRateBasedOnFrameDeltas(
             FrameTimingMethod.MEAN,

--- a/src/perspective_view/panel.ts
+++ b/src/perspective_view/panel.ts
@@ -293,7 +293,7 @@ export class PerspectivePanel extends RenderedDataPanel {
   // to avoid flickering when the camera is moving
   private frameRateCalculator = new DownsamplingBasedOnFrameRateCalculator(
     6 /* numberOfStoredFrameDeltas */,
-    8 /* maxDownsamplingFactor */,
+    4 /* maxDownsamplingFactor */,
     16 /* desiredFrameTimingMs */,
     60 /* downsamplingPersistenceDurationInFrames */,
   );

--- a/src/perspective_view/panel.ts
+++ b/src/perspective_view/panel.ts
@@ -1045,7 +1045,7 @@ export class PerspectivePanel extends RenderedDataPanel {
 
       if (this.viewer.enableAdaptiveDownsampling.value && this.isCameraMoving) {
         const downsamplingFactor =
-          this.frameRateCalculator.calculateDownsamplingRateBasedOnFrameDeltas(
+          this.frameRateCalculator.calculateDownsamplingRate(
             FrameTimingMethod.MEAN,
           );
         if (downsamplingFactor > 1) {

--- a/src/perspective_view/panel.ts
+++ b/src/perspective_view/panel.ts
@@ -1120,7 +1120,6 @@ export class PerspectivePanel extends RenderedDataPanel {
         WebGL2RenderingContext.ONE_MINUS_SRC_ALPHA,
       );
       renderContext.emitPickID = false;
-
       for (const [renderLayer, attachment] of visibleLayers) {
         if (renderLayer.isTransparent) {
           renderContext.depthBufferTexture =

--- a/src/perspective_view/panel.ts
+++ b/src/perspective_view/panel.ts
@@ -88,6 +88,7 @@ const MAX_TRANSPARENT_DOWNSAMPLE_FACTOR = 8;
 
 export interface PerspectiveViewerState extends RenderedDataViewerState {
   wireFrame: WatchableValueInterface<boolean>;
+  adaptiveDownsampling: WatchableValueInterface<boolean>;
   orthographicProjection: TrackableBoolean;
   showSliceViews: TrackableBoolean;
   showScaleBar: TrackableBoolean;
@@ -1004,7 +1005,10 @@ export class PerspectivePanel extends RenderedDataPanel {
     if (this.hasTransparent) {
       //Draw transparent objects.
 
-      if (this.shouldCheckFrameRate) {
+      let volumeRenderingBufferWidth = width;
+      let volumeRenderingBufferHeight = height;
+
+      if (this.viewer.adaptiveDownsampling.value && this.shouldCheckFrameRate) {
         const frameDelta = this.frameRateCalculator.calculateFrameTimeInMs();
         let transparentBufferDownsampleFactorBasedOnFramerate = Math.max(
           frameDelta / DESIRED_FRAME_TIMING_MS,
@@ -1024,17 +1028,15 @@ export class PerspectivePanel extends RenderedDataPanel {
           ),
           MAX_TRANSPARENT_DOWNSAMPLE_FACTOR,
         );
-      }
-      let volumeRenderingBufferWidth = width;
-      let volumeRenderingBufferHeight = height;
-      if (this.maxDownsamplingFactorThisCameraMove > 1) {
-        const originalRatio = width / height;
-        volumeRenderingBufferWidth = Math.round(
-          width / this.maxDownsamplingFactorThisCameraMove,
-        );
-        volumeRenderingBufferHeight = Math.round(
-          volumeRenderingBufferWidth / originalRatio,
-        );
+        if (this.maxDownsamplingFactorThisCameraMove > 1) {
+          const originalRatio = width / height;
+          volumeRenderingBufferWidth = Math.round(
+            width / this.maxDownsamplingFactorThisCameraMove,
+          );
+          volumeRenderingBufferHeight = Math.round(
+            volumeRenderingBufferWidth / originalRatio,
+          );
+        }
       }
 
       // Create max projection buffer if needed.

--- a/src/perspective_view/panel.ts
+++ b/src/perspective_view/panel.ts
@@ -1151,8 +1151,9 @@ export class PerspectivePanel extends RenderedDataPanel {
           renderContext.emitter = perspectivePanelEmitOIT;
           renderContext.bindFramebuffer();
           continue;
+        } else if (renderLayer.isTransparent) {
+          renderLayer.draw(renderContext, attachment);
         }
-        renderLayer.draw(renderContext, attachment);
       }
       // Copy transparent rendering result back to primary buffer.
       gl.disable(WebGL2RenderingContext.DEPTH_TEST);

--- a/src/perspective_view/panel.ts
+++ b/src/perspective_view/panel.ts
@@ -293,7 +293,7 @@ export class PerspectivePanel extends RenderedDataPanel {
   // to avoid flickering when the camera is moving
   private frameRateCalculator = new DownsamplingBasedOnFrameRateCalculator(
     6 /* numberOfStoredFrameDeltas */,
-    16 /* maxDownsamplingFactor */,
+    8 /* maxDownsamplingFactor */,
     8 /* desiredFrameTimingMs */,
     60 /* downsamplingPersistenceDurationInFrames */,
   );

--- a/src/perspective_view/panel.ts
+++ b/src/perspective_view/panel.ts
@@ -443,7 +443,7 @@ export class PerspectivePanel extends RenderedDataPanel {
         this.redrawAfterMoveTimeOutId = window.setTimeout(() => {
           this.redrawAfterMoveTimeOutId = -1;
           this.maxDownsamplingFactorThisCameraMove = 1;
-          this.frameRateCalculator.reset();
+          this.frameRateCalculator.resetLastFrameTime();
           this.context.scheduleRedraw();
         }, FULL_RESOLUTION_DRAW_DELAY_AFTER_CAMERA_MOVE);
       }),

--- a/src/perspective_view/panel.ts
+++ b/src/perspective_view/panel.ts
@@ -106,7 +106,7 @@ export enum OffscreenTextures {
 }
 
 enum TransparentRenderingState {
-  Transparent = 0,
+  TRANSPARENT = 0,
   VOLUME_RENDERING = 1,
   MAX_PROJECTION = 2,
 }
@@ -1172,7 +1172,7 @@ export class PerspectivePanel extends RenderedDataPanel {
       );
       renderContext.emitPickID = false;
       let currentTransparentRenderingState =
-        TransparentRenderingState.Transparent;
+        TransparentRenderingState.TRANSPARENT;
       for (const [renderLayer, attachment] of visibleLayers) {
         if (renderLayer.isTransparent) {
           renderContext.depthBufferTexture =
@@ -1259,13 +1259,13 @@ export class PerspectivePanel extends RenderedDataPanel {
         else if (renderLayer.isTransparent) {
           if (
             currentTransparentRenderingState !==
-            TransparentRenderingState.Transparent
+            TransparentRenderingState.TRANSPARENT
           ) {
             renderContext.emitter = perspectivePanelEmitOIT;
             renderContext.bindFramebuffer();
           }
           currentTransparentRenderingState =
-            TransparentRenderingState.Transparent;
+            TransparentRenderingState.TRANSPARENT;
           renderLayer.draw(renderContext, attachment);
         }
       }

--- a/src/perspective_view/panel.ts
+++ b/src/perspective_view/panel.ts
@@ -1022,7 +1022,7 @@ export class PerspectivePanel extends RenderedDataPanel {
               Math.log2(transparentBufferDownsampleFactorBasedOnFramerate),
             ),
           ),
-          8,
+          MAX_TRANSPARENT_DOWNSAMPLE_FACTOR,
         );
         this.maxDownsamplingFactorThisCameraMove = Math.max(
           this.maxDownsamplingFactorThisCameraMove,

--- a/src/perspective_view/panel.ts
+++ b/src/perspective_view/panel.ts
@@ -1256,7 +1256,6 @@ export class PerspectivePanel extends RenderedDataPanel {
             currentTransparentRenderingState !==
             TransparentRenderingState.Transparent
           ) {
-            console.log("transparent buffer binding");
             renderContext.emitter = perspectivePanelEmitOIT;
             renderContext.bindFramebuffer();
           }

--- a/src/perspective_view/panel.ts
+++ b/src/perspective_view/panel.ts
@@ -84,7 +84,7 @@ import { SharedObject } from "#src/worker_rpc.js";
 
 const FULL_RESOLUTION_DRAW_DELAY_AFTER_CAMERA_MOVE = 300;
 const DESIRED_FRAME_TIMING_MS = 1000 / 60;
-const MAX_TRANSPARENT_DOWNSAMPLE_FACTOR = 10;
+const MAX_TRANSPARENT_DOWNSAMPLE_FACTOR = 16;
 
 export interface PerspectiveViewerState extends RenderedDataViewerState {
   wireFrame: WatchableValueInterface<boolean>;
@@ -1006,16 +1006,27 @@ export class PerspectivePanel extends RenderedDataPanel {
       if (this.shouldCheckFrameRate) {
         const frameDelta = this.frameRateCalculator.calculateFrameTimeInMs();
         transparentBufferDownsampleFactorBasedOnFramerate = Math.min(
-          Math.round(frameDelta / DESIRED_FRAME_TIMING_MS),
+          Math.max(Math.round(frameDelta / DESIRED_FRAME_TIMING_MS), 1),
           MAX_TRANSPARENT_DOWNSAMPLE_FACTOR,
         );
+        console.log(
+          "before",
+          transparentBufferDownsampleFactorBasedOnFramerate,
+        );
+        transparentBufferDownsampleFactorBasedOnFramerate = Math.pow(
+          2,
+          Math.round(
+            Math.log2(transparentBufferDownsampleFactorBasedOnFramerate),
+          ),
+        );
+        console.log("after", transparentBufferDownsampleFactorBasedOnFramerate);
       }
       let volumeRenderingBufferWidth = width;
       let volumeRenderingBufferHeight = height;
-      if (transparentBufferDownsampleFactorBasedOnFramerate  > 1) {
+      if (transparentBufferDownsampleFactorBasedOnFramerate > 1) {
         const originalRatio = width / height;
         volumeRenderingBufferWidth = Math.round(
-          width / transparentBufferDownsampleFactorBasedOnFramerate ,
+          width / transparentBufferDownsampleFactorBasedOnFramerate,
         );
         volumeRenderingBufferHeight = Math.round(
           volumeRenderingBufferWidth / originalRatio,

--- a/src/perspective_view/panel.ts
+++ b/src/perspective_view/panel.ts
@@ -263,7 +263,7 @@ export class PerspectivePanel extends RenderedDataPanel {
     return this.navigationState.displayDimensionRenderInfo;
   }
 
-  private frameRateCalculator = new FrameRateCalculator(10);
+  private frameRateCalculator = new FrameRateCalculator(20);
   private redrawAfterMoveTimeOutId = -1;
   private maxDownsamplingFactorThisCameraMove = 1;
   private hasTransparent = false;

--- a/src/perspective_view/panel.ts
+++ b/src/perspective_view/panel.ts
@@ -293,7 +293,7 @@ export class PerspectivePanel extends RenderedDataPanel {
   // to avoid flickering when the camera is moving
   private frameRateCalculator = new DownsamplingBasedOnFrameRateCalculator(
     6 /* numberOfStoredFrameDeltas */,
-    8 /* maxDownsamplingFactor */,
+    4 /* maxDownsamplingFactor */,
     8 /* desiredFrameTimingMs */,
     60 /* downsamplingPersistenceDurationInFrames */,
   );

--- a/src/perspective_view/panel.ts
+++ b/src/perspective_view/panel.ts
@@ -444,7 +444,7 @@ export class PerspectivePanel extends RenderedDataPanel {
     );
     this.projectionParameters.changed.add(() => this.context.scheduleRedraw());
     this.viewer.enableAdaptiveDownsampling.changed.add(() => {
-      this.frameRateCalculator.resetLastFrameTime();
+      this.frameRateCalculator.resetForNewFrameSet();
     });
 
     const sharedObject = (this.sharedObject = this.registerDisposer(
@@ -472,7 +472,7 @@ export class PerspectivePanel extends RenderedDataPanel {
         }
         this.redrawAfterMoveTimeOutId = window.setTimeout(() => {
           this.redrawAfterMoveTimeOutId = -1;
-          this.frameRateCalculator.resetLastFrameTime();
+          this.frameRateCalculator.resetForNewFrameSet();
           this.context.scheduleRedraw();
         }, REDRAW_DELAY_AFTER_CAMERA_MOVE);
       }),

--- a/src/perspective_view/panel.ts
+++ b/src/perspective_view/panel.ts
@@ -1028,11 +1028,13 @@ export class PerspectivePanel extends RenderedDataPanel {
           ),
           MAX_TRANSPARENT_DOWNSAMPLE_FACTOR,
         );
-        if (this.maxDownsamplingFactorThisCameraMove > 1) {
+        const downsamplingFactor =
+          this.maxDownsamplingFactorThisCameraMove > 1
+            ? Math.max(2, transparentBufferDownsampleFactorBasedOnFramerate)
+            : 1;
+        if (downsamplingFactor > 1) {
           const originalRatio = width / height;
-          volumeRenderingBufferWidth = Math.round(
-            width / this.maxDownsamplingFactorThisCameraMove,
-          );
+          volumeRenderingBufferWidth = Math.round(width / downsamplingFactor);
           volumeRenderingBufferHeight = Math.round(
             volumeRenderingBufferWidth / originalRatio,
           );

--- a/src/perspective_view/panel.ts
+++ b/src/perspective_view/panel.ts
@@ -84,6 +84,7 @@ import { SharedObject } from "#src/worker_rpc.js";
 
 const CAMERA_MOVEMENT_VR_SETTLE_TIME_MS = 200;
 const DESIRED_FRAME_TIMING_MS = 1000 / 60;
+const MAX_VR_DOWNSAMPLE_FACTOR = 20;
 
 export interface PerspectiveViewerState extends RenderedDataViewerState {
   wireFrame: WatchableValueInterface<boolean>;
@@ -996,7 +997,7 @@ export class PerspectivePanel extends RenderedDataPanel {
       //Draw transparent objects.
 
       // Check the sample rate for volume rendering
-      let volumeRenderingDownsampleFactorBasedOnSize = 1000;
+      let volumeRenderingDownsampleFactorBasedOnSize = Infinity;
       for (const [renderLayer] of visibleLayers) {
         if (renderLayer.isVolumeRendering) {
           const volumeRenderingRenderLayer =
@@ -1009,7 +1010,9 @@ export class PerspectivePanel extends RenderedDataPanel {
           );
         }
       }
-      if (volumeRenderingDownsampleFactorBasedOnSize === 1000) {
+      if (
+        volumeRenderingDownsampleFactorBasedOnSize > MAX_VR_DOWNSAMPLE_FACTOR
+      ) {
         volumeRenderingDownsampleFactorBasedOnSize = 1;
       }
 
@@ -1021,7 +1024,7 @@ export class PerspectivePanel extends RenderedDataPanel {
             Math.round(frameDelta / DESIRED_FRAME_TIMING_MS),
             volumeRenderingDownsampleFactorBasedOnSize,
           ),
-          10,
+          MAX_VR_DOWNSAMPLE_FACTOR,
         );
       }
       const volumeRenderingDownsampleFactor = Math.max(

--- a/src/perspective_view/panel.ts
+++ b/src/perspective_view/panel.ts
@@ -472,17 +472,16 @@ export class PerspectivePanel extends RenderedDataPanel {
 
     this.registerDisposer(
       this.context.continuousCameraMotionFinished.add(() => {
+        this.isCameraInContinuousMotion = false;
         if (this.hasVolumeRendering) {
           this.scheduleRedraw();
-          this.isCameraInContinuousMotion = false;
+          this.frameRateCalculator.resetForNewFrameSet();
         }
       }),
     );
     this.registerDisposer(
       this.context.continuousCameraMotionStarted.add(() => {
-        if (this.hasVolumeRendering) {
-          this.isCameraInContinuousMotion = true;
-        }
+        this.isCameraInContinuousMotion = true;
       }),
     );
 

--- a/src/perspective_view/panel.ts
+++ b/src/perspective_view/panel.ts
@@ -1015,18 +1015,18 @@ export class PerspectivePanel extends RenderedDataPanel {
           1,
         );
         // Round to the nearest power of 2.
-        transparentBufferDownsampleFactorBasedOnFramerate = Math.pow(
-          2,
-          Math.round(
-            Math.log2(transparentBufferDownsampleFactorBasedOnFramerate),
+        transparentBufferDownsampleFactorBasedOnFramerate = Math.min(
+          Math.pow(
+            2,
+            Math.round(
+              Math.log2(transparentBufferDownsampleFactorBasedOnFramerate),
+            ),
           ),
+          8,
         );
-        this.maxDownsamplingFactorThisCameraMove = Math.min(
-          Math.max(
-            this.maxDownsamplingFactorThisCameraMove,
-            transparentBufferDownsampleFactorBasedOnFramerate,
-          ),
-          MAX_TRANSPARENT_DOWNSAMPLE_FACTOR,
+        this.maxDownsamplingFactorThisCameraMove = Math.max(
+          this.maxDownsamplingFactorThisCameraMove,
+          transparentBufferDownsampleFactorBasedOnFramerate,
         );
         const downsamplingFactor =
           this.maxDownsamplingFactorThisCameraMove > 1

--- a/src/perspective_view/panel.ts
+++ b/src/perspective_view/panel.ts
@@ -290,7 +290,7 @@ export class PerspectivePanel extends RenderedDataPanel {
   private frameRateCalculator = new DownsamplingBasedOnFrameRateCalculator(
     3 /* numberOfStoredFrameDeltas */,
     8 /* maxDownsamplingFactor */,
-    8 /* desiredFrameTimingMs */,
+    16 /* desiredFrameTimingMs */,
     60 /* downsamplingPersistenceDurationInFrames */,
   );
   private redrawAfterMoveTimeOutId = -1;

--- a/src/perspective_view/panel.ts
+++ b/src/perspective_view/panel.ts
@@ -263,7 +263,7 @@ export class PerspectivePanel extends RenderedDataPanel {
     return this.navigationState.displayDimensionRenderInfo;
   }
 
-  private frameRateCalculator = new FrameRateCalculator(20);
+  private frameRateCalculator = new FrameRateCalculator(10);
   private redrawAfterMoveTimeOutId = -1;
   private maxDownsamplingFactorThisCameraMove = 1;
   private hasTransparent = false;

--- a/src/perspective_view/panel.ts
+++ b/src/perspective_view/panel.ts
@@ -1082,11 +1082,6 @@ export class PerspectivePanel extends RenderedDataPanel {
             this.frameRateCalculator.numberOfStoredFrameDeltas,
           ),
         );
-        console.log(
-          this.context.getLastFrameTimesInMs(
-            this.frameRateCalculator.numberOfStoredFrameDeltas,
-          ),
-        );
         const downsamplingFactor =
           this.frameRateCalculator.calculateDownsamplingRate(
             FrameTimingMethod.MEAN,

--- a/src/perspective_view/panel.ts
+++ b/src/perspective_view/panel.ts
@@ -293,8 +293,8 @@ export class PerspectivePanel extends RenderedDataPanel {
   // to avoid flickering when the camera is moving
   private frameRateCalculator = new DownsamplingBasedOnFrameRateCalculator(
     6 /* numberOfStoredFrameDeltas */,
-    4 /* maxDownsamplingFactor */,
-    16 /* desiredFrameTimingMs */,
+    16 /* maxDownsamplingFactor */,
+    8 /* desiredFrameTimingMs */,
     60 /* downsamplingPersistenceDurationInFrames */,
   );
   private isCameraInContinuousMotion = false;
@@ -878,7 +878,6 @@ export class PerspectivePanel extends RenderedDataPanel {
     if (!this.navigationState.valid) {
       return false;
     }
-    this.frameRateCalculator.addFrame();
     const { width, height } = this.renderViewport;
     const showSliceViews = this.viewer.showSliceViews.value;
     for (const [sliceView, unconditional] of this.sliceViews) {
@@ -1078,6 +1077,16 @@ export class PerspectivePanel extends RenderedDataPanel {
       let volumeRenderingBufferHeight = height;
 
       if (this.shouldDownsample) {
+        this.frameRateCalculator.setFrameDeltas(
+          this.context.getLastFrameTimesInMs(
+            this.frameRateCalculator.numberOfStoredFrameDeltas,
+          ),
+        );
+        console.log(
+          this.context.getLastFrameTimesInMs(
+            this.frameRateCalculator.numberOfStoredFrameDeltas,
+          ),
+        );
         const downsamplingFactor =
           this.frameRateCalculator.calculateDownsamplingRate(
             FrameTimingMethod.MEAN,
@@ -1167,7 +1176,8 @@ export class PerspectivePanel extends RenderedDataPanel {
         WebGL2RenderingContext.ONE_MINUS_SRC_ALPHA,
       );
       renderContext.emitPickID = false;
-      let currentTransparentRenderingState = TransparentRenderingState.Transparent;
+      let currentTransparentRenderingState =
+        TransparentRenderingState.Transparent;
       for (const [renderLayer, attachment] of visibleLayers) {
         if (renderLayer.isTransparent) {
           renderContext.depthBufferTexture =

--- a/src/perspective_view/panel.ts
+++ b/src/perspective_view/panel.ts
@@ -1002,47 +1002,20 @@ export class PerspectivePanel extends RenderedDataPanel {
     if (this.hasTransparent) {
       //Draw transparent objects.
 
-      // Check the sample rate for volume rendering
-      let volumeRenderingDownsampleFactorBasedOnSize = Infinity;
-      for (const [renderLayer] of visibleLayers) {
-        if (renderLayer.isVolumeRendering) {
-          const volumeRenderingRenderLayer =
-            renderLayer as VolumeRenderingRenderLayer;
-          const sampleRate = volumeRenderingRenderLayer.lastUsedSampleRate;
-          const ratio = Math.floor(width / sampleRate);
-          volumeRenderingDownsampleFactorBasedOnSize = Math.max(
-            Math.min(volumeRenderingDownsampleFactorBasedOnSize, ratio),
-            1,
-          );
-        }
-      }
-      if (
-        volumeRenderingDownsampleFactorBasedOnSize > MAX_TRANSPARENT_DOWNSAMPLE_FACTOR
-      ) {
-        volumeRenderingDownsampleFactorBasedOnSize = 1;
-      }
-
-      let volumeRenderingDownsampleFactorBasedOnFramerate = 1;
+      let transparentBufferDownsampleFactorBasedOnFramerate = 1;
       if (this.shouldCheckFrameRate) {
         const frameDelta = this.frameRateCalculator.calculateFrameTimeInMs();
-        volumeRenderingDownsampleFactorBasedOnFramerate = Math.min(
-          Math.max(
-            Math.round(frameDelta / DESIRED_FRAME_TIMING_MS),
-            volumeRenderingDownsampleFactorBasedOnSize,
-          ),
+        transparentBufferDownsampleFactorBasedOnFramerate = Math.min(
+          Math.round(frameDelta / DESIRED_FRAME_TIMING_MS),
           MAX_TRANSPARENT_DOWNSAMPLE_FACTOR,
         );
       }
-      const volumeRenderingDownsampleFactor = Math.max(
-        volumeRenderingDownsampleFactorBasedOnSize,
-        volumeRenderingDownsampleFactorBasedOnFramerate,
-      );
       let volumeRenderingBufferWidth = width;
       let volumeRenderingBufferHeight = height;
-      if (volumeRenderingDownsampleFactor > 1) {
+      if (transparentBufferDownsampleFactorBasedOnFramerate  > 1) {
         const originalRatio = width / height;
         volumeRenderingBufferWidth = Math.round(
-          width / volumeRenderingDownsampleFactor,
+          width / transparentBufferDownsampleFactorBasedOnFramerate ,
         );
         volumeRenderingBufferHeight = Math.round(
           volumeRenderingBufferWidth / originalRatio,

--- a/src/perspective_view/panel.ts
+++ b/src/perspective_view/panel.ts
@@ -301,7 +301,8 @@ export class PerspectivePanel extends RenderedDataPanel {
   get shouldDownsample() {
     return (
       this.viewer.enableAdaptiveDownsampling.value &&
-      this.isCameraInContinuousMotion
+      this.isCameraInContinuousMotion &&
+      this.hasVolumeRendering
     );
   }
   private hasVolumeRendering = false;

--- a/src/perspective_view/panel.ts
+++ b/src/perspective_view/panel.ts
@@ -280,10 +280,15 @@ export class PerspectivePanel extends RenderedDataPanel {
     return this.navigationState.displayDimensionRenderInfo;
   }
 
+  // the frame rate calculator is used to determine if downsampling should be applied
+  // after a camera move
+  // if a high downsample rate is applied, it persists for a few frames
+  // to avoid flickering when the camera is moving
   private frameRateCalculator = new DownsamplingBasedOnFrameRateCalculator(
-    5 /* numberOfStoredFrameDeltas */,
+    1 /* numberOfStoredFrameDeltas */,
     8 /* maxDownsamplingFactor */,
     8 /* desiredFrameTimingMs */,
+    40 /* downsamplingPersistenceDurationInFrames */,
   );
   private redrawAfterMoveTimeOutId = -1;
   private hasTransparent = false;

--- a/src/perspective_view/panel.ts
+++ b/src/perspective_view/panel.ts
@@ -1037,9 +1037,7 @@ export class PerspectivePanel extends RenderedDataPanel {
 
       if (this.viewer.adaptiveDownsampling.value && this.shouldCheckFrameRate) {
         const downsamplingFactor =
-          this.frameRateCalculator.calculateDownsamplingRateBasedOnFrameDeltas(
-            false,
-          );
+          this.frameRateCalculator.calculateDownsamplingRateBasedOnFrameDeltas();
         if (downsamplingFactor > 1) {
           const originalRatio = width / height;
           volumeRenderingBufferWidth = Math.round(width / downsamplingFactor);

--- a/src/perspective_view/panel.ts
+++ b/src/perspective_view/panel.ts
@@ -325,12 +325,7 @@ export class PerspectivePanel extends RenderedDataPanel {
     OffscreenCopyHelper.get(this.gl, defineTransparencyCopyShader, 2),
   );
   protected maxProjectionColorCopyHelper = this.registerDisposer(
-    OffscreenCopyHelper.get(
-      this.gl,
-      defineMaxProjectionColorCopyShader,
-      1,
-      true,
-    ),
+    OffscreenCopyHelper.get(this.gl, defineMaxProjectionColorCopyShader, 1),
   );
   protected offscreenDepthCopyHelper = this.registerDisposer(
     OffscreenCopyHelper.get(this.gl, defineDepthCopyShader, 1),

--- a/src/perspective_view/panel.ts
+++ b/src/perspective_view/panel.ts
@@ -1002,7 +1002,7 @@ export class PerspectivePanel extends RenderedDataPanel {
 
       // Check the sample rate for volume rendering
       let volumeRenderingDownsampleFactorBasedOnSize = 1000;
-      for (const [renderLayer, ] of visibleLayers) {
+      for (const [renderLayer] of visibleLayers) {
         if (renderLayer.isVolumeRendering) {
           const volumeRenderingRenderLayer =
             renderLayer as VolumeRenderingRenderLayer;
@@ -1017,7 +1017,7 @@ export class PerspectivePanel extends RenderedDataPanel {
       if (volumeRenderingDownsampleFactorBasedOnSize === 1000) {
         volumeRenderingDownsampleFactorBasedOnSize = 1;
       }
-      
+
       let volumeRenderingDownsampleFactorBasedOnFramerate = 1;
       if (this.shouldCheckFrameRate) {
         const frameDelta = this.frameRateCounter.calculateFrameTimeInMs();

--- a/src/perspective_view/panel.ts
+++ b/src/perspective_view/panel.ts
@@ -263,7 +263,7 @@ export class PerspectivePanel extends RenderedDataPanel {
     return this.navigationState.displayDimensionRenderInfo;
   }
 
-  private frameRateCalculator = new FrameRateCalculator(10);
+  private frameRateCalculator = new FrameRateCalculator(5);
   private redrawAfterMoveTimeOutId = -1;
   private maxDownsamplingFactorThisCameraMove = 1;
   private hasTransparent = false;

--- a/src/perspective_view/panel.ts
+++ b/src/perspective_view/panel.ts
@@ -288,7 +288,7 @@ export class PerspectivePanel extends RenderedDataPanel {
   // if a high downsample rate is applied, it persists for a few frames
   // to avoid flickering when the camera is moving
   private frameRateCalculator = new DownsamplingBasedOnFrameRateCalculator(
-    3 /* numberOfStoredFrameDeltas */,
+    10 /* numberOfStoredFrameDeltas */,
     8 /* maxDownsamplingFactor */,
     16 /* desiredFrameTimingMs */,
     60 /* downsamplingPersistenceDurationInFrames */,
@@ -443,6 +443,9 @@ export class PerspectivePanel extends RenderedDataPanel {
       }),
     );
     this.projectionParameters.changed.add(() => this.context.scheduleRedraw());
+    this.viewer.adaptiveDownsampling.changed.add(() => {
+      this.frameRateCalculator.resetLastFrameTime();
+    });
 
     const sharedObject = (this.sharedObject = this.registerDisposer(
       new PerspectiveViewState(this),

--- a/src/rendered_data_panel.ts
+++ b/src/rendered_data_panel.ts
@@ -618,9 +618,9 @@ export abstract class RenderedDataPanel extends RenderedPanel {
     registerActionListener(element, "move-to-mouse-position", () => {
       const { mouseState } = this.viewer;
       if (mouseState.updateUnconditionally()) {
-        this.isMovingToMousePositionOnPick  = true;
+        this.isMovingToMousePositionOnPick = true;
         this.navigationState.position.value = mouseState.position;
-        this.isMovingToMousePositionOnPick  = false;
+        this.isMovingToMousePositionOnPick = false;
       }
     });
 

--- a/src/ui/viewer_settings.ts
+++ b/src/ui/viewer_settings.ts
@@ -125,6 +125,7 @@ export class ViewerSettingsPanel extends SidePanel {
     );
     addCheckbox("Wire frame rendering", viewer.wireFrame);
     addCheckbox("Enable prefetching", viewer.chunkQueueManager.enablePrefetch);
+    addCheckbox("Enable adaptive downsampling", viewer.adaptiveDownsampling);
 
     const addColor = (label: string, value: WatchableValueInterface<vec3>) => {
       const labelElement = document.createElement("label");

--- a/src/ui/viewer_settings.ts
+++ b/src/ui/viewer_settings.ts
@@ -64,7 +64,7 @@ export class ViewerSettingsPanel extends SidePanel {
     viewer: Viewer,
   ) {
     super(sidePanelManager, state.location);
-    this.addTitleBar({ title: "Settings (MC b1)" });
+    this.addTitleBar({ title: "Settings" });
 
     const body = document.createElement("div");
     body.classList.add("neuroglancer-settings-body");

--- a/src/ui/viewer_settings.ts
+++ b/src/ui/viewer_settings.ts
@@ -125,7 +125,7 @@ export class ViewerSettingsPanel extends SidePanel {
     );
     addCheckbox("Wire frame rendering", viewer.wireFrame);
     addCheckbox("Enable prefetching", viewer.chunkQueueManager.enablePrefetch);
-    addCheckbox("Enable adaptive downsampling", viewer.adaptiveDownsampling);
+    addCheckbox("Enable adaptive downsampling", viewer.enableAdaptiveDownsampling);
 
     const addColor = (label: string, value: WatchableValueInterface<vec3>) => {
       const labelElement = document.createElement("label");

--- a/src/util/framerate.spec.ts
+++ b/src/util/framerate.spec.ts
@@ -39,8 +39,14 @@ describe("FrameRateCounter", () => {
     }
     expect(frameRateCounter.calculateFrameTimeInMs()).toEqual(10);
   });
-  it("removes frames if no frames have been requested", () => {
-    // TODO (SKM) implement this test
-    expect(new FrameRateCalculator().calculateFrameTimeInMs()).toEqual(0);
+  it("removes frames after reset", () => {
+    const frameRateCounter = new FrameRateCalculator(10);
+    expect(frameRateCounter.calculateFrameTimeInMs()).toEqual(0);
+    for (let i = 0; i < 10; i++) {
+      frameRateCounter.addFrame(i * 100);
+    }
+    expect(frameRateCounter.calculateFrameTimeInMs()).toEqual(100);
+    frameRateCounter.reset();
+    expect(frameRateCounter.calculateFrameTimeInMs()).toEqual(0);
   });
 });

--- a/src/util/framerate.spec.ts
+++ b/src/util/framerate.spec.ts
@@ -15,11 +15,11 @@
  */
 
 import { describe, it, expect } from "vitest";
-import { FrameRateCounter } from "#src/util/framerate.js";
+import { FrameRateCalculator } from "#src/util/framerate.js";
 
 describe("FrameRateCounter", () => {
   it("calculates valid fps for evenly spaced frames", () => {
-    const frameRateCounter = new FrameRateCounter(10);
+    const frameRateCounter = new FrameRateCalculator(10);
     for (let i = 0; i < 10; i++) {
       frameRateCounter.addFrame(i * 100);
       if (i === 0) {
@@ -30,7 +30,7 @@ describe("FrameRateCounter", () => {
     }
   });
   it("calculates valid fps for many frames", () => {
-    const frameRateCounter = new FrameRateCounter(10);
+    const frameRateCounter = new FrameRateCalculator(10);
     for (let i = 0; i < 10; i++) {
       frameRateCounter.addFrame(i * 100);
     }
@@ -41,6 +41,6 @@ describe("FrameRateCounter", () => {
   });
   it("removes frames if no frames have been requested", () => {
     // TODO (SKM) implement this test
-    expect(new FrameRateCounter().calculateFrameTimeInMs()).toEqual(0);
+    expect(new FrameRateCalculator().calculateFrameTimeInMs()).toEqual(0);
   });
 });

--- a/src/util/framerate.spec.ts
+++ b/src/util/framerate.spec.ts
@@ -30,24 +30,28 @@ describe("FrameRateCounter", () => {
     }
   });
   it("calculates valid fps for many frames", () => {
-    const frameRateCounter = new FrameRateCalculator(10);
+    const frameRateCounter = new FrameRateCalculator(9);
     for (let i = 0; i < 10; i++) {
       frameRateCounter.addFrame(i * 100);
     }
+    frameRateCounter.resetLastFrameTime();
     for (let i = 0; i < 10; i++) {
       frameRateCounter.addFrame(i * 10);
     }
     expect(frameRateCounter.calculateFrameTimeInMs()).toEqual(10);
     expect(frameRateCounter.calculateFrameTimeInMs(false)).toEqual(10);
   });
-  it("removes frames after reset", () => {
+  it("removes last frame after reset", () => {
     const frameRateCounter = new FrameRateCalculator(10);
     expect(frameRateCounter.calculateFrameTimeInMs()).toEqual(0);
     for (let i = 0; i < 10; i++) {
       frameRateCounter.addFrame(i * 100);
     }
     expect(frameRateCounter.calculateFrameTimeInMs()).toEqual(100);
-    frameRateCounter.reset();
-    expect(frameRateCounter.calculateFrameTimeInMs()).toEqual(0);
+    frameRateCounter.resetLastFrameTime();
+    for (let i = 0; i < 5; i++) {
+      frameRateCounter.addFrame(i * 200);
+    }
+    expect(frameRateCounter.calculateFrameTimeInMs(false)).toEqual(140);
   });
 });

--- a/src/util/framerate.spec.ts
+++ b/src/util/framerate.spec.ts
@@ -64,4 +64,40 @@ describe("FrameRateCounter", () => {
       frameRateCounter.calculateFrameTimeInMs(FrameTimingMethod.MAX),
     ).toEqual(200);
   });
+  it("calculates a valid downsampling rate", () => {
+    const frameRateCounter = new DownsamplingBasedOnFrameRateCalculator(
+      10,
+      8,
+      100,
+      15,
+    );
+    for (let i = 0; i < 10; i++) {
+      frameRateCounter.addFrame(i * 80);
+    }
+    // 80ms / 100ms < 1, so no downsampling
+    expect(frameRateCounter.calculateDownsamplingRate()).toEqual(1);
+    for (let i = 0; i < 10; i++) {
+      frameRateCounter.addFrame(i * 400);
+    }
+    // 400ms / 100ms = 4, so downsampling by 4
+    expect(frameRateCounter.calculateDownsamplingRate()).toEqual(4);
+    // Better fps now, but the rate persists for a while
+    for (let i = 0; i < 10; i++) {
+      frameRateCounter.addFrame(i * 50);
+      frameRateCounter.calculateDownsamplingRate();
+    }
+    expect(frameRateCounter.calculateDownsamplingRate()).toEqual(4);
+    // The downsampling rate will eventually drop
+    for (let i = 0; i < 11; i++) {
+      frameRateCounter.addFrame(i * 50);
+      frameRateCounter.calculateDownsamplingRate();
+    }
+    expect(frameRateCounter.calculateDownsamplingRate()).toEqual(1);
+    // If the frame rate is very bad, still caps at 8
+    frameRateCounter.resetLastFrameTime();
+    for (let i = 0; i < 2; i++) {
+      frameRateCounter.addFrame(i * 10000);
+    }
+    expect(frameRateCounter.calculateDownsamplingRate()).toEqual(8);
+  });
 });

--- a/src/util/framerate.spec.ts
+++ b/src/util/framerate.spec.ts
@@ -15,11 +15,11 @@
  */
 
 import { describe, it, expect } from "vitest";
-import { FrameRateCalculator } from "#src/util/framerate.js";
+import { DownsamplingBasedOnFrameRateCalculator } from "#src/util/framerate.js";
 
 describe("FrameRateCounter", () => {
   it("calculates valid fps for evenly spaced frames", () => {
-    const frameRateCounter = new FrameRateCalculator(10);
+    const frameRateCounter = new DownsamplingBasedOnFrameRateCalculator(10);
     for (let i = 0; i < 10; i++) {
       frameRateCounter.addFrame(i * 100);
       if (i === 0) {
@@ -30,7 +30,7 @@ describe("FrameRateCounter", () => {
     }
   });
   it("calculates valid fps for many frames", () => {
-    const frameRateCounter = new FrameRateCalculator(9);
+    const frameRateCounter = new DownsamplingBasedOnFrameRateCalculator(9);
     for (let i = 0; i < 10; i++) {
       frameRateCounter.addFrame(i * 100);
     }
@@ -42,7 +42,7 @@ describe("FrameRateCounter", () => {
     expect(frameRateCounter.calculateFrameTimeInMs(false)).toEqual(10);
   });
   it("removes last frame after reset", () => {
-    const frameRateCounter = new FrameRateCalculator(10);
+    const frameRateCounter = new DownsamplingBasedOnFrameRateCalculator(10);
     expect(frameRateCounter.calculateFrameTimeInMs()).toEqual(0);
     for (let i = 0; i < 10; i++) {
       frameRateCounter.addFrame(i * 100);

--- a/src/util/framerate.spec.ts
+++ b/src/util/framerate.spec.ts
@@ -15,7 +15,10 @@
  */
 
 import { describe, it, expect } from "vitest";
-import { DownsamplingBasedOnFrameRateCalculator } from "#src/util/framerate.js";
+import {
+  DownsamplingBasedOnFrameRateCalculator,
+  FrameTimingMethod,
+} from "#src/util/framerate.js";
 
 describe("FrameRateCounter", () => {
   it("calculates valid fps for evenly spaced frames", () => {
@@ -39,7 +42,9 @@ describe("FrameRateCounter", () => {
       frameRateCounter.addFrame(i * 10);
     }
     expect(frameRateCounter.calculateFrameTimeInMs()).toEqual(10);
-    expect(frameRateCounter.calculateFrameTimeInMs(false)).toEqual(10);
+    expect(
+      frameRateCounter.calculateFrameTimeInMs(FrameTimingMethod.MEDIAN),
+    ).toEqual(10);
   });
   it("removes last frame after reset", () => {
     const frameRateCounter = new DownsamplingBasedOnFrameRateCalculator(10);
@@ -52,6 +57,11 @@ describe("FrameRateCounter", () => {
     for (let i = 0; i < 5; i++) {
       frameRateCounter.addFrame(i * 200);
     }
-    expect(frameRateCounter.calculateFrameTimeInMs(false)).toEqual(140);
+    expect(
+      frameRateCounter.calculateFrameTimeInMs(FrameTimingMethod.MEAN),
+    ).toEqual(140);
+    expect(
+      frameRateCounter.calculateFrameTimeInMs(FrameTimingMethod.MAX),
+    ).toEqual(200);
   });
 });

--- a/src/util/framerate.spec.ts
+++ b/src/util/framerate.spec.ts
@@ -38,7 +38,7 @@ describe("FrameRateCounter", () => {
       frameRateCounter.addFrame(i * 10);
     }
     expect(frameRateCounter.calculateFrameTimeInMs()).toEqual(10);
-    expect(frameRateCounter.calculateFrameTimeInMs(true)).toEqual(10);
+    expect(frameRateCounter.calculateFrameTimeInMs(false)).toEqual(10);
   });
   it("removes frames after reset", () => {
     const frameRateCounter = new FrameRateCalculator(10);

--- a/src/util/framerate.spec.ts
+++ b/src/util/framerate.spec.ts
@@ -38,6 +38,7 @@ describe("FrameRateCounter", () => {
       frameRateCounter.addFrame(i * 10);
     }
     expect(frameRateCounter.calculateFrameTimeInMs()).toEqual(10);
+    expect(frameRateCounter.calculateFrameTimeInMs(true)).toEqual(10);
   });
   it("removes frames after reset", () => {
     const frameRateCounter = new FrameRateCalculator(10);

--- a/src/util/framerate.ts
+++ b/src/util/framerate.ts
@@ -16,26 +16,39 @@
 
 export class FrameRateCalculator {
   private frameTimeStamps: number[] = [];
+  private frameDeltas: number[] = [];
   constructor(private numberOfStoredFrameTimes: number = 10) {}
   reset() {
     this.frameTimeStamps = [];
+    this.frameDeltas = [];
   }
 
   addFrame(timestamp: number = Date.now()) {
     if (this.frameTimeStamps.length >= this.numberOfStoredFrameTimes) {
       this.frameTimeStamps.shift();
+      this.frameDeltas.shift();
     }
     this.frameTimeStamps.push(timestamp);
+    if (this.frameTimeStamps.length > 1) {
+      this.calculateFrameDelta();
+    }
+  }
+
+  private calculateFrameDelta() {
+    this.frameDeltas.push(
+      this.frameTimeStamps[this.frameTimeStamps.length - 1] -
+        this.frameTimeStamps[this.frameTimeStamps.length - 2],
+    );
   }
 
   calculateFrameTimeInMs() {
-    if (this.frameTimeStamps.length <= 1) {
+    if (this.frameDeltas.length < 1) {
       return 0;
     }
-    return (
-      (this.frameTimeStamps[this.frameTimeStamps.length - 1] -
-        this.frameTimeStamps[0]) /
-      (this.frameTimeStamps.length - 1)
-    );
+    const sortedFrameDeltas = this.frameDeltas.slice().sort((a, b) => a - b);
+    const midpoint = Math.floor(sortedFrameDeltas.length / 2);
+    return sortedFrameDeltas.length % 2 === 1
+      ? sortedFrameDeltas[midpoint]
+      : (sortedFrameDeltas[midpoint - 1] + sortedFrameDeltas[midpoint]) / 2;
   }
 }

--- a/src/util/framerate.ts
+++ b/src/util/framerate.ts
@@ -45,6 +45,7 @@ export class DownsamplingBasedOnFrameRateCalculator {
   }
   resetLastFrameTime() {
     this.lastFrameTime = null;
+    this.downsamplingRates = [];
   }
 
   addFrame(timestamp: number = Date.now()) {

--- a/src/util/framerate.ts
+++ b/src/util/framerate.ts
@@ -96,8 +96,14 @@ export class DownsamplingBasedOnFrameRateCalculator {
       Math.pow(2, Math.round(Math.log2(downsampleFactorBasedOnFramerate))),
       this.maxDownsamplingFactor,
     );
-    const downsampleRateFromHistory =
-      this.maxDownsamplingFactorSinceReset > 1 ? 2 : 1;
+    this.maxDownsamplingFactorSinceReset = Math.max(
+      this.maxDownsamplingFactorSinceReset,
+      downsampleFactorBasedOnFramerate,
+    );
+    const downsampleRateFromHistory = Math.min(
+      this.maxDownsamplingFactorSinceReset,
+      4,
+    );
     return Math.max(
       downsampleFactorBasedOnFramerate,
       downsampleRateFromHistory,

--- a/src/util/framerate.ts
+++ b/src/util/framerate.ts
@@ -41,10 +41,20 @@ export class FrameRateCalculator {
     );
   }
 
-  calculateFrameTimeInMs() {
+  calculateFrameTimeInMs(useMedian: boolean = true): number {
     if (this.frameDeltas.length < 1) {
       return 0;
     }
+    if (useMedian) {
+      return this.calculateMedianFrameTime();
+    }
+    return (
+      this.frameTimeStamps[this.frameTimeStamps.length - 1] -
+      this.frameTimeStamps[0] / (this.frameTimeStamps.length - 1)
+    );
+  }
+
+  private calculateMedianFrameTime(): number {
     const sortedFrameDeltas = this.frameDeltas.slice().sort((a, b) => a - b);
     const midpoint = Math.floor(sortedFrameDeltas.length / 2);
     return sortedFrameDeltas.length % 2 === 1

--- a/src/util/framerate.ts
+++ b/src/util/framerate.ts
@@ -72,7 +72,8 @@ export class FramerateMonitor {
   ) {
     const { timeElapsedQueries } = this;
     const results: number[] = [];
-    timeElapsedQueries.forEach((timeElapsedQuery) => {
+    for (let i = timeElapsedQueries.length - 1; i >= 0; i--) {
+      const timeElapsedQuery = timeElapsedQueries[i];
       if (timeElapsedQuery !== null) {
         const available = gl.getQueryParameter(
           timeElapsedQuery,
@@ -84,8 +85,11 @@ export class FramerateMonitor {
           results.push(result);
         }
       }
-    });
-    return results.slice(-numberOfFrames);
+      if (results.length >= numberOfFrames) {
+        break;
+      }
+    }
+    return results;
   }
 }
 

--- a/src/util/framerate.ts
+++ b/src/util/framerate.ts
@@ -187,6 +187,7 @@ export class DownsamplingBasedOnFrameRateCalculator {
       Math.pow(2, Math.round(Math.log2(downsampleFactorBasedOnFramerate))),
       this.maxDownsamplingFactor,
     );
+    // Store the downsampling rate.
     this.downsamplingRates.push(downsampleFactorBasedOnFramerate);
     if (
       this.downsamplingRates.length >
@@ -194,6 +195,7 @@ export class DownsamplingBasedOnFrameRateCalculator {
     ) {
       this.downsamplingRates.shift();
     }
+    // Return the maximum downsampling rate over the last few frames.
     return Math.max(...this.downsamplingRates);
   }
 
@@ -202,6 +204,6 @@ export class DownsamplingBasedOnFrameRateCalculator {
   }
 
   setFrameDeltas(frameDeltas: number[]) {
-    this.frameDeltas = frameDeltas;
+    this.frameDeltas = frameDeltas.slice(-this.numberOfStoredFrameDeltas);
   }
 }

--- a/src/util/framerate.ts
+++ b/src/util/framerate.ts
@@ -43,18 +43,14 @@ export class DownsamplingBasedOnFrameRateCalculator {
   }
 
   private validateConstructorArguments() {
-    if (this.numberOfStoredFrameDeltas < 1) {
-      throw new Error(
-        `Number of stored frame deltas must be at least 1, ` +
-          `but got ${this.numberOfStoredFrameDeltas}.`,
-      );
-    }
-    if (this.maxDownsamplingFactor < 2) {
-      throw new Error(
-        `Max downsampling factor must be at least 2, ` +
-          `but got ${this.maxDownsamplingFactor}.`,
-      );
-    }
+    this.numberOfStoredFrameDeltas = Math.max(
+      1,
+      Math.round(this.numberOfStoredFrameDeltas),
+    );
+    this.maxDownsamplingFactor = Math.max(
+      2,
+      Math.round(this.maxDownsamplingFactor),
+    );
   }
 
   private storeFrameDelta(frameDelta: number) {

--- a/src/util/framerate.ts
+++ b/src/util/framerate.ts
@@ -100,13 +100,9 @@ export class DownsamplingBasedOnFrameRateCalculator {
       this.maxDownsamplingFactorSinceReset,
       downsampleFactorBasedOnFramerate,
     );
-    const downsampleRateFromHistory = Math.min(
-      this.maxDownsamplingFactorSinceReset,
-      4,
-    );
     return Math.max(
       downsampleFactorBasedOnFramerate,
-      downsampleRateFromHistory,
+      this.maxDownsamplingFactorSinceReset,
     );
   }
 

--- a/src/util/framerate.ts
+++ b/src/util/framerate.ts
@@ -16,22 +16,7 @@
 
 export class FrameRateCalculator {
   private frameTimeStamps: number[] = [];
-  constructor(
-    private numberOfStoredFrameTimes: number = 10,
-    private timeoutInMS: number = 1000,
-  ) {}
-
-  start(timestamp: number = Date.now()) {
-    if (this.frameTimeStamps.length == 0) {
-      this.frameTimeStamps.push(timestamp);
-    } else if (
-      timestamp - this.frameTimeStamps[this.frameTimeStamps.length - 1] >=
-      this.timeoutInMS
-    ) {
-      this.reset();
-      this.frameTimeStamps.push(timestamp);
-    }
-  }
+  constructor(private numberOfStoredFrameTimes: number = 10) {}
   reset() {
     this.frameTimeStamps = [];
   }

--- a/src/util/framerate.ts
+++ b/src/util/framerate.ts
@@ -27,8 +27,6 @@ export class DownsamplingBasedOnFrameRateCalculator {
   private frameCount = 0;
 
   /**
-   * Creates an instance of DownsamplingBasedOnFrameRateCalculator.
-   *
    * @param numberOfStoredFrameDeltas The number of frame deltas to store. Oldest frame deltas are removed. Must be at least 1.
    * @param maxDownsamplingFactor The maximum factor for downsampling. Must be at least 2.
    * @param desiredFrameTimingMs The desired frame timing in milliseconds. The downsampling rate is based on a comparison of the actual frame timing to this value.

--- a/src/util/framerate.ts
+++ b/src/util/framerate.ts
@@ -49,8 +49,9 @@ export class FrameRateCalculator {
       return this.calculateMedianFrameTime();
     }
     return (
-      this.frameTimeStamps[this.frameTimeStamps.length - 1] -
-      this.frameTimeStamps[0] / (this.frameTimeStamps.length - 1)
+      (this.frameTimeStamps[this.frameTimeStamps.length - 1] -
+        this.frameTimeStamps[0]) /
+      (this.frameTimeStamps.length - 1)
     );
   }
 

--- a/src/util/framerate.ts
+++ b/src/util/framerate.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-export class FrameRateCounter {
+export class FrameRateCalculator {
   private frameTimeStamps: number[] = [];
   constructor(
     private numberOfStoredFrameTimes: number = 10,

--- a/src/viewer.ts
+++ b/src/viewer.ts
@@ -295,7 +295,7 @@ class TrackableViewerState extends CompoundTrackable {
     this.add("layers", viewer.layerSpecification);
     this.add("showAxisLines", viewer.showAxisLines);
     this.add("wireFrame", viewer.wireFrame);
-    this.add("adaptiveDownsampling", viewer.adaptiveDownsampling);
+    this.add("enableAdaptiveDownsampling", viewer.enableAdaptiveDownsampling);
     this.add("showScaleBar", viewer.showScaleBar);
     this.add("showDefaultAnnotations", viewer.showDefaultAnnotations);
 
@@ -459,7 +459,7 @@ export class Viewer extends RefCounted implements ViewerState {
   );
   showAxisLines = new TrackableBoolean(true, true);
   wireFrame = new TrackableBoolean(false, false);
-  adaptiveDownsampling = new TrackableBoolean(true, true);
+  enableAdaptiveDownsampling = new TrackableBoolean(true, true);
   showScaleBar = new TrackableBoolean(true, true);
   showPerspectiveSliceViews = new TrackableBoolean(true, true);
   visibleLayerRoles = allRenderLayerRoles();

--- a/src/viewer.ts
+++ b/src/viewer.ts
@@ -295,6 +295,7 @@ class TrackableViewerState extends CompoundTrackable {
     this.add("layers", viewer.layerSpecification);
     this.add("showAxisLines", viewer.showAxisLines);
     this.add("wireFrame", viewer.wireFrame);
+    this.add("adaptiveDownsampling", viewer.adaptiveDownsampling);
     this.add("showScaleBar", viewer.showScaleBar);
     this.add("showDefaultAnnotations", viewer.showDefaultAnnotations);
 
@@ -458,6 +459,7 @@ export class Viewer extends RefCounted implements ViewerState {
   );
   showAxisLines = new TrackableBoolean(true, true);
   wireFrame = new TrackableBoolean(false, false);
+  adaptiveDownsampling = new TrackableBoolean(true, true);
   showScaleBar = new TrackableBoolean(true, true);
   showPerspectiveSliceViews = new TrackableBoolean(true, true);
   visibleLayerRoles = allRenderLayerRoles();

--- a/src/volume_rendering/volume_render_layer.ts
+++ b/src/volume_rendering/volume_render_layer.ts
@@ -190,8 +190,6 @@ export class VolumeRenderingRenderLayer extends PerspectiveViewRenderLayer {
     return true;
   }
 
-  public lastUsedSampleRate = 0;
-
   constructor(options: VolumeRenderingRenderLayerOptions) {
     super();
     this.gain = options.gain;
@@ -774,12 +772,6 @@ void main() {
                   ? 1
                   : chunkDataSize[chunkDim];
             }
-            this.lastUsedSampleRate = Math.max(
-              this.lastUsedSampleRate,
-              chunkDataDisplaySize[0],
-              chunkDataDisplaySize[1],
-              chunkDataDisplaySize[2],
-            );
             gl.uniform3fv(
               shader.uniform("uChunkDataSize"),
               chunkDataDisplaySize,
@@ -813,7 +805,6 @@ void main() {
         }
       },
     );
-    this.lastUsedSampleRate = this.lastUsedSampleRate * presentCount;
     gl.disable(WebGL2RenderingContext.CULL_FACE);
     endShader();
     this.vertexIdHelper.disable();

--- a/src/volume_rendering/volume_render_layer.ts
+++ b/src/volume_rendering/volume_render_layer.ts
@@ -728,7 +728,6 @@ void main() {
         const optimalSampleRate = optimalSamples;
         const actualSampleRate = this.depthSamplesTarget.value;
         const brightnessFactor = optimalSampleRate / actualSampleRate;
-        this.lastUsedSampleRate = Math.max(actualSampleRate, optimalSampleRate);
         gl.uniform1f(shader.uniform("uBrightnessFactor"), brightnessFactor);
         const nearLimitFraction = (adjustedNear - near) / (far - near);
         const farLimitFraction = (adjustedFar - near) / (far - near);

--- a/src/webgl/offscreen.ts
+++ b/src/webgl/offscreen.ts
@@ -349,7 +349,6 @@ export class OffscreenCopyHelper extends RefCounted {
   constructor(
     public gl: GL,
     public shader: ShaderProgram,
-    public linearInterpolation = false,
   ) {
     super();
     this.registerDisposer(shader);
@@ -365,10 +364,6 @@ export class OffscreenCopyHelper extends RefCounted {
     for (let i = 0; i < numTextures; ++i) {
       gl.activeTexture(gl.TEXTURE0 + i);
       gl.bindTexture(gl.TEXTURE_2D, textures[i]);
-      if (this.linearInterpolation) {
-        gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.LINEAR);
-        gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.LINEAR);
-      }
     }
 
     gl.uniformMatrix4fv(
@@ -401,7 +396,6 @@ export class OffscreenCopyHelper extends RefCounted {
     gl: GL,
     shaderModule: ShaderModule = defineCopyFragmentShader,
     numTextures = 1,
-    linearInterpolation = false,
   ) {
     return gl.memoize.get(
       `OffscreenCopyHelper:${numTextures}:${getObjectId(shaderModule)}`,
@@ -409,7 +403,6 @@ export class OffscreenCopyHelper extends RefCounted {
         new OffscreenCopyHelper(
           gl,
           elementWiseTextureShader(gl, shaderModule, numTextures),
-          linearInterpolation,
         ),
     );
   }

--- a/src/webgl/offscreen.ts
+++ b/src/webgl/offscreen.ts
@@ -409,7 +409,7 @@ export class OffscreenCopyHelper extends RefCounted {
         new OffscreenCopyHelper(
           gl,
           elementWiseTextureShader(gl, shaderModule, numTextures),
-          linearInterpolation
+          linearInterpolation,
         ),
     );
   }


### PR DESCRIPTION
The overall idea is that a setting (currently on by default) would allow a global downsampling in XY resolution for 3D panels of transparent layers during camera movement if the framerate drops below a certain threshold.

All of this is open to change, but currently:

Target FPS is 60
The mean framerate over a running 6 frames after a camera move is initiated is calculated
If this median framerate drops below 60, a downsampling rate of 2, 4, or 8 is chosen based on how far from 60 the framerate is.
If a downsample is detected, then during this camera movement, the downsampling rate will never go back above the highest downsample rate detected for about the last second
When the camera stops moving, a fresh full resolution drawing is requested after 300ms

To update:
1. Only DS for VR, new buffer
2. Make timing easy to change so that GL query can slot in as needs be
3. More global setting for camera in constant movement. Discrete movements won't trigger DS