### PR TITLE
ome.ts: update with ome-zarr 0.5

### DIFF
--- a/src/datasource/zarr/frontend.ts
+++ b/src/datasource/zarr/frontend.ts
@@ -501,7 +501,7 @@ export class ZarrDataSource extends DataSourceProvider {
         let multiscaleInfo: ZarrMultiscaleInfo;
         if (metadata.nodeType === "group") {
           // May be an OME-zarr multiscale dataset.
-          const multiscale = parseOmeMetadata(url, metadata.userAttributes, this.zarrVersion);
+          const multiscale = parseOmeMetadata(url, metadata.userAttributes, metadata.zarrVersion);
           if (multiscale === undefined) {
             throw new Error("Neithre array nor OME multiscale metadata found");
           }

--- a/src/datasource/zarr/frontend.ts
+++ b/src/datasource/zarr/frontend.ts
@@ -504,7 +504,8 @@ export class ZarrDataSource extends DataSourceProvider {
           const multiscale = parseOmeMetadata(
             url,
             metadata.userAttributes,
-            metadata.zarrVersion);
+            metadata.zarrVersion,
+          );
           if (multiscale === undefined) {
             throw new Error("Neithre array nor OME multiscale metadata found");
           }

--- a/src/datasource/zarr/frontend.ts
+++ b/src/datasource/zarr/frontend.ts
@@ -501,7 +501,10 @@ export class ZarrDataSource extends DataSourceProvider {
         let multiscaleInfo: ZarrMultiscaleInfo;
         if (metadata.nodeType === "group") {
           // May be an OME-zarr multiscale dataset.
-          const multiscale = parseOmeMetadata(url, metadata.userAttributes, metadata.zarrVersion);
+          const multiscale = parseOmeMetadata(
+            url,
+            metadata.userAttributes,
+            metadata.zarrVersion);
           if (multiscale === undefined) {
             throw new Error("Neithre array nor OME multiscale metadata found");
           }

--- a/src/datasource/zarr/frontend.ts
+++ b/src/datasource/zarr/frontend.ts
@@ -501,7 +501,7 @@ export class ZarrDataSource extends DataSourceProvider {
         let multiscaleInfo: ZarrMultiscaleInfo;
         if (metadata.nodeType === "group") {
           // May be an OME-zarr multiscale dataset.
-          const multiscale = parseOmeMetadata(url, metadata.userAttributes);
+          const multiscale = parseOmeMetadata(url, metadata.userAttributes, this.zarrVersion);
           if (multiscale === undefined) {
             throw new Error("Neithre array nor OME multiscale metadata found");
           }

--- a/src/datasource/zarr/ome.ts
+++ b/src/datasource/zarr/ome.ts
@@ -268,7 +268,7 @@ export function parseOmeMetadata(
   zarrVersion: number,
 ): OmeMultiscaleMetadata | undefined {
   const ome = attrs.ome;
-  const multiscales = (ome == undefined) ? attrs.multiscales : ome.multiscales; // >0.4
+  const multiscales = ome == undefined ? attrs.multiscales : ome.multiscales; // >0.4
 
   if (!Array.isArray(multiscales)) return undefined;
   const errors: string[] = [];
@@ -282,7 +282,7 @@ export function parseOmeMetadata(
       return undefined;
     }
 
-    const version = (ome == undefined) ? multiscale.version : ome.version; // >0.4
+    const version = ome == undefined ? multiscale.version : ome.version; // >0.4
 
     if (version === undefined) return undefined;
     if (!SUPPORTED_OME_MULTISCALE_VERSIONS.has(version)) {

--- a/src/datasource/zarr/ome.ts
+++ b/src/datasource/zarr/ome.ts
@@ -265,9 +265,11 @@ function parseOmeMultiscale(
 export function parseOmeMetadata(
   url: string,
   attrs: any,
+  zarrVersion: number,
 ): OmeMultiscaleMetadata | undefined {
+
   const ome = attrs.ome;
-  const multiscales = (ome == undefined) ? attrs.multiscales : ome.multiscales; // >0.4
+  const multiscales = (zarrVersion === 2) ? attrs.multiscales : ome.multiscales; // >0.4
 
   if (!Array.isArray(multiscales)) return undefined;
   const errors: string[] = [];
@@ -281,7 +283,7 @@ export function parseOmeMetadata(
       return undefined;
     }
 
-    const version = (ome == undefined) ? multiscale.version : ome.version; // >0.4
+    const version = (zarrVersion === 2) ? multiscale.version : ome.version; // >0.4
 
     if (version === undefined) return undefined;
     if (!SUPPORTED_OME_MULTISCALE_VERSIONS.has(version)) {
@@ -292,7 +294,7 @@ export function parseOmeMetadata(
       );
       continue;
     }
-    return parseOmeMultiscale(url, multiscale);
+    return parseOmeMultiscale(url, multiscale, zarrVersion);
   }
   if (errors.length !== 0) {
     throw new Error(errors[0]);

--- a/src/datasource/zarr/ome.ts
+++ b/src/datasource/zarr/ome.ts
@@ -39,7 +39,7 @@ export interface OmeMultiscaleMetadata {
   coordinateSpace: CoordinateSpace;
 }
 
-const SUPPORTED_OME_MULTISCALE_VERSIONS = new Set(["0.4", "0.5-dev"]);
+const SUPPORTED_OME_MULTISCALE_VERSIONS = new Set(["0.4", "0.5-dev", "0.5"]);
 
 const OME_UNITS = new Map<string, { unit: string; scale: number }>([
   ["angstrom", { unit: "m", scale: 1e-10 }],
@@ -266,7 +266,9 @@ export function parseOmeMetadata(
   url: string,
   attrs: any,
 ): OmeMultiscaleMetadata | undefined {
-  const multiscales = attrs.multiscales;
+  const ome = attrs.ome;
+  const multiscales = (ome == undefined) ? attrs.multiscales : ome.multiscales; // >0.4
+
   if (!Array.isArray(multiscales)) return undefined;
   const errors: string[] = [];
   for (const multiscale of multiscales) {
@@ -278,7 +280,9 @@ export function parseOmeMetadata(
       // Not valid OME multiscale spec.
       return undefined;
     }
-    const version = multiscale.version;
+
+    const version = (ome == undefined) ? multiscale.version : ome.version; // >0.4
+
     if (version === undefined) return undefined;
     if (!SUPPORTED_OME_MULTISCALE_VERSIONS.has(version)) {
       errors.push(

--- a/src/datasource/zarr/ome.ts
+++ b/src/datasource/zarr/ome.ts
@@ -267,9 +267,8 @@ export function parseOmeMetadata(
   attrs: any,
   zarrVersion: number,
 ): OmeMultiscaleMetadata | undefined {
-
   const ome = attrs.ome;
-  const multiscales = (zarrVersion === 2) ? attrs.multiscales : ome.multiscales; // >0.4
+  const multiscales = (ome == undefined) ? attrs.multiscales : ome.multiscales; // >0.4
 
   if (!Array.isArray(multiscales)) return undefined;
   const errors: string[] = [];
@@ -283,7 +282,7 @@ export function parseOmeMetadata(
       return undefined;
     }
 
-    const version = (zarrVersion === 2) ? multiscale.version : ome.version; // >0.4
+    const version = (ome == undefined) ? multiscale.version : ome.version; // >0.4
 
     if (version === undefined) return undefined;
     if (!SUPPORTED_OME_MULTISCALE_VERSIONS.has(version)) {
@@ -294,7 +293,15 @@ export function parseOmeMetadata(
       );
       continue;
     }
-    return parseOmeMultiscale(url, multiscale, zarrVersion);
+    if (version === "0.5" && zarrVersion !== 3) {
+      errors.push(
+        `OME multiscale metadata version ${JSON.stringify(
+          version,
+        )} is not supported for zarr v${zarrVersion}`,
+      );
+      continue;
+    }
+    return parseOmeMultiscale(url, multiscale);
   }
   if (errors.length !== 0) {
     throw new Error(errors[0]);


### PR DESCRIPTION
[RFC-2](https://ngff.openmicroscopy.org/rfc/2) has now been adopted. In preparation for the OME-Zarr 0.5 release, this PR wraps the NGFF metadata in the Zarr metadata within an "ome" block. This checks for that block and if it exists unwraps the necessary metadata if the Zarr version is 3.

Originally opened as #616 

cc: @normanrz