### PR TITLE
fix(zstd): Upgrade numcodecs.js to 0.3.2 for Zstd streaming decompression

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "ikonate": "github:mikolajdobrucki/ikonate#a86b4107c6ec717e7877f880a930d1ccf0b59d89",
         "lodash-es": "^4.17.21",
         "nifti-reader-js": "^0.6.8",
-        "numcodecs": "^0.3.1",
+        "numcodecs": "^0.3.2",
         "pako": "^2.1.0"
       },
       "devDependencies": {
@@ -10044,9 +10044,10 @@
       }
     },
     "node_modules/numcodecs": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/numcodecs/-/numcodecs-0.3.1.tgz",
-      "integrity": "sha512-ywIyGpJ+c6Ojktq9a8jsWSy12ZSUcW/W+I3jlH0q0zv9aR/ZiMsN7IrWaNq9YV2FRdLu6r/M6lp35jMA6fug/A==",
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/numcodecs/-/numcodecs-0.3.2.tgz",
+      "integrity": "sha512-6YSPnmZgg0P87jnNhi3s+FVLOcIn3y+1CTIgUulA3IdASzK9fJM87sUFkpyA+be9GibGRaST2wCgkD+6U+fWKw==",
+      "license": "MIT",
       "dependencies": {
         "fflate": "^0.8.0"
       }

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "ikonate": "github:mikolajdobrucki/ikonate#a86b4107c6ec717e7877f880a930d1ccf0b59d89",
     "lodash-es": "^4.17.21",
     "nifti-reader-js": "^0.6.8",
-    "numcodecs": "^0.3.1",
+    "numcodecs": "^0.3.2",
     "pako": "^2.1.0"
   },
   "overrides": {


### PR DESCRIPTION
Fix #625

Upgrade numcodecs.js to version 0.3.2

Version 0.3.2 incorporates https://github.com/manzt/numcodecs.js/pull/47 which supports detection of 
`ZSTD_CONTENTSIZE_UNKNOWN` from `ZSTD_getFrameContentSize`.

Zstd decompression is now handled via the advanced streaming API so that the entire buffer size does
not need to be known ahead of time.

Incorporating this allows Neuroglancer to read Zstd compressed data from Tensorstore. However, this not resolve 
https://github.com/google/tensorstore/issues/182 . Other Zarr implementations such as zarr-python continue to 
have issues:
https://github.com/zarr-developers/zarr-python/issues/2056 
