### PR TITLE
fix(layer): layer reference now reacts to layersChanged signal to unset reference when a layer is deleted

### DIFF
--- a/src/layer/index.ts
+++ b/src/layer/index.ts
@@ -1792,7 +1792,7 @@ export class LayerReference extends RefCounted implements Trackable {
     super();
     this.registerDisposer(layerManager);
     this.registerDisposer(
-      layerManager.specificationChanged.add(() => {
+      layerManager.layersChanged.add(() => {
         const { layer_ } = this;
         if (layer_ !== undefined) {
           if (!this.layerManager.layerSet.has(layer_) || !this.filter(layer_)) {


### PR DESCRIPTION
While testing the timestamp/cave annotation functionality, I came across this "issue" where deleting a segmentation layer that is linked from an annotation layer triggers this exception `TypeError: Cannot read properties of undefined (reading 'visibleSegmentEquivalencePolicy')`
<img width="502" alt="Screenshot 2024-11-14 at 11 00 28 AM" src="https://github.com/user-attachments/assets/de449f07-d165-4c5c-96a1-b5e067fcb56c">

Having LayerReference listen `layersChanged` instead of `specificationChanged` seems to make sense and works for both deleting a layer through the UI and through the state editor.
