### PR TITLE
fix(framerate tracking): better handling of query failures

### DIFF
--- a/src/display_context.ts
+++ b/src/display_context.ts
@@ -587,7 +587,7 @@ export class DisplayContext extends RefCounted implements FrameNumberCounter {
     this.updateStarted.dispatch();
     const gl = this.gl;
     const ext = this.framerateMonitor.getTimingExtension(gl);
-    const query = this.framerateMonitor.startFrameTimeQuery(gl, ext);
+    this.framerateMonitor.startFrameTimeQuery(gl, ext, this.frameNumber);
     this.ensureBoundsUpdated();
     this.gl.clearColor(0.0, 0.0, 0.0, 0.0);
     gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT);
@@ -611,7 +611,7 @@ export class DisplayContext extends RefCounted implements FrameNumberCounter {
     gl.clear(gl.COLOR_BUFFER_BIT);
     this.gl.colorMask(true, true, true, true);
     this.updateFinished.dispatch();
-    this.framerateMonitor.endFrameTimeQuery(gl, ext, query);
+    this.framerateMonitor.endLastTimeQuery(gl, ext);
     this.framerateMonitor.grabAnyFinishedQueryResults(gl);
   }
 

--- a/src/util/framerate.ts
+++ b/src/util/framerate.ts
@@ -20,8 +20,15 @@ export enum FrameTimingMethod {
   MAX = 2,
 }
 
