### PR TITLE
fix(http_requests): allow blob: to prepend URL string

### DIFF
--- a/src/util/http_request.spec.ts
+++ b/src/util/http_request.spec.ts
@@ -1,0 +1,57 @@
+/**
+ * @license
+ * Copyright 2016 Google Inc.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, it, expect } from "vitest"
+
+import { parseUrl } from "#src/util/http_request.ts"
+
+describe("parseUrl", () => {
+  it("parses http correctly", () => {
+    expect(parseUrl("http://example.foo/bar")).toEqual({
+      protcol: "http",
+      host: "example.foo",
+      path: "/bar"
+    })
+  })
+  it("parses http with port correctly", () => {
+    expect(parseUrl("http://example.foo:8080/bar")).toEqual({
+      protcol: "http",
+      host: "example.foo:8080",
+      path: "/bar"
+    })
+  })
+  it("parses https correctly", () => {
+    expect(parseUrl("https://example.foo/bar")).toEqual({
+      protcol: "https",
+      host: "example.foo",
+      path: "/bar"
+    })
+  })
+  it("parses blob correctly", () => {
+    expect(parseUrl("blob:http://example.foo/bar")).toEqual({
+      protcol: "http",
+      host: "example.foo",
+      path: "/bar"
+    })
+  })
+  it("parses blob with port correctly", () => {
+    expect(parseUrl("blob:http://example.foo:8080/bar")).toEqual({
+      protcol: "http",
+      host: "example.foo:8080",
+      path: "/bar"
+    })
+  })
+})

--- a/src/util/http_request.spec.ts
+++ b/src/util/http_request.spec.ts
@@ -14,44 +14,44 @@
  * limitations under the License.
  */
 
-import { describe, it, expect } from "vitest"
+import { describe, it, expect } from "vitest";
 
-import { parseUrl } from "#src/util/http_request.ts"
+import { parseUrl } from "#src/util/http_request.ts";
 
 describe("parseUrl", () => {
   it("parses http correctly", () => {
     expect(parseUrl("http://example.foo/bar")).toEqual({
       protcol: "http",
       host: "example.foo",
-      path: "/bar"
-    })
-  })
+      path: "/bar",
+    });
+  });
   it("parses http with port correctly", () => {
     expect(parseUrl("http://example.foo:8080/bar")).toEqual({
       protcol: "http",
       host: "example.foo:8080",
-      path: "/bar"
-    })
-  })
+      path: "/bar",
+    });
+  });
   it("parses https correctly", () => {
     expect(parseUrl("https://example.foo/bar")).toEqual({
       protcol: "https",
       host: "example.foo",
-      path: "/bar"
-    })
-  })
+      path: "/bar",
+    });
+  });
   it("parses blob correctly", () => {
     expect(parseUrl("blob:http://example.foo/bar")).toEqual({
       protcol: "http",
       host: "example.foo",
-      path: "/bar"
-    })
-  })
+      path: "/bar",
+    });
+  });
   it("parses blob with port correctly", () => {
     expect(parseUrl("blob:http://example.foo:8080/bar")).toEqual({
       protcol: "http",
       host: "example.foo:8080",
-      path: "/bar"
-    })
-  })
-})
+      path: "/bar",
+    });
+  });
+});

--- a/src/util/http_request.ts
+++ b/src/util/http_request.ts
@@ -195,12 +195,12 @@ export function parseUrl(url: string): {
   host: string;
   path: string;
 } {
-  const urlProtocolPattern = /^([^:/]+):\/\/([^/]+)((?:\/.*)?)$/;
+  const urlProtocolPattern = /^(blob:)?([^:/]+):\/\/([^/]+)((?:\/.*)?)$/;
   const match = url.match(urlProtocolPattern);
   if (match === null) {
     throw new Error(`Invalid URL: ${JSON.stringify(url)}`);
   }
-  return { protocol: match[1], host: match[2], path: match[3] };
+  return { protocol: match[2], host: match[3], path: match[4] };
 }
 
 export function isNotFoundError(e: any) {


### PR DESCRIPTION
This is my first PR in this repo. Apologies if I have made any mistakes.

Currently, if the data source originates from the web (thus have the URL of `https?://`), the `parseUrl` function correctly parses the protcol, host and path. 

In our usecase, we often need to download the entire (nifti) image, preprocess them, and generate a blob URL. According to [mdn doc](https://developer.mozilla.org/en-US/docs/Web/API/URL#static_methods) on `URL.createObjectURL` , it creates a URL with `blob:` prepended. This fails the check as it is implemented currently. 

This PR addresses this issue. 