### PR TITLE
fix(url_hash_bindings): added debouce maxWait value for throttledSetUrlHash

### DIFF
--- a/src/ui/url_hash_binding.ts
+++ b/src/ui/url_hash_binding.ts
@@ -82,6 +82,7 @@ export class UrlHashBinding extends RefCounted {
     const throttledSetUrlHash = debounce(
       () => this.setUrlHash(),
       updateDelayMilliseconds,
+      { maxWait: updateDelayMilliseconds * 2 },
     );
     this.registerDisposer(root.changed.add(throttledSetUrlHash));
     this.registerDisposer(() => throttledSetUrlHash.cancel());


### PR DESCRIPTION
without a maxWait value, debounce can cause important state changes to be lost if there is high rate of state change between the important change and a page reload

mouse movement causes state changes and is probably the main reason this can happen. I just threw in a value of double the debounce delay.

Alternatively, we could use throttle with the trailing option set to true. This should give the same behavior as using a maxWait value of updateDelayMilliseconds but maxWait allows more control with performance tuning.
