### PR TITLE
fix(virtual_lists) use existing debounceUpdateView with resize observer

### DIFF
--- a/src/widget/virtual_list.ts
+++ b/src/widget/virtual_list.ts
@@ -300,7 +300,7 @@ export class VirtualList extends RefCounted {
   private debouncedUpdateView = this.registerCancellable(
     animationFrameDebounce(() => this.updateView()),
   );
-  private resizeObserver = new ResizeObserver(() => this.updateView());
+  private resizeObserver = new ResizeObserver(() => this.debouncedUpdateView());
 
   constructor(options: {
     source: VirtualListSource;


### PR DESCRIPTION
Use the existing `debounceUpdateView()` in place of just `updateView()` for the `resizeObserver()`, similar to other updates in the class.

When embedding Neuroglancer in an React app, the lack of debounce causes an infinite update loop and it will not load.