### PR TITLE
fix(volume-rendering): correct data access for histogram in volume rendering with unequal chunk sizes

### DIFF
--- a/src/volume_rendering/volume_render_layer.ts
+++ b/src/volume_rendering/volume_render_layer.ts
@@ -628,15 +628,10 @@ float getHistogramValue${i}() {
     simpleFloatHash(vec2(aInput1 + float(gl_VertexID) + 20.0, 15.0 + float(gl_InstanceID))));
   chunkSamplePosition = rand3val * (uChunkDataSize - 1.0);
 ${histogramFetchCode}
-  if (x == 0.0) {
-    gl_Position = vec4(2.0, 2.0, 2.0, 1.0);
-  }
-  else {
-    if (x < 0.0) x = 0.0;
-    else if (x > 1.0) x = 1.0;
-    else x = (1.0 + x * 253.0) / 255.0;
-    gl_Position = vec4(2.0 * (x * 255.0 + 0.5) / 256.0 - 1.0, 0.0, 0.0, 1.0);
-  }
+  if (x < 0.0) x = 0.0;
+  else if (x > 1.0) x = 1.0;
+  else x = (1.0 + x * 253.0) / 255.0;
+  gl_Position = vec4(2.0 * (x * 255.0 + 0.5) / 256.0 - 1.0, 0.0, 0.0, 1.0);
   gl_PointSize = 1.0;`);
           builder.setFragmentMain(`
 outputValue = vec4(1.0, 1.0, 1.0, 1.0);

--- a/src/volume_rendering/volume_render_layer.ts
+++ b/src/volume_rendering/volume_render_layer.ts
@@ -1126,9 +1126,9 @@ outputValue = vec4(1.0, 1.0, 1.0, 1.0);
         totalChunkVolume: number,
       ) => {
         const chunkVolume = chunkDataSize.reduce((a, b) => a * b, 1);
-        const maxSamplesInChunk = chunkVolume / 2.0;
         const desiredChunkSamples =
           NUM_HISTOGRAM_SAMPLES * (chunkVolume / totalChunkVolume);
+        const maxSamplesInChunk = chunkVolume / 2.0;
         const clampedSamples = Math.min(maxSamplesInChunk, desiredChunkSamples);
         return Math.max(
           Math.round(clampedSamples / HISTOGRAM_SAMPLES_PER_INSTANCE),

--- a/src/volume_rendering/volume_render_layer.ts
+++ b/src/volume_rendering/volume_render_layer.ts
@@ -1123,20 +1123,15 @@ outputValue = vec4(1.0, 1.0, 1.0, 1.0);
       };
       const determineNumHistogramInstances = (
         chunkDataSize: vec3,
-        chunkVolumeSum: number,
+        totalChunkVolume: number,
       ) => {
-        const chunkSizeProduct = chunkDataSize.reduce((a, b) => a * b, 1);
-        const maxSamplesInChunk = chunkSizeProduct / 2.0;
-        const totalDesiredSamplesInChunk =
-          (NUM_HISTOGRAM_SAMPLES * chunkSizeProduct) / chunkVolumeSum;
-        const desiredSamples = Math.min(
-          maxSamplesInChunk,
-          totalDesiredSamplesInChunk,
-        );
-
-        // round to nearest multiple of NUM_HISTOGRAM_SAMPLES_PER_INSTANCE
+        const chunkVolume = chunkDataSize.reduce((a, b) => a * b, 1);
+        const maxSamplesInChunk = chunkVolume / 2.0;
+        const desiredChunkSamples =
+          NUM_HISTOGRAM_SAMPLES * (chunkVolume / totalChunkVolume);
+        const clampedSamples = Math.min(maxSamplesInChunk, desiredChunkSamples);
         return Math.max(
-          Math.round(desiredSamples / HISTOGRAM_SAMPLES_PER_INSTANCE),
+          Math.round(clampedSamples / HISTOGRAM_SAMPLES_PER_INSTANCE),
           1,
         );
       };
@@ -1156,7 +1151,7 @@ outputValue = vec4(1.0, 1.0, 1.0, 1.0);
       gl.enable(WebGL2RenderingContext.BLEND);
       gl.disable(WebGL2RenderingContext.DEPTH_TEST);
 
-      const chunkVolumeSum = shaderUniformsForSecondPass.reduce(
+      const totalChunkVolume = shaderUniformsForSecondPass.reduce(
         (sum, uniforms) => {
           const chunkVolume = uniforms.uChunkDataSize.reduce(
             (a, b) => a * b,
@@ -1215,7 +1210,7 @@ outputValue = vec4(1.0, 1.0, 1.0, 1.0);
         // Draw each histogram
         const numInstances = determineNumHistogramInstances(
           uniforms.uChunkDataSize,
-          chunkVolumeSum,
+          totalChunkVolume,
         );
         for (let i = 0; i < numHistograms; ++i) {
           histogramFramebuffers[i].bind(256, 1);


### PR DESCRIPTION
Included also in #614 as changes along these lines are needed for that PR.

The histogram computation in volume rendering has been fixed for unequal chunk sizes to both:
1. Pass the correct chunk size to the data sampling shader per chunk
2. Distribute the total number of samples for the histogram according to the percentage of the total chunk volume that each chunk takes up. E.g. with 1k samples overall, total chunk volume of 10k voxels, and a single chunk with 1k voxels, we would aim to obtain 100 random samples from that chunk for the histogram. While for a chunk with 300 voxels, we would aim for 30 random samples from that chunk for the histogram.

In addition, the 3D histogram calculation no longer discards values at exactly 0 after invlerp. The previous behaviour was due to mistaking the above problem with unequal chunk sizes for a different error.