### PR TITLE
feat(status): add modal status message option that can be closed back to a normal status message

### DIFF
--- a/src/datasource/middleauth/credentials_provider.ts
+++ b/src/datasource/middleauth/credentials_provider.ts
@@ -52,7 +52,7 @@ function openPopupCenter(url: string, width: number, height: number) {
 }
 
 async function waitForLogin(serverUrl: string): Promise<MiddleAuthToken> {
-  const status = new StatusMessage(/*delay=*/ false);
+  const status = new StatusMessage(/*delay=*/ false, /*modal=*/ true);
 
   const res: Promise<MiddleAuthToken> = new Promise((f) => {
     function writeLoginStatus(message: string, buttonMessage: string) {

--- a/src/status.css
+++ b/src/status.css
@@ -38,3 +38,41 @@
   background-color: #333;
   padding: 2px;
 }
+
+#statusContainerModal {
+  pointer-events: none;
+  position: absolute;
+  z-index: 100;
+  color: white;
+  margin: 0px;
+  padding: 0px;
+  font: 10pt sans-serif;
+
+  display: grid;
+  align-content: center;
+  justify-content: center;
+  height: 100vh;
+  width: 80vw;
+  left: 10vw;
+  grid-row-gap: 10px;
+}
+
+#statusContainerModal > div {
+  pointer-events: initial;
+  position: relative;
+  background-color: #808080;
+  padding: 20px;
+  padding-top: 30px;
+}
+
+#statusContainerModal > div > div:first-child {
+  position: absolute;
+  top: 4px;
+  right: 4px;
+  margin: 0;
+  padding: 0;
+}
+
+#statusContainerModal li {
+  display: block;
+}


### PR DESCRIPTION
I tried to be unopinionated with the styling, keeping it minimal/using original status message styling. I am not blocking any input while the modal is up. Multiple modals at the same time get arranged in a list from oldest to newest. Perhaps I should reverse the order.

<img width="741" alt="Screenshot 2024-07-17 at 11 35 07 AM" src="https://github.com/user-attachments/assets/ba13ac3d-39bc-4cf9-ad00-9c7c0edace1a">
