### PR TITLE
fix(ui): increase z-index for layer data source dropdowns, which were appearing below pinned panels

### DIFF
--- a/src/ui/layer_data_sources_tab.css
+++ b/src/ui/layer_data_sources_tab.css
@@ -25,6 +25,7 @@
   flex-direction: column;
   flex: 1;
   height: 0px;
+  z-index: 1;
 }
 
 .neuroglancer-layer-data-source-url-input input.autocomplete-input {


### PR DESCRIPTION
<img width="309" alt="Screenshot 2024-05-30 at 11 55 46 AM" src="https://github.com/google/neuroglancer/assets/188155/a25b2e54-d071-4ec6-aa87-3bd8cade87e3">

https://neuroglancer-demo.appspot.com/#!%7B%22dimensions%22:%7B%22x%22:%5B6.000000000000001e-9%2C%22m%22%5D%2C%22y%22:%5B6.000000000000001e-9%2C%22m%22%5D%2C%22z%22:%5B3.0000000000000004e-8%2C%22m%22%5D%7D%2C%22position%22:%5B5523.99072265625%2C8538.9384765625%2C1198.0423583984375%5D%2C%22crossSectionScale%22:3.7621853549999242%2C%22projectionOrientation%22:%5B-0.0040475670248270035%2C-0.9566215872764587%2C-0.22688281536102295%2C-0.18271005153656006%5D%2C%22projectionScale%22:4699.372698097029%2C%22layers%22:%5B%7B%22type%22:%22segmentation%22%2C%22source%22:%22precomputed://gs://neuroglancer-public-data/kasthuri2011/ground_truth%22%2C%22tab%22:%22source%22%2C%22panels%22:%5B%7B%22row%22:1%2C%22flex%22:1.6%2C%22tab%22:%22segments%22%2C%22tabs%22:%5B%22segments%22%5D%7D%5D%2C%22selectedAlpha%22:0.63%2C%22notSelectedAlpha%22:0.14%2C%22segments%22:%5B%223208%22%2C%224901%22%2C%2213%22%2C%224965%22%2C%224651%22%2C%222282%22%2C%223189%22%2C%223758%22%2C%2215%22%2C%224027%22%2C%223228%22%2C%22444%22%2C%223207%22%2C%223224%22%2C%223710%22%5D%2C%22name%22:%22ground_truth%22%7D%2C%7B%22type%22:%22new%22%2C%22source%22:%22%22%2C%22tab%22:%22source%22%2C%22name%22:%22new%20layer%22%7D%5D%2C%22selectedLayer%22:%7B%22flex%22:0.4%2C%22visible%22:true%2C%22layer%22:%22new%20layer%22%7D%2C%22layout%22:%22xy%22%2C%22selection%22:%7B%22row%22:2%2C%22visible%22:false%7D%7D