### PR TITLE
wip:feat: adds Globus GCS-sourced assets as a datasource

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,8 +96,8 @@
   "type": "module",
   "exports": {
     ".": "./src/main_module.ts",
-    "./unstable/*.js": "./src/*.ts",
-    "./unstable/*": "./src/*"
+    "./*.js": "./src/*.ts",
+    "./*": "./src/*"
   },
   "imports": {
     "#src/third_party/jpgjs/jpg.js": "./src/third_party/jpgjs/jpg.js",
@@ -196,6 +196,13 @@
       "neuroglancer/datasource:none_by_default": "./src/util/false.ts",
       "neuroglancer/datasource/dvid:disabled": "./src/datasource/dvid/register_credentials_provider.ts",
       "default": "./src/datasource/dvid/register_credentials_provider.ts"
+    },
+    "#datasource/globus/register_credentials_provider": {
+      "neuroglancer/python": "./src/util/false.ts",
+      "neuroglancer/datasource/globus:enabled": "./src/datasource/globus/register_credentials_provider.ts",
+      "neuroglancer/datasource:none_by_default": "./src/util/false.ts",
+      "neuroglancer/datasource/globus:disabled": "./src/datasource/globus/register_credentials_provider.ts",
+      "default": "./src/datasource/globus/register_credentials_provider.ts"
     },
     "#datasource/graphene/backend": {
       "neuroglancer/datasource/graphene:enabled": "./src/datasource/graphene/backend.ts",

--- a/src/datasource/enabled_frontend_modules.ts
+++ b/src/datasource/enabled_frontend_modules.ts
@@ -6,6 +6,7 @@ import "#datasource/brainmaps/register_credentials_provider";
 import "#datasource/deepzoom/register_default";
 import "#datasource/dvid/register_default";
 import "#datasource/dvid/register_credentials_provider";
+import "#datasource/globus/register_credentials_provider";
 import "#datasource/graphene/register_default";
 import "#datasource/middleauth/register_credentials_provider";
 import "#datasource/n5/register_default";

--- a/src/datasource/globus/README.md
+++ b/src/datasource/globus/README.md
@@ -1,0 +1,1 @@
+Provides access to resources stored on Globus resources.

--- a/src/datasource/globus/credentials_provider.ts
+++ b/src/datasource/globus/credentials_provider.ts
@@ -1,0 +1,250 @@
+/**
+ * @license
+ * Copyright 2020 Google Inc.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// import { fetchWithCredentials } from "#src/credentials_provider/http_request.js";
+import {
+  CredentialsProvider,
+  makeCredentialsGetter,
+} from "#src/credentials_provider/index.js";
+import type { OAuth2Credentials } from "#src/credentials_provider/oauth2.js";
+import { StatusMessage } from "#src/status.js";
+import { uncancelableToken } from "#src/util/cancellation.js";
+import { HttpError } from "#src/util/http_request.js";
+import {
+  generateCodeChallenge,
+  generateCodeVerifier,
+  waitForPKCEResponseMessage,
+} from "#src/util/pkce.js";
+import { getRandomHexString } from "#src/util/random.js";
+
+function makeOriginError(serverUrl: string): Error {
+  return new Error(
+    `ngauth server ${serverUrl} ` +
+      `does not allow requests from Neuroglancer instance ${self.origin}`,
+  );
+}
+
+const GLOBUS_AUTH_HOST = "https://auth.globus.org";
+// const REDIRECT_URI = "https://auth.globus.org/v2/web/auth-code";
+
+const REDIRECT_URI = new URL("./globus_oauth2_redirect.html", import.meta.url)
+  .href;
+
+const CLIENT_ID = "9305520c-8b3b-47fb-9346-e38a7eeb0b26";
+
+function getRequiredScopes(endpoint: string) {
+  return `https://auth.globus.org/scopes/${endpoint}/https`;
+}
+
+function getGlobusAuthorizeURL({
+  endpoint,
+  code_challenge,
+  state,
+}: {
+  endpoint: string;
+  code_challenge: string;
+  state: string;
+}) {
+  const url = new URL("/v2/oauth2/authorize", GLOBUS_AUTH_HOST);
+  url.searchParams.set("response_type", "code");
+  url.searchParams.set("client_id", CLIENT_ID);
+  url.searchParams.set("redirect_uri", REDIRECT_URI);
+  url.searchParams.set("code_challenge", code_challenge);
+  url.searchParams.set("code_challenge_method", "S256");
+  url.searchParams.set("state", state);
+  url.searchParams.set("scope", getRequiredScopes(endpoint));
+  return url.toString();
+}
+
+function getGlobusTokenURL({
+  code,
+  code_verifier,
+}: {
+  code: string;
+  code_verifier: string;
+}) {
+  const url = new URL("/v2/oauth2/token", GLOBUS_AUTH_HOST);
+  url.searchParams.set("grant_type", "authorization_code");
+  url.searchParams.set("client_id", CLIENT_ID);
+  url.searchParams.set("code_verifier", code_verifier);
+  url.searchParams.set("code", code);
+  return url.toString();
+}
+
+// type GlobusLocalStorage = {
+//   authorizations?: {
+//     [resourceServer: string]: OAuth2Credentials;
+//   }[];
+//   domainMappings?: {
+//     [domain: string]: string;
+//   };
+// };
+
+// function getStorage() {
+//   return JSON.parse(
+//     localStorage.getItem("globus") || "{}",
+//   ) as GlobusLocalStorage;
+// }
+
+export interface GlobusCredentials extends OAuth2Credentials {}
+
+async function waitForAuth(): Promise<GlobusCredentials> {
+  const status = new StatusMessage(/*delay=*/ false, /*modal=*/ true);
+
+  const res: Promise<GlobusCredentials> = new Promise((resolve) => {
+    const frag = document.createDocumentFragment();
+
+    const title = document.createElement("h1");
+    title.textContent = "Globus Login Required";
+
+    const lead = document.createElement("p");
+    lead.textContent = `You need to log in to Globus to access this resource.`;
+
+    const verifier = generateCodeVerifier();
+    const state = getRandomHexString();
+
+    const link = document.createElement("a");
+    link.textContent = "Log in to Globus";
+    link.rel = "noopener noreferrer";
+    link.addEventListener("click", async (event) => {
+      event.preventDefault();
+      const source = window.open(link.href, "_blank");
+      if (!source) {
+        status.setText("Failed to open login window.");
+        return;
+      }
+      waitForPKCEResponseMessage({
+        client_id: CLIENT_ID,
+        source,
+        state,
+        verifier,
+        redirect_uri: REDIRECT_URI,
+        cancellationToken: uncancelableToken,
+      }).then((res) => {
+        console.log(res);
+        resolve(res);
+      });
+    });
+
+    const endpoint = document.createElement("input");
+    endpoint.value = "a17d7fac-ce06-4ede-8318-ad8dc98edd69";
+    endpoint.type = "text";
+    endpoint.placeholder = "Enter endpoint";
+    endpoint.addEventListener("input", async () => {
+      const challenge = await generateCodeChallenge(verifier);
+      link.href = getGlobusAuthorizeURL({
+        endpoint: endpoint.value,
+        code_challenge: challenge,
+        state,
+      });
+    });
+
+    // const button = document.createElement("button");
+    // button.textContent = "Submit";
+    // button.addEventListener("click", async () => {
+    //   const response = await fetch(
+    //     getGlobusTokenURL({
+    //       code: code.value,
+    //       code_verifier: verifier,
+    //     }),
+    //     {
+    //       method: "POST",
+    //     },
+    //   );
+    //   const responseJson = await response.json();
+    //   resolve({
+    //     accessToken: responseJson.access_token,
+    //     tokenType: responseJson.token_type,
+    //   });
+    // });
+
+    frag.appendChild(title);
+    frag.appendChild(lead);
+    frag.appendChild(endpoint);
+    frag.appendChild(link);
+    // frag.appendChild(button);
+
+    status.element.appendChild(frag);
+  });
+
+  try {
+    return await res;
+  } finally {
+    status.dispose();
+  }
+}
+
+export class GlobusCredentialsProvider extends CredentialsProvider<GlobusCredentials> {
+  constructor(public serverUrl: string) {
+    super();
+  }
+  get = makeCredentialsGetter(async () => {
+    const token = "";
+    const response = await fetch(`${this.serverUrl}`, {
+      method: "HEAD",
+      headers: {
+        "X-Requested-With": "XMLHttpRequest",
+        Authorization: `Bearer ${token}`,
+      },
+    });
+    switch (response.status) {
+      case 200:
+        // Token worked for the HEAD request, so it should work for GET access.
+        return { accessToken: token, tokenType: "Bearer" };
+      case 401:
+        return await waitForAuth();
+      case 403:
+        throw makeOriginError(this.serverUrl);
+      default:
+        throw HttpError.fromResponse(response);
+    }
+  });
+}
+
+// export class GlobusCredentialsProvider extends CredentialsProvider<OAuth2Credentials> {
+//   constructor(
+//     public ngauthCredentialsProvider: CredentialsProvider<Credentials>,
+//     public serverUrl: string,
+//     public bucket: string,
+//   ) {
+//     super();
+//   }
+//   get = makeCredentialsGetter(async () => {
+//     const response = await fetchWithCredentials(
+//       this.ngauthCredentialsProvider,
+//       `${this.serverUrl}/gcs_token`,
+//       { method: "POST" },
+//       responseJson,
+//       (credentials, init) => {
+//         return {
+//           ...init,
+//           body: JSON.stringify({
+//             token: credentials.token,
+//             bucket: this.bucket,
+//           }),
+//         };
+//       },
+//       (error) => {
+//         const { status } = error;
+//         if (status === 401) {
+//           return "refresh";
+//         }
+//         throw error;
+//       },
+//     );
+//     return { tokenType: "Bearer", accessToken: response.token };
+//   });
+// }

