### PR TITLE
Feature - continous camera movement tracking

### DIFF
--- a/src/perspective_view/panel.ts
+++ b/src/perspective_view/panel.ts
@@ -914,7 +914,7 @@ export class PerspectivePanel extends RenderedDataPanel {
       bindFramebuffer,
       frameNumber: this.context.frameNumber,
       sliceViewsPresent: this.sliceViews.size > 0,
-      continousCameraMovementInProgress:
+      isContinuousCameraMotionInProgress:
         this.context.isContinuousCameraMotionInProgress,
     };
 

--- a/src/perspective_view/panel.ts
+++ b/src/perspective_view/panel.ts
@@ -447,6 +447,7 @@ export class PerspectivePanel extends RenderedDataPanel {
       element,
       "rotate-in-plane-via-touchrotate",
       (e: ActionEvent<TouchRotateInfo>) => {
+        this.context.flagContinuousCameraMotion();
         const { detail } = e;
         this.navigationState.pose.rotateRelative(
           kAxes[2],
@@ -459,6 +460,7 @@ export class PerspectivePanel extends RenderedDataPanel {
       element,
       "rotate-out-of-plane-via-touchtranslate",
       (e: ActionEvent<TouchTranslateInfo>) => {
+        this.context.flagContinuousCameraMotion();
         const { detail } = e;
         this.navigationState.pose.rotateRelative(
           kAxes[1],

--- a/src/perspective_view/render_layer.ts
+++ b/src/perspective_view/render_layer.ts
@@ -64,7 +64,7 @@ export interface PerspectiveViewRenderContext
   /**
    * Specifies if the camera is moving
    */
-  cameraMovementInProgress: boolean;
+  continousCameraMovementInProgress: boolean;
 
   /**
    * Specifices how to bind the max projection buffer

--- a/src/perspective_view/render_layer.ts
+++ b/src/perspective_view/render_layer.ts
@@ -64,7 +64,7 @@ export interface PerspectiveViewRenderContext
   /**
    * Specifies if the camera is moving
    */
-  continousCameraMovementInProgress: boolean;
+  isContinuousCameraMotionInProgress: boolean;
 
   /**
    * Specifices how to bind the max projection buffer

--- a/src/rendered_data_panel.ts
+++ b/src/rendered_data_panel.ts
@@ -506,18 +506,22 @@ export abstract class RenderedDataPanel extends RenderedPanel {
     });
 
     registerActionListener(element, "zoom-in", () => {
+      this.context.flagContinuousCameraMotion();
       this.navigationState.zoomBy(0.5);
     });
 
     registerActionListener(element, "zoom-out", () => {
+      this.context.flagContinuousCameraMotion();
       this.navigationState.zoomBy(2.0);
     });
 
     registerActionListener(element, "depth-range-decrease", () => {
+      this.context.flagContinuousCameraMotion();
       this.navigationState.depthRange.value *= 0.5;
     });
 
     registerActionListener(element, "depth-range-increase", () => {
+      this.context.flagContinuousCameraMotion();
       this.navigationState.depthRange.value *= 2;
     });
 
@@ -529,11 +533,13 @@ export abstract class RenderedDataPanel extends RenderedPanel {
           element,
           `rotate-relative-${axisName}${signStr}`,
           () => {
+            this.context.flagContinuousCameraMotion();
             this.navigationState.pose.rotateRelative(kAxes[axis], sign * 0.1);
           },
         );
         const tempOffset = vec3.create();
         registerActionListener(element, `${axisName}${signStr}`, () => {
+          this.context.flagContinuousCameraMotion();
           const { navigationState } = this;
           const offset = tempOffset;
           offset[0] = 0;
@@ -549,6 +555,7 @@ export abstract class RenderedDataPanel extends RenderedPanel {
       element,
       "zoom-via-wheel",
       (event: ActionEvent<WheelEvent>) => {
+        this.context.flagContinuousCameraMotion();
         const e = event.detail;
         this.onMousemove(e, false);
         this.zoomByMouse(getWheelZoomAmount(e));
@@ -559,6 +566,7 @@ export abstract class RenderedDataPanel extends RenderedPanel {
       element,
       "adjust-depth-range-via-wheel",
       (event: ActionEvent<WheelEvent>) => {
+        this.context.flagContinuousCameraMotion();
         const e = event.detail;
         this.navigationState.depthRange.value *= getWheelZoomAmount(e);
       },
@@ -569,6 +577,7 @@ export abstract class RenderedDataPanel extends RenderedPanel {
       "translate-via-mouse-drag",
       (e: ActionEvent<MouseEvent>) => {
         startRelativeMouseDrag(e.detail, (_event, deltaX, deltaY) => {
+          this.context.flagContinuousCameraMotion();
           this.translateByViewportPixels(deltaX, deltaY);
         });
       },
@@ -578,6 +587,7 @@ export abstract class RenderedDataPanel extends RenderedPanel {
       element,
       "translate-in-plane-via-touchtranslate",
       (e: ActionEvent<TouchTranslateInfo>) => {
+        this.context.flagContinuousCameraMotion();
         const { detail } = e;
         this.translateByViewportPixels(detail.deltaX, detail.deltaY);
       },
@@ -587,6 +597,7 @@ export abstract class RenderedDataPanel extends RenderedPanel {
       element,
       "translate-z-via-touchtranslate",
       (e: ActionEvent<TouchTranslateInfo>) => {
+        this.context.flagContinuousCameraMotion();
         const { detail } = e;
         const { navigationState } = this;
         const offset = tempVec3;
@@ -602,6 +613,7 @@ export abstract class RenderedDataPanel extends RenderedPanel {
         element,
         `z+${amount}-via-wheel`,
         (event: ActionEvent<WheelEvent>) => {
+          this.context.flagContinuousCameraMotion();
           const e = event.detail;
           const { navigationState } = this;
           const offset = tempVec3;
@@ -737,6 +749,7 @@ export abstract class RenderedDataPanel extends RenderedPanel {
       element,
       "zoom-via-touchpinch",
       (e: ActionEvent<TouchPinchInfo>) => {
+        this.context.flagContinuousCameraMotion();
         const { detail } = e;
         this.handleMouseMove(detail.centerX, detail.centerY);
         const ratio = detail.prevDistance / detail.distance;

--- a/src/sliceview/panel.ts
+++ b/src/sliceview/panel.ts
@@ -176,6 +176,7 @@ export class SliceViewPanel extends RenderedDataPanel {
         if (mouseState.updateUnconditionally()) {
           const initialPosition = Float32Array.from(mouseState.position);
           startRelativeMouseDrag(e.detail, (_event, deltaX, deltaY) => {
+            this.context.flagContinuousCameraMotion();
             const { pose } = this.navigationState;
             const xAxis = vec3.transformQuat(
               tempVec3,
@@ -210,6 +211,7 @@ export class SliceViewPanel extends RenderedDataPanel {
         const { mouseState } = this.viewer;
         this.handleMouseMove(detail.centerX, detail.centerY);
         if (mouseState.updateUnconditionally()) {
+          this.context.flagContinuousCameraMotion();
           this.navigationState.pose.rotateAbsolute(
             this.sliceView.projectionParameters.value
               .viewportNormalInCanonicalCoordinates,

--- a/src/volume_rendering/volume_render_layer.ts
+++ b/src/volume_rendering/volume_render_layer.ts
@@ -819,7 +819,7 @@ outputValue = vec4(1.0, 1.0, 1.0, 1.0);
       this.getDataHistogramCount() > 0 &&
       !renderContext.wireFrame &&
       !renderContext.sliceViewsPresent &&
-      !renderContext.continousCameraMovementInProgress;
+      !renderContext.isContinuousCameraMotionInProgress;
 
     gl.enable(WebGL2RenderingContext.CULL_FACE);
     gl.cullFace(WebGL2RenderingContext.FRONT);

--- a/src/volume_rendering/volume_render_layer.ts
+++ b/src/volume_rendering/volume_render_layer.ts
@@ -819,7 +819,7 @@ outputValue = vec4(1.0, 1.0, 1.0, 1.0);
       this.getDataHistogramCount() > 0 &&
       !renderContext.wireFrame &&
       !renderContext.sliceViewsPresent &&
-      !renderContext.cameraMovementInProgress;
+      !renderContext.continousCameraMovementInProgress;
 
     gl.enable(WebGL2RenderingContext.CULL_FACE);
     gl.cullFace(WebGL2RenderingContext.FRONT);


### PR DESCRIPTION
The context can be used to mark the camera continuously moving. The context will mark the camera movement as completed after 300ms using lodash debounce, and emit a signal when this happens. At the moment, only the perspective panel listens for this signal, and uses it to trigger a redraw request if volume rendering is enabled on that panel.

The actions that flag the start of a continuous camera movement are:
* Zooming via mouse, touch, or keys
* Rotating via mouse, touch or keys
* Changing the depth planes