### PR TITLE
fix(datasource/zarr) `HEAD` to get content length

### DIFF
--- a/src/kvstore/special/index.ts
+++ b/src/kvstore/special/index.ts
@@ -52,7 +52,7 @@ class SpecialProtocolKvStore implements ReadableKvStore {
     public baseUrl: string,
   ) {}
 
-  async getObjectLength(url: string, options: ReadOptions){
+  async getObjectLength(url: string, options: ReadOptions) {
     // Use a HEAD request to get the length of an object
     const { cancellationToken = uncancelableToken } = options;
     const headResponse = await cancellableFetchSpecialOk(
@@ -62,7 +62,7 @@ class SpecialProtocolKvStore implements ReadableKvStore {
       async (response) => response,
       cancellationToken,
     );
-  
+
     if (headResponse.status !== 200) {
       throw new Error(
         "Failed to determine total size in order to fetch suffix",
@@ -75,7 +75,7 @@ class SpecialProtocolKvStore implements ReadableKvStore {
       );
     }
     const contentLengthNumber = Number(contentLength);
-    return contentLengthNumber
+    return contentLengthNumber;
   }
 
   async read(
@@ -110,25 +110,24 @@ class SpecialProtocolKvStore implements ReadableKvStore {
           if (contentRange === null) {
             if (byteRangeRequest !== undefined) {
               if ("suffixLength" in byteRangeRequest) {
-               const objectSize = await this.getObjectLength(url, options)
+                const objectSize = await this.getObjectLength(url, options);
                 byteRange = {
                   offset: objectSize - byteRangeRequest.suffixLength,
-                  length: Number(response.headers.get('content-length'))
-                }
+                  length: Number(response.headers.get("content-length")),
+                };
+              } else {
+                byteRange = {
+                  offset: byteRangeRequest.offset,
+                  length: data.byteLength,
+                };
               }
-              else {
-              byteRange = {
-                offset: byteRangeRequest.offset,
-                length: data.byteLength,
-              }}
             } else {
               throw new Error(
                 "Unexpected HTTP 206 response when no byte range specified.",
               );
             }
           }
-          
-          if (contentRange !== null) {        
+          if (contentRange !== null) {
             const m = contentRange.match(
               /bytes ([0-9]+)-([0-9]+)\/([0-9]+|\*)/,
             );
@@ -165,7 +164,7 @@ class SpecialProtocolKvStore implements ReadableKvStore {
         ) {
           // Some servers, such as the npm http-server package, do not support suffixLength
           // byte-range requests.
-          const contentLengthNumber = await this.getObjectLength(url, options)
+          const contentLengthNumber = await this.getObjectLength(url, options);
           byteRangeRequest = composeByteRangeRequest(
             { offset: 0, length: contentLengthNumber },
             byteRangeRequest,
@@ -186,4 +185,3 @@ export function getSpecialProtocolKvStore(
 ): ReadableKvStore {
   return new SpecialProtocolKvStore(credentialsProvider, baseUrl);
 }
-


### PR DESCRIPTION
Some static file servers (e.g., the nodejs program [`serve`](https://github.com/vercel/serve)) will handle a successful HTTP range request (i.e., status code 206) _without_ including a `content-range` header in that response. Perhaps `content-range` is omitted because it's not on the list of [CORS safelisted response headers](https://developer.mozilla.org/en-US/docs/Glossary/CORS-safelisted_response_header), but that's just a guess. This impairs neuroglancer's ability to read sharded zarr v3 chunks when the shard index is configured to reside at the end of a chunk, as in this case neuroglancer makes a GET with a suffixLength byte range request but if the response from the server does not include the `content-length` header, it's not possible to resolve an offset + length representation of the body of that request.

This PR addresses this problem by falling back to a HEAD request against the shard to figure out its length. I am re-using a routine already employed for hosts that don't support suffixLength byte range requests. 

I can confirm from local testing that this patch enables reading sharded zarr v3 arrays from the nodejs `serve` application, which are failing on main, but I would appreciate any pointers on places inside the neuroglancer codebase to modify / add a test.