### PR TITLE
fix(ui): buttons now display the title set in the makeIcon options

### DIFF
--- a/src/widget/icon.css
+++ b/src/widget/icon.css
@@ -42,6 +42,7 @@
   stroke-width: 2;
   stroke-linecap: round;
   stroke-linejoin: round;
+  pointer-events: none;
 }
 
 .neuroglancer-icon:hover {


### PR DESCRIPTION
…when hovering inside the ikonate svg with a default title. Previously you would only see the correct title if you hovered in the tiny margin surrounding the svg.

Tested on chrome and firefox

Before:
<img width="69" alt="Screenshot 2024-08-07 at 1 30 18 PM" src="https://github.com/user-attachments/assets/3432618f-6e8b-4ca2-bc3d-336adf45635a">

After:
<img width="177" alt="Screenshot 2024-08-07 at 1 32 03 PM" src="https://github.com/user-attachments/assets/d78f63f7-ed6a-4933-83c4-b1296022444a">
