### PR TITLE
feat(datasource/graphene) added timestamp tool to graphene, timestamp property to SegmentationUserLayer

### DIFF
--- a/src/layer/segmentation/json_keys.ts
+++ b/src/layer/segmentation/json_keys.ts
@@ -25,3 +25,5 @@ export const SEGMENT_DEFAULT_COLOR_JSON_KEY = "segmentDefaultColor";
 export const ANCHOR_SEGMENT_JSON_KEY = "anchorSegment";
 export const SKELETON_RENDERING_SHADER_CONTROL_TOOL_ID =
   "skeletonShaderControl";
+export const TIMESTAMP_JSON_KEY = "timestamp";
+export const TIMESTAMP_OWNER_JSON_KEY = "timestampOwner";

--- a/src/segmentation_display_state/backend.ts
+++ b/src/segmentation_display_state/backend.ts
@@ -27,12 +27,13 @@ import type {
   VisibleSegmentsState,
 } from "#src/segmentation_display_state/base.js";
 import {
+  VISIBLE_SEGMENTS_STATE_PROPERTIES,
   onTemporaryVisibleSegmentsStateChanged,
   onVisibleSegmentsStateChanged,
-  VISIBLE_SEGMENTS_STATE_PROPERTIES,
 } from "#src/segmentation_display_state/base.js";
 import type { SharedDisjointUint64Sets } from "#src/shared_disjoint_sets.js";
 import type { SharedWatchableValue } from "#src/shared_watchable_value.js";
+import type { WatchableValue } from "#src/trackable_value.js";
 import type { Uint64OrderedSet } from "#src/uint64_ordered_set.js";
 import type { Uint64Set } from "#src/uint64_set.js";
 import type { AnyConstructor } from "#src/util/mixin.js";
@@ -57,6 +58,7 @@ export const withSegmentationLayerBackendState = <
   Base: TBase,
 ) =>
   class SegmentationLayerState extends Base implements VisibleSegmentsState {
+    timestamp: WatchableValue<number | undefined>;
     visibleSegments: Uint64Set;
     selectedSegments: Uint64OrderedSet;
     segmentEquivalences: SharedDisjointUint64Sets;

--- a/src/segmentation_display_state/base.ts
+++ b/src/segmentation_display_state/base.ts
@@ -17,12 +17,14 @@
 import { VisibleSegmentEquivalencePolicy } from "#src/segmentation_graph/segment_id.js";
 import type { SharedDisjointUint64Sets } from "#src/shared_disjoint_sets.js";
 import type { SharedWatchableValue } from "#src/shared_watchable_value.js";
+import type { WatchableValue } from "#src/trackable_value.js";
 import type { Uint64OrderedSet } from "#src/uint64_ordered_set.js";
 import type { Uint64Set } from "#src/uint64_set.js";
 import type { RefCounted } from "#src/util/disposable.js";
 import type { Uint64 } from "#src/util/uint64.js";
 
 export interface VisibleSegmentsState {
+  timestamp: WatchableValue<number | undefined>;
   visibleSegments: Uint64Set;
   selectedSegments: Uint64OrderedSet;
   segmentEquivalences: SharedDisjointUint64Sets;

--- a/src/util/json.ts
+++ b/src/util/json.ts
@@ -702,6 +702,16 @@ export function verifyIntegerArray(a: unknown) {
   return <number[]>a;
 }
 
+export function verifyFloatArray(a: unknown) {
+  if (!Array.isArray(a)) {
+    throw new Error(`Expected array, received: ${JSON.stringify(a)}.`);
+  }
+  for (const x of a) {
+    verifyFloat(x);
+  }
+  return <number[]>a;
+}
+
 export function verifyBoolean(x: any) {
   if (typeof x !== "boolean") {
     throw new Error(`Expected boolean, received: ${JSON.stringify(x)}`);

--- a/src/widget/datetime.ts
+++ b/src/widget/datetime.ts
@@ -1,0 +1,82 @@
+/**
+ * @license
+ * Copyright 2020 Google Inc.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { WatchableValue } from "#src/trackable_value.js";
+import { RefCounted } from "#src/util/disposable.js";
+import { removeFromParent } from "#src/util/dom.js";
+
+function toDateTimeLocalString(date: Date) {
+  return new Date(date.getTime() - date.getTimezoneOffset() * 60000)
+    .toISOString()
+    .slice(0, -8);
+}
+
+export class DateTimeInputWidget extends RefCounted {
+  element = document.createElement("input");
+  constructor(
+    public model: WatchableValue<number | undefined>,
+    minDate?: Date,
+    maxDate?: Date,
+  ) {
+    super();
+    this.registerDisposer(model.changed.add(() => this.updateView()));
+    const { element } = this;
+    element.type = "datetime-local";
+    if (minDate) {
+      this.setMin(minDate);
+    }
+    if (maxDate) {
+      this.setMax(maxDate);
+    }
+    this.registerEventListener(element, "change", () => this.updateModel());
+    this.updateView();
+  }
+
+  setMin(date: Date) {
+    const { element } = this;
+    element.min = toDateTimeLocalString(date);
+  }
+
+  setMax(date: Date) {
+    const { element } = this;
+    element.max = toDateTimeLocalString(date);
+  }
+
+  disposed() {
+    removeFromParent(this.element);
+  }
+
+  private updateView() {
+    if (this.model.value !== undefined) {
+      this.element.value = toDateTimeLocalString(new Date(this.model.value));
+    } else {
+      this.element.value = "";
+    }
+  }
+
+  private updateModel() {
+    try {
+      if (this.element.value) {
+        this.model.value = new Date(this.element.value).valueOf();
+      } else {
+        this.model.value = undefined;
+      }
+    } catch {
+      // Ignore invalid input.
+    }
+    this.updateView();
+  }
+}

--- a/src/widget/icon.css
+++ b/src/widget/icon.css
@@ -48,6 +48,10 @@
   background-color: #db4437;
 }
 
+.neuroglancer-icon.locked {
+  background-color: yellow;
+}
+
 .neuroglancer-icon-hover:not(:hover) svg:last-child {
   display: none;
 }


### PR DESCRIPTION
replaces https://github.com/google/neuroglancer/pull/587

This is also designed to support our future cave annotation layers being able to synchronize/control with the segmentation timestamp.

Here is part of that implementation https://github.com/seung-lab/neuroglancer/commit/4d41b32e67e1ed28228fc3f68056a5637d1eeccc