--- a/src/datasource/globus/globus_oauth2_redirect.html
+++ b/src/datasource/globus/globus_oauth2_redirect.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html>
+  <head>
+    <title>Globus OAuth Redirect</title>
+    <script>
+      const data = Object.fromEntries(
+        new URLSearchParams(location.search).entries(),
+      );
+      const target = window.opener || window.parent;
+      if (target === window) {
+        console.error("No opener/parent to receive successful oauth2 response");
+      } else {
+        console.log("Posting!", data, window.location.origin);
+        target.postMessage(data, window.location.origin);
+      }
+    </script>
+  </head>
+  <body>
+    <p>Globus authentication successful.</p>
+    <p><button onclick="window.close()">Close</button></p>
+  </body>
+</html>

--- a/src/datasource/globus/register_credentials_provider.ts
+++ b/src/datasource/globus/register_credentials_provider.ts
@@ -1,0 +1,41 @@
+/**
+ * @license
+ * Copyright 2020 Google Inc.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { defaultCredentialsManager } from "#src/credentials_provider/default_manager.js";
+// import type { CredentialsManager } from "#src/credentials_provider/index.js";
+import { GlobusCredentialsProvider } from "#src/datasource/globus/credentials_provider.js";
+
+defaultCredentialsManager.register(
+  "globus",
+  (serverUrl) => new GlobusCredentialsProvider(serverUrl),
+);
+
+// defaultCredentialsManager.register(
+//   "ngauth_gcs",
+//   (
+//     parameters: { authServer: string; bucket: string },
+//     credentialsManager: CredentialsManager,
+//   ) => {
+//     return new NgauthGcsCredentialsProvider(
+//       credentialsManager.getCredentialsProvider(
+//         "ngauth",
+//         parameters.authServer,
+//       ),
+//       parameters.authServer,
+//       parameters.bucket,
+//     );
+//   },
+// );

--- a/src/util/http_path_completion.ts
+++ b/src/util/http_path_completion.ts
@@ -116,6 +116,10 @@ const specialProtocolEmptyCompletions: CompletionWithDescription[] = [
     value: "gs+xml+ngauth+https://",
     description: "Google Cloud Storage (XML API) authenticated via ngauth",
   },
+  {
+    value: "globus+https://",
+    description: "Globus-sourced data authenticated via Globus Auth",
+  },
   { value: "s3://", description: "Amazon Simple Storage Service (S3)" },
   { value: "https://" },
   { value: "http://" },

--- a/src/util/pkce.ts
+++ b/src/util/pkce.ts
@@ -1,0 +1,186 @@
+import { OAuth2Credentials } from "#src/credentials_provider/oauth2.js";
+import { type CancellationToken, CANCELED } from "#src/util/cancellation.js";
+import { RefCounted } from "#src/util/disposable.js";
+import {
+  type OAuth2Token,
+  extractEmailFromIdToken,
+} from "#src/util/google_oauth2.js";
+import {
+  verifyObject,
+  verifyObjectProperty,
+  verifyString,
+} from "#src/util/json.js";
+
+/**
+ * Utilities related to Proof Key for Code Exchange (PKCE).
+ * @see https://oauth.net/2/pkce/
+ */
+
+/**
+ * Character set for generating random alpha-numeric strings.
+ */
+const CHARSET =
+  "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
+/**
+ * Character set allowed to be used in the PKCE `code_verifier`
+ * @see https://www.rfc-editor.org/rfc/rfc7636#section-4.1
+ */
+const PKCE_SAFE_CHARSET = `${CHARSET}-._~`;
+
+/**
+ * Create a Code Verifier for PKCE
+ * @see https://www.rfc-editor.org/rfc/rfc7636#section-4.1
+ */
+export function generateCodeVerifier(size = 43) {
+  return Array.from(crypto.getRandomValues(new Uint8Array(size)))
+    .map((v) => PKCE_SAFE_CHARSET[v % PKCE_SAFE_CHARSET.length])
+    .join("");
+}
+
+/**
+ * Base64 URL encode a string.
+ * @see https://www.oauth.com/oauth2-servers/pkce/authorization-request/
+ */
+const encode = (value: string) =>
+  btoa(value).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+
+async function sha256(input: string) {
+  const hashBuffer = await crypto.subtle.digest(
+    "SHA-256",
+    new TextEncoder().encode(input),
+  );
+  return String.fromCharCode(...new Uint8Array(hashBuffer));
+}
+
+/**
+ * Create a Code Challenge from a provided Code Verifier (assumes S256 `code_challenge_method`).
+ * @see https://www.rfc-editor.org/rfc/rfc7636#section-4.2
+ */
+export async function generateCodeChallenge(verifier: string) {
+  const hashed = await sha256(verifier);
+  return encode(hashed);
+}
+
+/**
+ * Similar to `#src/util/google_oauth2.ts` `waitForAuthResponseMessage`, but incorporates PKCE.
+ */
+export async function waitForPKCEResponseMessage({
+  source,
+  client_id,
+  verifier,
+  state,
+  redirect_uri,
+  cancellationToken,
+}: {
+  source: Window;
+  client_id: string;
+  verifier: string;
+  state: string;
+  redirect_uri: string;
+  cancellationToken: CancellationToken;
+}): Promise<OAuth2Credentials> {
+  const context = new RefCounted();
+  try {
+    return await new Promise((resolve, reject) => {
+      context.registerDisposer(cancellationToken.add(() => reject(CANCELED)));
+      console.log("Waiting for message");
+      context.registerEventListener(
+        window,
+        "message",
+        (event: MessageEvent) => {
+          console.log(event);
+
+          if (event.origin !== location.origin) {
+            return;
+          }
+
+          if (event.source !== source) return;
+
+          try {
+            const obj = verifyObject(event.data);
+            const receivedState = verifyObjectProperty(
+              obj,
+              "state",
+              verifyString,
+            );
+            if (receivedState !== state) {
+              throw new Error("invalid state");
+            }
+
+            const receivedCode = verifyObjectProperty(
+              obj,
+              "code",
+              verifyString,
+            );
+
+            if (receivedCode === undefined) {
+              throw new Error("missing code");
+            }
+
+            const payload = {
+              code: receivedCode,
+              client_id,
+              code_verifier: verifier,
+              grant_type: "authorization_code",
+              redirect_uri,
+            };
+
+            fetch("https://auth.globus.org/v2/oauth2/token", {
+              method: "POST",
+              headers: {
+                "Content-Type": "application/x-www-form-urlencoded",
+              },
+              body: new URLSearchParams(payload).toString(),
+            }).then((response) => {
+              if (!response.ok) {
+                throw new Error("Failed to exchange code for token");
+              }
+
+              response.json().then((json) => {
+                console.log(json);
+                resolve({
+                  accessToken: json.access_token,
+                  tokenType: json.token_type,
+                  // expiresIn: json.expires_in,
+                  // scope: json.scope,
+                  // email: extractEmailFromIdToken(json.id_token),
+                });
+              });
+            });
+
+            // const response = await(
+            //   await oauth2.token.exchange({
+            //     payload,
+            //   }),
+            // ).json();
+
+            // console.log(response);
+
+            // const idToken = verifyObjectProperty(obj, "id_token", verifyString);
+            // const token: OAuth2Token = {
+            //   accessToken: verifyObjectProperty(
+            //     obj,
+            //     "access_token",
+            //     verifyString,
+            //   ),
+            //   tokenType: verifyObjectProperty(obj, "token_type", verifyString),
+            //   expiresIn: verifyObjectProperty(obj, "expires_in", verifyString),
+            //   scope: verifyObjectProperty(obj, "scope", verifyString),
+            //   email: extractEmailFromIdToken(idToken),
+            // };
+            // resolve(token);
+          } catch (parseError) {
+            reject(
+              new Error(
+                `Received unexpected authentication response: ${parseError.message}`,
+              ),
+            );
+            console.error("Response received: ", event.data);
+          }
+        },
+      );
+    });
+  } finally {
+    context.dispose();
+  }
+}

