### PR TITLE
feat(annotation) Add default annotation properties

### DIFF
--- a/src/annotation/index.ts
+++ b/src/annotation/index.ts
@@ -18,6 +18,7 @@
  * @file Basic annotation data structures.
  */
 
+import { vec3 } from "gl-matrix";
 import type {
   BoundingBox,
   CoordinateSpaceTransform,
@@ -695,6 +696,13 @@ export interface AnnotationTypeHandler<T extends Annotation = Annotation> {
     annotation: T,
     callback: (vec: Float32Array, isVector: boolean) => void,
   ) => void;
+  defaultProperties: (
+    annotation: T,
+    scales: vec3,
+  ) => {
+    properties: AnnotationNumericPropertySpec[];
+    values: number[];
+  };
 }
 
 function serializeFloatVector(
@@ -814,6 +822,24 @@ export const annotationTypeHandlers: Record<
       callback(annotation.pointA, false);
       callback(annotation.pointB, false);
     },
+    defaultProperties(annotation: Line, scales: vec3) {
+      return {
+        properties: [
+          {
+            type: "float32",
+            identifier: "Length",
+            default: 0,
+            description: "Length of the line annotation in nanometers",
+          },
+        ],
+        values: [
+          vec3.dist(
+            vec3.mul(vec3.create(), scales, annotation.pointA as vec3),
+            vec3.mul(vec3.create(), scales, annotation.pointB as vec3),
+          ),
+        ],
+      };
+    },
   },
   [AnnotationType.POINT]: {
     icon: "⚬",
@@ -857,6 +883,11 @@ export const annotationTypeHandlers: Record<
     },
     visitGeometry(annotation: Point, callback) {
       callback(annotation.point, false);
+    },
+    defaultProperties(annotation: Point, scales: vec3) {
+      annotation;
+      scales;
+      return { properties: [], values: [] };
     },
   },
   [AnnotationType.AXIS_ALIGNED_BOUNDING_BOX]: {
@@ -926,6 +957,11 @@ export const annotationTypeHandlers: Record<
       callback(annotation.pointA, false);
       callback(annotation.pointB, false);
     },
+    defaultProperties(annotation: AxisAlignedBoundingBox, scales: vec3) {
+      annotation;
+      scales;
+      return { properties: [], values: [] };
+    },
   },
   [AnnotationType.ELLIPSOID]: {
     icon: "◎",
@@ -993,6 +1029,11 @@ export const annotationTypeHandlers: Record<
     visitGeometry(annotation: Ellipsoid, callback) {
       callback(annotation.center, false);
       callback(annotation.radii, true);
+    },
+    defaultProperties(annotation: Ellipsoid, scales: vec3) {
+      annotation;
+      scales;
+      return { properties: [], values: [] };
     },
   },
 };

--- a/src/annotation/index.ts
+++ b/src/annotation/index.ts
@@ -55,6 +55,7 @@ import {
 import { parseDataTypeValue } from "#src/util/lerp.js";
 import { getRandomHexString } from "#src/util/random.js";
 import { NullarySignal, Signal } from "#src/util/signal.js";
+import { formatLength } from "#src/util/spatial_units.js";
 import { Uint64 } from "#src/util/uint64.js";
 
 export type AnnotationId = string;
@@ -107,6 +108,7 @@ export interface AnnotationNumericPropertySpec
   min?: number;
   max?: number;
   step?: number;
+  format?: (x: number) => string;
 }
 
 export const propertyTypeDataType: Record<
