### PR TITLE
fix(layer): ensure layer references are unset when the associated layer is deleted

### DIFF
--- a/src/layer/index.ts
+++ b/src/layer/index.ts
@@ -955,6 +955,7 @@ export class LayerManager extends RefCounted {
     // Also notify the root LayerManager, to ensures the layer is removed if this is the last direct
     // reference.
     managedLayer.manager.rootLayers.layersChanged.dispatch();
+    managedLayer.manager.rootLayers.specificationChanged.dispatch();
     managedLayer.dispose();
   }
 

--- a/src/shared_disjoint_sets.ts
+++ b/src/shared_disjoint_sets.ts
@@ -67,12 +67,6 @@ export class SharedDisjointUint64Sets
     return obj;
   }
 
-  disposed() {
-    this.disjointSets = <any>undefined;
-    this.changed = <any>undefined;
-    super.disposed();
-  }
-
   link(a: Uint64, b: Uint64) {
     if (this.disjointSets.link(a, b)) {
       const { rpc } = this;


### PR DESCRIPTION
also removed disposed method on SharedDisjointUint64Sets to prevent potential "cannot read properties of undefined" errors as garbage collection benefit is likely insignificant

replaces https://github.com/google/neuroglancer/pull/664