+interface QueryInfo {
+  glQuery: WebGLQuery;
+  frameNumber: number;
+  wasStarted: boolean;
+  wasEnded: boolean;
+}
+
 export class FramerateMonitor {
-  private timeElapsedQueries: (WebGLQuery | null)[] = [];
+  private timeElapsedQueries: QueryInfo[] = [];
   private warnedAboutMissingExtension = false;
   private storedTimeDeltas: number[] = [];
 
@@ -48,47 +55,88 @@ export class FramerateMonitor {
     return ext;
   }
 
-  startFrameTimeQuery(gl: WebGL2RenderingContext, ext: any) {
+  getOldestQueryIndexByFrameNumber() {
+    if (this.timeElapsedQueries.length === 0) {
+      return undefined;
+    }
+    let oldestQueryIndex = 0;
+    for (let i = 1; i < this.timeElapsedQueries.length; i++) {
+      const oldestQuery = this.timeElapsedQueries[oldestQueryIndex];
+      if (this.timeElapsedQueries[i].frameNumber < oldestQuery.frameNumber) {
+        oldestQueryIndex = i;
+      }
+    }
+    return oldestQueryIndex;
+  }
+
+  startFrameTimeQuery(
+    gl: WebGL2RenderingContext,
+    ext: any,
+    frameNumber: number,
+  ) {
     if (ext === null) {
       return null;
     }
     const query = gl.createQuery();
-    if (query !== null) {
+    const currentQuery =
+      this.timeElapsedQueries[this.timeElapsedQueries.length - 1];
+    if (query !== null && currentQuery !== query) {
       gl.beginQuery(ext.TIME_ELAPSED_EXT, query);
+      if (this.timeElapsedQueries.length >= this.queryPoolSize) {
+        const oldestQueryIndex = this.getOldestQueryIndexByFrameNumber();
+        if (oldestQueryIndex !== undefined) {
+          const oldestQuery = this.timeElapsedQueries.splice(
+            oldestQueryIndex,
+            1,
+          )[0];
+          gl.deleteQuery(oldestQuery.glQuery);
+        }
+      }
+      const queryInfo: QueryInfo = {
+        glQuery: query,
+        frameNumber: frameNumber,
+        wasStarted: true,
+        wasEnded: false,
+      };
+      this.timeElapsedQueries.push(queryInfo);
     }
     return query;
   }
 
-  endFrameTimeQuery(
-    gl: WebGL2RenderingContext,
-    ext: any,
-    query: WebGLQuery | null,
-  ) {
-    if (ext !== null && query !== null) {
-      gl.endQuery(ext.TIME_ELAPSED_EXT);
-    }
-    if (this.timeElapsedQueries.length >= this.queryPoolSize) {
-      const oldestQuery = this.timeElapsedQueries.shift();
-      if (oldestQuery !== null && oldestQuery !== undefined) {
-        gl.deleteQuery(oldestQuery);
+  endLastTimeQuery(gl: WebGL2RenderingContext, ext: any) {
+    if (ext !== null) {
+      const currentQuery =
+        this.timeElapsedQueries[this.timeElapsedQueries.length - 1];
+      if (!currentQuery.wasEnded && currentQuery.wasStarted) {
+        gl.endQuery(ext.TIME_ELAPSED_EXT);
+        currentQuery.wasEnded = true;
       }
     }
-    this.timeElapsedQueries.push(query);
   }
 
   grabAnyFinishedQueryResults(gl: WebGL2RenderingContext) {
     const deletedQueryIndices: number[] = [];
     for (let i = 0; i < this.timeElapsedQueries.length; i++) {
       const query = this.timeElapsedQueries[i];
-      if (query !== null) {
+      // Error checking: if the query was not started or ended, just delete it.
+      // This can happen from errors in the rendering
+      if (!query.wasEnded || !query.wasStarted) {
+        gl.deleteQuery(query.glQuery);
+        deletedQueryIndices.push(i);
+      } else {
         const available = gl.getQueryParameter(
-          query,
+          query.glQuery,
           gl.QUERY_RESULT_AVAILABLE,
         );
-        if (available) {
-          const result = gl.getQueryParameter(query, gl.QUERY_RESULT) / 1e6;
+        // If the result is null, then something went wrong and we should just delete the query.
+        if (available === null) {
+          gl.deleteQuery(query.glQuery);
+          deletedQueryIndices.push(i);
+        } else if (available) {
+          const result =
+            gl.getQueryParameter(query.glQuery, gl.QUERY_RESULT) / 1e6;
           this.storedTimeDeltas.push(result);
-          gl.deleteQuery(query);
+          gl.deleteQuery(query.glQuery);
           deletedQueryIndices.push(i);
         }
       }

--- a/src/util/framerate.ts
+++ b/src/util/framerate.ts
@@ -149,10 +149,9 @@ export class FramerateMonitor {
         }
       }
     }
-    for (let i = deletedQueryIndices.length - 1; i >= 0; i--) {
-      const index = deletedQueryIndices[i];
-      this.timeElapsedQueries.splice(index, 1);
-    }
+    this.timeElapsedQueries = this.timeElapsedQueries.filter(
+      (_, i) => !deletedQueryIndices.includes(i),
+    );
     if (this.storedTimeDeltas.length > this.numStoredTimes) {
       this.storedTimeDeltas = this.storedTimeDeltas.slice(-this.numStoredTimes);
     }

--- a/src/util/framerate.ts
+++ b/src/util/framerate.ts
@@ -27,10 +27,15 @@ interface QueryInfo {
   wasEnded: boolean;
 }
 
+interface FrameDeltaInfo {
+  frameDelta: number;
+  frameNumber: number;
+}
+
 export class FramerateMonitor {
   private timeElapsedQueries: QueryInfo[] = [];
   private warnedAboutMissingExtension = false;
-  private storedTimeDeltas: number[] = [];
+  private storedTimeDeltas: FrameDeltaInfo[] = [];
 
   constructor(
     private numStoredTimes: number = 10,
@@ -135,7 +140,10 @@ export class FramerateMonitor {
         } else if (available) {
           const result =
             gl.getQueryParameter(query.glQuery, gl.QUERY_RESULT) / 1e6;
-          this.storedTimeDeltas.push(result);
+          this.storedTimeDeltas.push({
+            frameDelta: result,
+            frameNumber: query.frameNumber,
+          });
           gl.deleteQuery(query.glQuery);
           deletedQueryIndices.push(i);
         }
@@ -151,7 +159,9 @@ export class FramerateMonitor {
   }
 
   getLastFrameTimesInMs(numberOfFrames: number = 10) {
-    return this.storedTimeDeltas.slice(-numberOfFrames);
+    return this.storedTimeDeltas
+      .slice(-numberOfFrames)
+      .map((frameDeltaInfo) => frameDeltaInfo.frameDelta);
   }
 
   getQueries() {

--- a/src/util/framerate.ts
+++ b/src/util/framerate.ts
@@ -94,7 +94,8 @@ export class FramerateMonitor {
       }
     }
     for (let i = deletedQueryIndices.length - 1; i >= 0; i--) {
-      this.timeElapsedQueries.splice(i, 1);
+      const index = deletedQueryIndices[i];
+      this.timeElapsedQueries.splice(index, 1);
     }
     if (this.storedTimeDeltas.length > this.numStoredTimes) {
       this.storedTimeDeltas = this.storedTimeDeltas.slice(-this.numStoredTimes);


### PR DESCRIPTION
Summary: improved handling of gl query errors that could cause failed queries to hang around in the pool and decrease frame time tracking accuracy

In some cases the query handling for frame deltas was not properly accounting for errors in the queries. This could lead to some old queries get left in the query pool for a long time, and warnings in the console about trying to start the same query multiple times, or fetching from a query that never started.

To address this, the main changes are:
1. Keep track of the query started and ended state manually in the code. The state from gl is also checked, but if we know that the query never started or ended for some reason, we can avoid triggering a gl error trying to get results from that query - and instead delete the failed query.
2. Keep the frame number along with the queries and frame deltas. This is used to help delete old failed queries that may get left in the query pool. Also helps for debugging and has possible downstream applications