@@ -497,6 +499,9 @@ export function formatNumericProperty(
   property: AnnotationNumericPropertySpec,
   value: number,
 ): string {
+  if (property.format) {
+    return property.format(value);
+  }
   const formattedValue =
     property.type === "float32" ? value.toPrecision(6) : value.toString();
   const { enumValues, enumLabels } = property;
@@ -830,6 +835,7 @@ export const annotationTypeHandlers: Record<
             identifier: "Length",
             default: 0,
             description: "Length of the line annotation in nanometers",
+            format: formatLength,
           },
         ],
         values: [

--- a/src/annotation/index.ts
+++ b/src/annotation/index.ts
@@ -703,6 +703,7 @@ export interface AnnotationTypeHandler<T extends Annotation = Annotation> {
   ) => void;
   defaultProperties: (
     annotation: T,
+    layerPosition: Float32Array<ArrayBufferLike>[],
     scales: Float64Array,
     units: readonly string[],
   ) => {
@@ -766,12 +767,16 @@ function deserializeTwoFloatVectors(
 }
 
 function lineLength(
-  line: Line,
+  annotationLayerPositions: Float32Array<ArrayBufferLike>[],
   scales: Float64Array,
   units: readonly string[],
 ) {
+  if (annotationLayerPositions.length !== 2) {
+    return;
+  }
+  const [pointA, pointB] = annotationLayerPositions;
   const scalesRank = scales.length;
-  const lineRank = line.pointA.length;
+  const lineRank = pointA.length;
   if (scalesRank < lineRank) {
     return;
   }
@@ -782,8 +787,7 @@ function lineLength(
       return;
     }
     const voxelToNanometers = scales[dim] * unitInfo.lengthInNanometers;
-    lengthSquared +=
-      ((line.pointA[dim] - line.pointB[dim]) * voxelToNanometers) ** 2;
+    lengthSquared += ((pointA[dim] - pointB[dim]) * voxelToNanometers) ** 2;
   }
   return Math.sqrt(lengthSquared);
 }
@@ -853,12 +857,14 @@ export const annotationTypeHandlers: Record<
     },
     defaultProperties(
       annotation: Line,
+      annotationLayerPositions: Float32Array<ArrayBufferLike>[],
       scales: Float64Array,
       units: readonly string[],
     ) {
+      annotation;
       const properties: AnnotationNumericPropertySpec[] = [];
       const values: number[] = [];
-      const length = lineLength(annotation, scales, units);
+      const length = lineLength(annotationLayerPositions, scales, units);
       if (length) {
         properties.push({
           type: "float32",
@@ -917,10 +923,12 @@ export const annotationTypeHandlers: Record<
     },
     defaultProperties(
       annotation: Point,
+      layerPosition: Float32Array<ArrayBufferLike>[],
       scales: Float64Array,
       units: string[],
     ) {
       annotation;
+      layerPosition;
       scales;
       units;
       return { properties: [], values: [] };
@@ -995,10 +1003,12 @@ export const annotationTypeHandlers: Record<
     },
     defaultProperties(
       annotation: AxisAlignedBoundingBox,
+      layerPosition: Float32Array<ArrayBufferLike>[],
       scales: Float64Array,
       units: string[],
     ) {
       annotation;
+      layerPosition;
       scales;
       units;
       return { properties: [], values: [] };
@@ -1073,10 +1083,12 @@ export const annotationTypeHandlers: Record<
     },
     defaultProperties(
       annotation: Ellipsoid,
+      layerPosition: Float32Array<ArrayBufferLike>[],
       scales: Float64Array,
       units: string[],
     ) {
       annotation;
+      layerPosition;
       scales;
       units;
       return { properties: [], values: [] };

--- a/src/ui/annotations.ts
+++ b/src/ui/annotations.ts
@@ -1783,6 +1783,8 @@ export function UserLayerWithAnnotationsMixin<
                 icon.textContent = handler.icon;
                 positionGrid.appendChild(icon);
 
+                const annotationLayerPositions: Float32Array<ArrayBufferLike>[] =
+                  [];
                 if (layerRank !== 0) {
                   const { layerDimensionNames } = (
                     chunkTransform as ChunkTransformParameters
@@ -1800,6 +1802,7 @@ export function UserLayerWithAnnotationsMixin<
                     annotation,
                     chunkTransform as ChunkTransformParameters,
                     (layerPosition, isVector) => {
+                      annotationLayerPositions.push(layerPosition);
                       const copyButton = makeCopyButton({
                         title: "Copy position",
                         onClick: () => {
@@ -1860,6 +1863,7 @@ export function UserLayerWithAnnotationsMixin<
                   annotation.type
                 ].defaultProperties(
                   annotation,
+                  annotationLayerPositions,
                   globalCoordinateSpace.scales,
                   globalCoordinateSpace.units,
                 );

--- a/src/ui/annotations.ts
+++ b/src/ui/annotations.ts
@@ -1856,12 +1856,9 @@ export function UserLayerWithAnnotationsMixin<
                 const sourceReadonly = annotationLayer.source.readonly;
                 const globalCoordinateSpace =
                   this.manager.root.coordinateSpace.value;
-                const scales = new Float32Array(
-                  globalCoordinateSpace.scales.map((x) => x / 1e-9),
-                ) as vec3;
                 const defaultProperties = annotationTypeHandlers[
                   annotation.type
-                ].defaultProperties(annotation, scales);
+                ].defaultProperties(annotation, globalCoordinateSpace.scales);
                 const allProperties = [
                   ...defaultProperties.properties,
                   ...properties,

--- a/src/ui/annotations.ts
+++ b/src/ui/annotations.ts
@@ -1854,6 +1854,22 @@ export function UserLayerWithAnnotationsMixin<
 
                 const { relationships, properties } = annotationLayer.source;
                 const sourceReadonly = annotationLayer.source.readonly;
+                const globalCoordinateSpace =
+                  this.manager.root.coordinateSpace.value;
+                const scales = new Float32Array(
+                  globalCoordinateSpace.scales.map((x) => x / 1e-9),
+                ) as vec3;
+                const defaultProperties = annotationTypeHandlers[
+                  annotation.type
+                ].defaultProperties(annotation, scales);
+                const allProperties = [
+                  ...defaultProperties.properties,
+                  ...properties,
+                ];
+                const allValues = [
+                  ...defaultProperties.values,
+                  ...annotation.properties,
+                ];
 
                 // Add the ID to the annotation details.
                 const label = document.createElement("label");
@@ -1872,8 +1888,10 @@ export function UserLayerWithAnnotationsMixin<
                 label.appendChild(valueElement);
                 parent.appendChild(label);
 
-                for (let i = 0, count = properties.length; i < count; ++i) {
-                  const property = properties[i];
+                for (let i = 0, count = allProperties.length; i < count; ++i) {
+                  const property = allProperties[i];
+                  const value = allValues[i];
+
                   const label = document.createElement("label");
                   label.classList.add("neuroglancer-annotation-property");
                   const idElement = document.createElement("span");
@@ -1886,7 +1904,6 @@ export function UserLayerWithAnnotationsMixin<
                   if (description !== undefined) {
                     label.title = description;
                   }
-                  const value = annotation.properties[i];
                   const valueElement = document.createElement("span");
                   valueElement.classList.add(
                     "neuroglancer-annotation-property-value",

--- a/src/ui/annotations.ts
+++ b/src/ui/annotations.ts
@@ -1858,7 +1858,11 @@ export function UserLayerWithAnnotationsMixin<
                   this.manager.root.coordinateSpace.value;
                 const defaultProperties = annotationTypeHandlers[
                   annotation.type
-                ].defaultProperties(annotation, globalCoordinateSpace.scales);
+                ].defaultProperties(
+                  annotation,
+                  globalCoordinateSpace.scales,
+                  globalCoordinateSpace.units,
+                );
                 const allProperties = [
                   ...defaultProperties.properties,
                   ...properties,


### PR DESCRIPTION
add line length property

This came up during a meeting that the scale bar has been used as a rough measure of the size of features in datasets. I was thinking we should have a better way to measure distance and the line annotation is already a tool that has most of the requirements.

I think it would also make sense to add additional properties for other types such as ellipsoid volume and semi axis lengths, bounding box volume and dimensions.

I am currently making assumptions to cast float32array to a vec3 and there might be a better method of using the globalCoordinateSpace.