### PR TITLE
Fix: automatic range computation in transfer functions for float32 datasets no longer fails for one point

### DIFF
--- a/src/widget/transfer_function.ts
+++ b/src/widget/transfer_function.ts
@@ -262,9 +262,16 @@ export class SortedControlPoints {
       if (this.controlPoints.length == 0) {
         this.range = defaultDataTypeRange[this.dataType];
       } else if (this.controlPoints.length === 1) {
+        let rangeEnd = defaultDataTypeRange[this.dataType][1];
+        if (
+          this.dataType === DataType.FLOAT32 &&
+          rangeEnd <= this.controlPoints[0].inputValue
+        ) {
+          rangeEnd = (this.controlPoints[0].inputValue as number) + 1;
+        }
         this.range = [
           this.controlPoints[0].inputValue,
-          defaultDataTypeRange[this.dataType][1],
+          rangeEnd,
         ] as DataTypeInterval;
       } else {
         this.range = [


### PR DESCRIPTION
Previously, the auto range could get computed as `[point_x_value, 1]` where `point_x_value > 1` with only one point, which would cause incorrect transfer function calculations. This could only happen for float32 datasets. This is to correct for this, by setting the range to `[point_x_value, point_x_value + 1]` for single point transfer functions and float32 data.