--- a/src/util/special_protocol_request.ts
+++ b/src/util/special_protocol_request.ts
@@ -109,6 +109,14 @@ export function parseSpecialUrl(
         ),
         url: "gs+xml:/" + u.path,
       };
+    case "globus+https":
+      return {
+        credentialsProvider: credentialsManager.getCredentialsProvider(
+          "globus",
+          `https://${u.host}`,
+        ),
+        url: `https://${u.host}${u.path}`,
+      };
     case "middleauth+https":
       url = url.substr("middleauth+".length);
       return {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -55,9 +55,9 @@ export default (env, args) => {
           type: "asset/source",
         },
         // Needed for .html assets used for auth redirect pages for the
-        // brainmaps and bossDB data sources.
+        // brainmaps, globus, and bossDB data sources.
         {
-          test: /(bossauth|google_oauth2_redirect)\.html$/,
+          test: /(bossauth|google_oauth2_redirect|globus_oauth2_redirect)\.html$/,
           type: "asset/resource",
           generator: {
             // Filename must be preserved since exact redirect URLs must be allowlisted.


### PR DESCRIPTION
This pull request adds integration with [Globus](https://www.globus.org/). Specifically, adding the ability to source data via HTTPS on a Globus Connect Server instance, authenticated using Globus Auth.

- The `credential_provider` was created based off of the `#src/util/google_oauth2.ts` implementation and other OAuth-like credential providers (e.g. `middleauth` and `ngauth`).

The Globus credential provider uses [PKCE](https://oauth.net/2/pkce/) for the authorization flow, which I've added a few basic utilities around [^1].


[^1]: These utilities could be replaced with an external library (e.g. [`pkce-challenge`](https://www.npmjs.com/package/pkce-challenge)) if that is preferred. 