### PR TITLE
fix: update transfer function points in JSON in all cases

### DIFF
--- a/src/webgl/shader_ui_controls.ts
+++ b/src/webgl/shader_ui_controls.ts
@@ -1155,7 +1155,7 @@ export class TrackableTransferFunctionParameters extends TrackableValue<Transfer
     // to the control points in the trackable value.
     const defaultValueCopy = copyTransferFunctionParameters(defaultValue);
     super(defaultValueCopy, (obj) =>
-      parseTransferFunctionParameters(obj, dataType, defaultValue),
+      parseTransferFunctionParameters(obj, dataType, defaultValueCopy),
     );
   }
 


### PR DESCRIPTION
Fix accidental passing of actual default value into the trackable transfer function validator function. Now correctly passes the copy of the default value to the validator.

Impact: previously if the JSON contained information about the default color, or the window, but not about the transfer function points, the points wouldn't get tracked in the JSON state correctly anymore in some cases.