### PR TITLE
chore(lint): Use oxlint in addition to eslint

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -1,0 +1,60 @@
+{
+  "$schema": "./node_modules/oxlint/configuration_schema.json",
+  "plugins": ["import", "typescript", "oxc", "unicorn", "promise", "vitest"],
+  "env": {
+    "browser": true
+  },
+  "settings": {},
+  "rules": {
+    // Seems to be buggy
+    "no-loss-of-precision": "off",
+    "import/no-cycle": "error",
+    "import/first": "error",
+    "no-unsafe-finally": "off",
+    "require-yield": "off",
+    "@typescript-eslint/no-explicit-any": "off",
+    "@typescript-eslint/no-non-null-assertion": "off",
+    "@typescript-eslint/no-inferrable-types": "off",
+    "@typescript-eslint/no-this-alias": "off",
+    "@typescript-eslint/no-empty-function": "off",
+    "@typescript-eslint/no-empty-interface": "off",
+    "erasing-op": "off",
+    "no-unused-vars": [
+      "error",
+      {
+        "argsIgnorePattern": "^_",
+        "varsIgnorePattern": "^_",
+        "ignoreRestSiblings": true
+      }
+    ],
+    "no-new-array": "off",
+    "no-document-cookie": "off",
+    "@typescript-eslint/consistent-type-imports": "error"
+  },
+  "overrides": [
+    {
+      "files": ["*.test.ts", "*.spec.ts"],
+      "rules": {
+        "@typescript-eslint/no-explicit-any": "off"
+      }
+    }
+  ],
+  "ignorePatterns": [
+    "**/node_modules",
+    "**/dist",
+    "**/python",
+    "templates/neuroglancer/sliceview",
+    "src/third_party/jpgjs/jpg.js",
+    "**/templates",
+    "**/build",
+    "**/.tox",
+    "**/.nox",
+    "lib",
+    "**/python",
+    "**/config",
+    "**/typings",
+    "src/mesh/draco/stub.js",
+    "**/tsconfig.tsbuildinfo",
+    "examples"
+  ]
+}

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -55,6 +55,8 @@ export default tseslint.config(
 
       "no-constant-condition": "off",
 
+      "no-unused-disable": "off",
+
       "@typescript-eslint/no-unused-vars": [
         "error",
         {
@@ -69,19 +71,16 @@ export default tseslint.config(
       "no-unsafe-finally": "off",
       "require-yield": "off",
       "no-inner-declarations": "off",
+
+      // Supported by oxlint
+      "import/namespace": "off",
+      "import/default": "off",
+
       "import/no-named-as-default": "off",
       "import/no-named-as-default-member": "off",
-      "import/no-cycle": [
-        "error",
-        {
-          ignoreExternal: true,
-          disableScc: true,
-        },
-      ],
       "@typescript-eslint/consistent-type-imports": "error",
       "import/no-unresolved": "error",
       "import/no-extraneous-dependencies": "error",
-      "import/first": "error",
 
       "import/order": [
         "error",

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,8 +40,10 @@
         "css-loader": "^7.1.2",
         "esbuild": "^0.24.2",
         "eslint": "^9.18.0",
+        "eslint-formatter-codeframe": "^7.32.1",
         "eslint-import-resolver-typescript": "^3.7.0",
         "eslint-plugin-import": "^2.31.0",
+        "eslint-plugin-oxlint": "^0.15.7",
         "eslint-rspack-plugin": "^4.2.1",
         "express": "^4.21.2",
         "glob": "^11.0.1",
@@ -49,6 +51,7 @@
         "jsdom": "^26.0.0",
         "msw": "^2.7.0",
         "nunjucks": "^3.2.4",
+        "oxlint": "^0.15.7",
         "playwright": "^1.49.1",
         "prettier": "3.4.2",
         "s3rver": "^3.7.1",
@@ -117,6 +120,100 @@
       "dev": true,
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/highlight": {
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.25.9.tgz",
+      "integrity": "sha512-llL88JShoCsth8fF8R4SJnIn+WLvR6ccFxu1H3FlMhDontdcmZWf2HgIZ7AIqV3Xcck1idlohrN4EUBQz6klbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.25.9",
+        "chalk": "^2.4.2",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/highlight/node_modules/ansi-styles": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/@babel/highlight/node_modules/chalk": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/@babel/highlight/node_modules/color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "1.1.3"
+      }
+    },
+    "node_modules/@babel/highlight/node_modules/color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@babel/highlight/node_modules/escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/@babel/highlight/node_modules/has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/@babel/highlight/node_modules/supports-color": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/@babel/runtime": {
@@ -1481,6 +1578,118 @@
       "resolved": "https://registry.npmjs.org/@open-draft/until/-/until-2.1.0.tgz",
       "integrity": "sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==",
       "dev": true
+    },
+    "node_modules/@oxlint/darwin-arm64": {
+      "version": "0.15.7",
+      "resolved": "https://registry.npmjs.org/@oxlint/darwin-arm64/-/darwin-arm64-0.15.7.tgz",
+      "integrity": "sha512-+8jOC9MfzIhbRdmNYl+gLlGZe8dhl2hrQRLJ+mriPRXxtpfBmT5aOmEQrs9BX5GPnh6hy4ArMvjDbCCXD+bl+w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@oxlint/darwin-x64": {
+      "version": "0.15.7",
+      "resolved": "https://registry.npmjs.org/@oxlint/darwin-x64/-/darwin-x64-0.15.7.tgz",
+      "integrity": "sha512-4y1v3zCtQU0dv5SxwBZqtYiqtQTUSvEdK3XzWg/JxN8qEleHonQrbSvGKmlkzraEouKTIm1bXjmnrX26MX22cQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@oxlint/linux-arm64-gnu": {
+      "version": "0.15.7",
+      "resolved": "https://registry.npmjs.org/@oxlint/linux-arm64-gnu/-/linux-arm64-gnu-0.15.7.tgz",
+      "integrity": "sha512-g01PWQl1+HLlMGK3lwH8G+A/5vA6H7tcKUHnx/qGz4+LM1zKfp1w2d2aoXxPqpIgtBPn19JRcBiEMv+nr40fiw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@oxlint/linux-arm64-musl": {
+      "version": "0.15.7",
+      "resolved": "https://registry.npmjs.org/@oxlint/linux-arm64-musl/-/linux-arm64-musl-0.15.7.tgz",
+      "integrity": "sha512-8Dg7qaHXNgiZgP3TxQU8k/5fpzGfcxYVLK58Sj/vSZ3vMrI68ipkq+rkNBjAXT1Aq2/eM6L/9CLH8pex+I1Nkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@oxlint/linux-x64-gnu": {
+      "version": "0.15.7",
+      "resolved": "https://registry.npmjs.org/@oxlint/linux-x64-gnu/-/linux-x64-gnu-0.15.7.tgz",
+      "integrity": "sha512-hLsfcOgoky/FUGF2s3v7+wd0xGGuyE7EBPSTV7BPQYEm5+P5ZeWXPlUg8uTPee6bIxHa6lZLqunRl8Jn44b/ig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@oxlint/linux-x64-musl": {
+      "version": "0.15.7",
+      "resolved": "https://registry.npmjs.org/@oxlint/linux-x64-musl/-/linux-x64-musl-0.15.7.tgz",
+      "integrity": "sha512-BW9dACxzLRZq67lPFis/NCiitQucZbbrONeK0mReBWPSM3MaegLY82kZU7sMq3fpBbzGaKFoNLp2EcsNfS5IVw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@oxlint/win32-arm64": {
+      "version": "0.15.7",
+      "resolved": "https://registry.npmjs.org/@oxlint/win32-arm64/-/win32-arm64-0.15.7.tgz",
+      "integrity": "sha512-VvIaIdfCjcYy8cj3yAjHwj2dDFIFxdUS7G+KeDK/iH7O3uXW8wOec2wFYcd8xmVYHEcnw8fgNAXy04gXpB6KnQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@oxlint/win32-x64": {
+      "version": "0.15.7",
+      "resolved": "https://registry.npmjs.org/@oxlint/win32-x64/-/win32-x64-0.15.7.tgz",
+      "integrity": "sha512-1WKZTgtJswATA8NYeUfMnN4ei7AUVyomrWBiPwYGMRMOo4jeGkOlOr2/iYq/vbtOCyOuqAo2JjfzN5sBOPfI/A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
     },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
@@ -4534,9 +4743,9 @@
       "integrity": "sha512-9o5UecI3GhkpM6DrXr69PblIuWxPKk9Y0jHBRhdocZ2y7YECBFCsHm79Pr3OyR2AvjhDkabFJaDJMYRazHgsow=="
     },
     "node_modules/browserslist": {
-      "version": "4.24.2",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.24.2.tgz",
-      "integrity": "sha512-ZIc+Q62revdMcqC6aChtW4jz3My3klmCO1fEmINZY/8J3EpBg5/A/D0AKmBveUh6pgoeycoMkVMko84tuYS+Gg==",
+      "version": "4.24.4",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.24.4.tgz",
+      "integrity": "sha512-KDi1Ny1gSePi1vm0q4oxSF8b4DR44GF4BbmS2YdhPLOEqd8pDviZOGH/GsmRwoWJ2+5Lr085X7naowMwKHDG1A==",
       "dev": true,
       "funding": [
         {
@@ -4552,12 +4761,13 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "license": "MIT",
       "optional": true,
       "peer": true,
       "dependencies": {
-        "caniuse-lite": "^1.0.30001669",
-        "electron-to-chromium": "^1.5.41",
-        "node-releases": "^2.0.18",
+        "caniuse-lite": "^1.0.30001688",
+        "electron-to-chromium": "^1.5.73",
+        "node-releases": "^2.0.19",
         "update-browserslist-db": "^1.1.1"
       },
       "bin": {
@@ -4728,9 +4938,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001687",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001687.tgz",
-      "integrity": "sha512-0S/FDhf4ZiqrTUiQ39dKeUjYRjkv7lOZU1Dgif2rIqrTzX/1wV2hfKu9TOm1IHkdSijfLswxTFzl/cvir+SLSQ==",
+      "version": "1.0.30001695",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001695.tgz",
+      "integrity": "sha512-vHyLade6wTgI2u1ec3WQBxv+2BrTERV28UXQu9LO6lZ9pYeMk34vjXFLOxo1A4UBA8XTL4njRQZdno/yYaSmWw==",
       "dev": true,
       "funding": [
         {
@@ -4745,7 +4955,8 @@
           "type": "github",
           "url": "https://github.com/sponsors/ai"
         }
-      ]
+      ],
+      "license": "CC-BY-4.0"
     },
     "node_modules/caseless": {
       "version": "0.12.0",
@@ -6209,10 +6420,11 @@
       "dev": true
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.72",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.72.tgz",
-      "integrity": "sha512-ZpSAUOZ2Izby7qnZluSrAlGgGQzucmFbN0n64dYzocYxnxV5ufurpj3VgEe4cUp7ir9LmeLxNYo8bVnlM8bQHw==",
+      "version": "1.5.83",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.83.tgz",
+      "integrity": "sha512-LcUDPqSt+V0QmI47XLzZrz5OqILSMGsPFkDYus22rIbgorSvBYEFqq854ltTmUdHkY92FSdAAvsh4jWEULMdfQ==",
       "dev": true,
+      "license": "ISC",
       "optional": true,
       "peer": true
     },
@@ -6589,6 +6801,30 @@
         }
       }
     },
+    "node_modules/eslint-formatter-codeframe": {
+      "version": "7.32.1",
+      "resolved": "https://registry.npmjs.org/eslint-formatter-codeframe/-/eslint-formatter-codeframe-7.32.1.tgz",
+      "integrity": "sha512-DK/3Q3+zVKq/7PdSYiCxPrsDF8H/TRMK5n8Hziwr4IMkMy+XiKSwbpj25AdajS63I/B61Snetq4uVvX9fOLyAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "7.12.11",
+        "chalk": "^4.0.0"
+      },
+      "engines": {
+        "node": "^10.12.0 || >=12.0.0"
+      }
+    },
+    "node_modules/eslint-formatter-codeframe/node_modules/@babel/code-frame": {
+      "version": "7.12.11",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.11.tgz",
+      "integrity": "sha512-Zt1yodBx1UcyiePMSkWnU4hPqhwq7hGi2nFL1LeA3EUl+q2LQx16MISgJ0+z7dnmgvP9QtIleuETGOiOH1RcIw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/highlight": "^7.10.4"
+      }
+    },
     "node_modules/eslint-import-resolver-node": {
       "version": "0.3.9",
       "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.9.tgz",
@@ -6753,6 +6989,16 @@
       "dev": true,
       "bin": {
         "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/eslint-plugin-oxlint": {
+      "version": "0.15.7",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-oxlint/-/eslint-plugin-oxlint-0.15.7.tgz",
+      "integrity": "sha512-u/Abrwh/6uu533ofqKlzmZra8ezgoMfUpRJ4I0UQmque/TqDPa+WSbdTLqRopmuTtBExUKJ4/jnyrFB3jk4GOg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "jsonc-parser": "^3.3.1"
       }
     },
     "node_modules/eslint-rspack-plugin": {
@@ -6965,10 +7211,11 @@
       }
     },
     "node_modules/esquery": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.5.0.tgz",
-      "integrity": "sha512-YQLXUplAwJgCydQ78IMJywZCceoqk1oH01OERdSAJc/7U2AylwjhSCLDEtqwg811idIS/9fIU5GjG73IgjKMVg==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.6.0.tgz",
+      "integrity": "sha512-ca9pw9fomFcKPvFLXhBKUK90ZvGibiGOvRJNbjljY7s7uq/5YO4BOzcYtJqExdx99rF6aAcnRxHmcUHcz6sQsg==",
       "dev": true,
+      "license": "BSD-3-Clause",
       "dependencies": {
         "estraverse": "^5.1.0"
       },
@@ -9652,6 +9899,13 @@
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
       "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA=="
     },
+    "node_modules/jsonc-parser": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.3.1.tgz",
+      "integrity": "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/jsonfile": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
@@ -10846,6 +11100,33 @@
       "resolved": "https://registry.npmjs.org/outvariant/-/outvariant-1.4.3.tgz",
       "integrity": "sha512-+Sl2UErvtsoajRDKCE5/dBz4DIvHXQQnAxtQTF04OJxY0+DyZXSo5P5Bb7XYWOh81syohlYL24hbDwxedPUJCA==",
       "dev": true
+    },
+    "node_modules/oxlint": {
+      "version": "0.15.7",
+      "resolved": "https://registry.npmjs.org/oxlint/-/oxlint-0.15.7.tgz",
+      "integrity": "sha512-ECx9retPd7Rvq62TasGODyQ4mrMtqBCCB18xOYGiAf8PP61snHaokLeTWQFf+pTURWpJZ9pIi2pMIDKh2P2SpQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "oxc_language_server": "bin/oxc_language_server",
+        "oxlint": "bin/oxlint"
+      },
+      "engines": {
+        "node": ">=14.*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      },
+      "optionalDependencies": {
+        "@oxlint/darwin-arm64": "0.15.7",
+        "@oxlint/darwin-x64": "0.15.7",
+        "@oxlint/linux-arm64-gnu": "0.15.7",
+        "@oxlint/linux-arm64-musl": "0.15.7",
+        "@oxlint/linux-x64-gnu": "0.15.7",
+        "@oxlint/linux-x64-musl": "0.15.7",
+        "@oxlint/win32-arm64": "0.15.7",
+        "@oxlint/win32-x64": "0.15.7"
+      }
     },
     "node_modules/p-limit": {
       "version": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -32,8 +32,8 @@
     "test:watch": "vitest watch",
     "benchmark": "vitest bench --run",
     "benchmark:watch": "vitest bench",
-    "lint:check": "eslint .",
-    "lint:fix": "eslint . --fix",
+    "lint:check": "oxlint && eslint . --cache --format codeframe",
+    "lint:fix": "oxlint --fix && eslint . --cache --fix --format codeframe && prettier --cache -w -l .",
     "format:check": "prettier --cache . -c",
     "format:fix": "prettier --cache -w -l .",
     "typecheck": "tsc --noEmit",
@@ -62,8 +62,10 @@
     "css-loader": "^7.1.2",
     "esbuild": "^0.24.2",
     "eslint": "^9.18.0",
+    "eslint-formatter-codeframe": "^7.32.1",
     "eslint-import-resolver-typescript": "^3.7.0",
     "eslint-plugin-import": "^2.31.0",
+    "eslint-plugin-oxlint": "^0.15.7",
     "eslint-rspack-plugin": "^4.2.1",
     "express": "^4.21.2",
     "glob": "^11.0.1",
@@ -71,6 +73,7 @@
     "jsdom": "^26.0.0",
     "msw": "^2.7.0",
     "nunjucks": "^3.2.4",
+    "oxlint": "^0.15.7",
     "playwright": "^1.49.1",
     "prettier": "3.4.2",
     "s3rver": "^3.7.1",
@@ -251,12 +254,6 @@
       "neuroglancer/datasource:none_by_default": "./src/util/false.ts",
       "neuroglancer/datasource/n5:disabled": "./src/util/false.ts",
       "default": "./src/datasource/n5/register_default.ts"
-    },
-    "#datasource/nggraph/backend": {
-      "neuroglancer/datasource/nggraph:enabled": "./src/datasource/nggraph/backend.ts",
-      "neuroglancer/datasource:none_by_default": "./src/util/false.ts",
-      "neuroglancer/datasource/nggraph:disabled": "./src/util/false.ts",
-      "default": "./src/datasource/nggraph/backend.ts"
     },
     "#datasource/nggraph/register_default": {
       "neuroglancer/datasource/nggraph:enabled": "./src/datasource/nggraph/register_default.ts",

--- a/src/annotation/bounding_box.ts
+++ b/src/annotation/bounding_box.ts
@@ -37,7 +37,7 @@ import type { SliceViewPanelRenderContext } from "#src/sliceview/renderlayer.js"
 import { tile2dArray } from "#src/util/array.js";
 import { getViewFrustrumWorldBounds, mat4 } from "#src/util/geom.js";
 import { CORNERS_PER_BOX, EDGES_PER_BOX } from "#src/webgl/bounding_box.js";
-import { Buffer } from "#src/webgl/buffer.js";
+import { GLBuffer } from "#src/webgl/buffer.js";
 import {
   defineCircleShader,
   drawCircles,
@@ -293,7 +293,7 @@ void setBoundingBoxFillColor(vec4 color) {
 
 class PerspectiveViewRenderHelper extends RenderHelper {
   private edgeBoxCornerOffsetsBuffer = this.registerDisposer(
-    Buffer.fromData(
+    GLBuffer.fromData(
       this.gl,
       tile2dArray(
         edgeBoxCornerOffsetData,
@@ -346,7 +346,7 @@ emitAnnotation(vec4(vColor.rgb, getLineAlpha() * vClipCoefficient));
   );
 
   private boxCornerOffsetsBuffer = this.registerDisposer(
-    Buffer.fromData(
+    GLBuffer.fromData(
       this.gl,
       tile2dArray(
         vertexBasePositions,

--- a/src/annotation/frontend_source.ts
+++ b/src/annotation/frontend_source.ts
@@ -61,7 +61,7 @@ import { ENDIANNESS, Endianness } from "#src/util/endian.js";
 import * as matrix from "#src/util/matrix.js";
 import type { Signal } from "#src/util/signal.js";
 import { NullarySignal } from "#src/util/signal.js";
-import type { Buffer } from "#src/webgl/buffer.js";
+import type { GLBuffer } from "#src/webgl/buffer.js";
 import type { GL } from "#src/webgl/context.js";
 import type { RPC } from "#src/worker_rpc.js";
 import {
@@ -90,7 +90,7 @@ export function computeNumPickIds(
 }
 
 export class AnnotationGeometryData {
-  buffer: Buffer | undefined;
+  buffer: GLBuffer | undefined;
   bufferValid = false;
   serializedAnnotations: SerializedAnnotations;
   numPickIds = 0;

--- a/src/annotation/renderlayer.ts
+++ b/src/annotation/renderlayer.ts
@@ -128,7 +128,7 @@ import type { AnyConstructor, MixinConstructor } from "#src/util/mixin.js";
 import { NullarySignal } from "#src/util/signal.js";
 import type { Uint64 } from "#src/util/uint64.js";
 import { withSharedVisibility } from "#src/visibility_priority/frontend.js";
-import { Buffer } from "#src/webgl/buffer.js";
+import { GLBuffer } from "#src/webgl/buffer.js";
 import type { ParameterizedContextDependentShaderGetter } from "#src/webgl/dynamic_shader.js";
 import { parameterizedEmitterDependentShaderGetter } from "#src/webgl/dynamic_shader.js";
 import type {
@@ -228,7 +228,7 @@ export class AnnotationLayer extends RefCounted {
   /**
    * Stores a serialized representation of the information needed to render the annotations.
    */
-  buffer: Buffer | undefined;
+  buffer: GLBuffer | undefined;
 
   numPickIds = 0;
 
@@ -367,7 +367,7 @@ export class AnnotationLayer extends RefCounted {
         let { buffer } = this;
         if (buffer === undefined) {
           buffer = this.buffer = this.registerDisposer(
-            new Buffer(this.chunkManager.gl),
+            new GLBuffer(this.chunkManager.gl),
           );
         }
         this.generation = generation;
@@ -385,7 +385,7 @@ export class AnnotationLayer extends RefCounted {
 
 interface AnnotationGeometryDataInterface {
   serializedAnnotations: SerializedAnnotations;
-  buffer: Buffer;
+  buffer: GLBuffer;
   numPickIds: number;
 }
 
@@ -609,7 +609,7 @@ function AnnotationRenderLayer<
       if (!chunk.bufferValid) {
         let { buffer } = chunk;
         if (buffer === undefined) {
-          buffer = chunk.buffer = new Buffer(this.gl);
+          buffer = chunk.buffer = new GLBuffer(this.gl);
         }
         const { serializedAnnotations } = chunk;
         buffer.setData(serializedAnnotations.data);

--- a/src/annotation/type_handler.ts
+++ b/src/annotation/type_handler.ts
@@ -31,7 +31,7 @@ import type { SliceViewPanelRenderContext } from "#src/sliceview/renderlayer.js"
 import type { WatchableValueInterface } from "#src/trackable_value.js";
 import { RefCounted } from "#src/util/disposable.js";
 import type { mat4 } from "#src/util/geom.js";
-import type { Buffer } from "#src/webgl/buffer.js";
+import type { GLBuffer } from "#src/webgl/buffer.js";
 import { glsl_COLORMAPS } from "#src/webgl/colormaps.js";
 import type { GL } from "#src/webgl/context.js";
 import type {
@@ -65,7 +65,7 @@ export type AnnotationShaderGetter = ParameterizedContextDependentShaderGetter<
 >;
 
 export interface AnnotationRenderContext {
-  buffer: Buffer;
+  buffer: GLBuffer;
   annotationLayer: AnnotationLayer;
   renderContext: SliceViewPanelRenderContext | PerspectiveViewRenderContext;
   bufferOffset: number;

--- a/src/axes_lines.ts
+++ b/src/axes_lines.ts
@@ -17,7 +17,7 @@
 import type { ProjectionParameters } from "#src/projection_parameters.js";
 import { RefCounted } from "#src/util/disposable.js";
 import { mat4 } from "#src/util/geom.js";
-import { Buffer } from "#src/webgl/buffer.js";
+import { GLBuffer } from "#src/webgl/buffer.js";
 import type { GL } from "#src/webgl/context.js";
 import type { ShaderProgram } from "#src/webgl/shader.js";
 import { trivialColorShader } from "#src/webgl/trivial_shaders.js";
@@ -46,14 +46,14 @@ export function computeAxisLineMatrix(
 }
 
 export class AxesLineHelper extends RefCounted {
-  vertexBuffer: Buffer;
-  colorBuffer: Buffer;
+  vertexBuffer: GLBuffer;
+  colorBuffer: GLBuffer;
   trivialColorShader: ShaderProgram;
 
   constructor(public gl: GL) {
     super();
     this.vertexBuffer = this.registerDisposer(
-      Buffer.fromData(
+      GLBuffer.fromData(
         gl,
         new Float32Array([
           0,
@@ -88,7 +88,7 @@ export class AxesLineHelper extends RefCounted {
 
     const alpha = 0.5;
     this.colorBuffer = this.registerDisposer(
-      Buffer.fromData(
+      GLBuffer.fromData(
         gl,
         new Float32Array([
           1,

--- a/src/datasource/enabled_backend_modules.ts
+++ b/src/datasource/enabled_backend_modules.ts
@@ -5,7 +5,6 @@ import "#datasource/deepzoom/backend";
 import "#datasource/dvid/backend";
 import "#datasource/graphene/backend";
 import "#datasource/n5/backend";
-import "#datasource/nggraph/backend";
 import "#datasource/nifti/backend";
 import "#datasource/obj/backend";
 import "#datasource/precomputed/backend";

--- a/src/datasource/precomputed/frontend.ts
+++ b/src/datasource/precomputed/frontend.ts
@@ -24,6 +24,7 @@ import {
   makeDataBoundsBoundingBoxAnnotationSet,
   parseAnnotationPropertySpecs,
 } from "#src/annotation/index.js";
+import type { ChunkManager } from "#src/chunk_manager/frontend.js";
 import { WithParameters } from "#src/chunk_manager/frontend.js";
 import type {
   BoundingBox,
@@ -405,9 +406,12 @@ export class PrecomputedAnnotationSource extends MultiscaleAnnotationSourceBase 
   declare key: any;
   metadata: AnnotationMetadata;
   declare OPTIONS: PrecomputedAnnotationSourceOptions;
-  constructor(options: PrecomputedAnnotationSourceOptions) {
+  constructor(
+    chunkManager: ChunkManager,
+    options: PrecomputedAnnotationSourceOptions,
+  ) {
     const { parameters } = options;
-    super(options.sharedKvStoreContext.chunkManager, {
+    super(chunkManager, {
       rank: parameters.rank,
       relationships: parameters.relationships.map((x) => x.name),
       properties: parameters.properties,

--- a/src/mesh/frontend.ts
+++ b/src/mesh/frontend.ts
@@ -67,7 +67,7 @@ import {
 } from "#src/util/geom.js";
 import * as matrix from "#src/util/matrix.js";
 import type { Uint64 } from "#src/util/uint64.js";
-import { Buffer } from "#src/webgl/buffer.js";
+import { GLBuffer } from "#src/webgl/buffer.js";
 import type { GL } from "#src/webgl/context.js";
 import { parameterizedEmitterDependentShaderGetter } from "#src/webgl/dynamic_shader.js";
 import type { ShaderBuilder, ShaderProgram } from "#src/webgl/shader.js";
@@ -86,19 +86,19 @@ function copyMeshDataToGpu(
   gl: GL,
   chunk: FragmentChunk | MultiscaleFragmentChunk,
 ) {
-  chunk.vertexBuffer = Buffer.fromData(
+  chunk.vertexBuffer = GLBuffer.fromData(
     gl,
     chunk.meshData.vertexPositions,
     gl.ARRAY_BUFFER,
     gl.STATIC_DRAW,
   );
-  chunk.indexBuffer = Buffer.fromData(
+  chunk.indexBuffer = GLBuffer.fromData(
     gl,
     chunk.meshData.indices,
     gl.ELEMENT_ARRAY_BUFFER,
     gl.STATIC_DRAW,
   );
-  chunk.normalBuffer = Buffer.fromData(
+  chunk.normalBuffer = GLBuffer.fromData(
     gl,
     chunk.meshData.vertexNormals,
     gl.ARRAY_BUFFER,
@@ -680,9 +680,9 @@ export class ManifestChunk extends Chunk {
 
 export class FragmentChunk extends Chunk {
   declare source: FragmentSource;
-  vertexBuffer: Buffer;
-  indexBuffer: Buffer;
-  normalBuffer: Buffer;
+  vertexBuffer: GLBuffer;
+  indexBuffer: GLBuffer;
+  normalBuffer: GLBuffer;
   meshData: EncodedMeshData;
 
   constructor(source: FragmentSource, x: any) {
@@ -1099,9 +1099,9 @@ export class MultiscaleManifestChunk extends Chunk {
 export class MultiscaleFragmentChunk extends Chunk {
   meshData: EncodedMeshData & { subChunkOffsets: Uint32Array };
   declare source: MultiscaleFragmentSource;
-  vertexBuffer: Buffer;
-  indexBuffer: Buffer;
-  normalBuffer: Buffer;
+  vertexBuffer: GLBuffer;
+  indexBuffer: GLBuffer;
+  normalBuffer: GLBuffer;
 
   constructor(source: MultiscaleFragmentSource, x: any) {
     super(source);

--- a/src/single_mesh/frontend.ts
+++ b/src/single_mesh/frontend.ts
@@ -45,7 +45,7 @@ import type { mat4 } from "#src/util/geom.js";
 import { vec3 } from "#src/util/geom.js";
 import type { ProgressOptions } from "#src/util/progress_listener.js";
 import { withSharedVisibility } from "#src/visibility_priority/frontend.js";
-import type { Buffer } from "#src/webgl/buffer.js";
+import type { GLBuffer } from "#src/webgl/buffer.js";
 import { glsl_COLORMAPS } from "#src/webgl/colormaps.js";
 import type { GL } from "#src/webgl/context.js";
 import {
@@ -396,7 +396,7 @@ export class VertexChunkData {
 
 export class SingleMeshChunk extends Chunk {
   declare source: SingleMeshSource;
-  indexBuffer: Buffer;
+  indexBuffer: GLBuffer;
   numIndices: number;
   indices: Uint32Array;
   vertexData: VertexChunkData;

--- a/src/skeleton/frontend.ts
+++ b/src/skeleton/frontend.ts
@@ -51,7 +51,7 @@ import { NullarySignal } from "#src/util/signal.js";
 import type { Trackable } from "#src/util/trackable.js";
 import { CompoundTrackable } from "#src/util/trackable.js";
 import { TrackableEnum } from "#src/util/trackable_enum.js";
-import { Buffer } from "#src/webgl/buffer.js";
+import { GLBuffer } from "#src/webgl/buffer.js";
 import {
   defineCircleShader,
   drawCircles,
@@ -781,7 +781,7 @@ export class SkeletonChunk extends Chunk {
   declare source: SkeletonSource;
   vertexAttributes: Uint8Array;
   indices: Uint32Array;
-  indexBuffer: Buffer;
+  indexBuffer: GLBuffer;
   numIndices: number;
   numVertices: number;
   vertexAttributeOffsets: Uint32Array;
@@ -822,7 +822,7 @@ export class SkeletonChunk extends Chunk {
       vertexAttributeTextures[i] = texture;
     }
     gl.bindTexture(WebGL2RenderingContext.TEXTURE_2D, null);
-    this.indexBuffer = Buffer.fromData(
+    this.indexBuffer = GLBuffer.fromData(
       gl,
       this.indices,
       WebGL2RenderingContext.ARRAY_BUFFER,

--- a/src/ui/tool_palette.ts
+++ b/src/ui/tool_palette.ts
@@ -1028,7 +1028,7 @@ export class MultiToolPaletteState implements Trackable {
     this.checkTitles(palette);
     palette.location.value = {
       ...DEFAULT_TOOL_PALETTE_PANEL_LOCATION,
-      ...(location ?? {}),
+      ...location,
     };
     palette.location.locationChanged.dispatch();
     this.add(palette);

--- a/src/volume_rendering/volume_render_layer.ts
+++ b/src/volume_rendering/volume_render_layer.ts
@@ -74,7 +74,7 @@ import {
   drawBoxes,
   glsl_getBoxFaceVertexPosition,
 } from "#src/webgl/bounding_box.js";
-import type { Buffer } from "#src/webgl/buffer.js";
+import type { GLBuffer } from "#src/webgl/buffer.js";
 import { getMemoizedBuffer } from "#src/webgl/buffer.js";
 import { glsl_COLORMAPS } from "#src/webgl/colormaps.js";
 import type {
@@ -250,7 +250,7 @@ export class VolumeRenderingRenderLayer extends PerspectiveViewRenderLayer {
     return this.dataHistogramSpecifications.visibleHistograms;
   }
 
-  private histogramIndexBuffer: RefCountedValue<Buffer>;
+  private histogramIndexBuffer: RefCountedValue<GLBuffer>;
 
   constructor(options: VolumeRenderingRenderLayerOptions) {
     super();

--- a/src/webgl/buffer.ts
+++ b/src/webgl/buffer.ts
@@ -24,7 +24,7 @@ import type { AttributeIndex } from "#src/webgl/shader.js";
 export type BufferType = number;
 export type WebGLDataType = number;
 export type WebGLBufferUsage = number;
-export class Buffer implements Disposable {
+export class GLBuffer implements Disposable {
   buffer: WebGLBuffer | null;
   constructor(
     public gl: WebGL2RenderingContext,
@@ -98,7 +98,7 @@ export class Buffer implements Disposable {
     bufferType?: BufferType,
     usage?: WebGLBufferUsage,
   ) {
-    const buffer = new Buffer(gl, bufferType);
+    const buffer = new GLBuffer(gl, bufferType);
     buffer.setData(data, usage);
     return buffer;
   }
@@ -118,7 +118,7 @@ export function getMemoizedBuffer(
     }),
     () => {
       const result = new RefCountedValue(
-        Buffer.fromData(
+        GLBuffer.fromData(
           gl,
           getter(...args),
           bufferType,

--- a/src/webgl/index_emulation.ts
+++ b/src/webgl/index_emulation.ts
@@ -15,7 +15,7 @@
  */
 
 import { RefCounted } from "#src/util/disposable.js";
-import { Buffer } from "#src/webgl/buffer.js";
+import { GLBuffer } from "#src/webgl/buffer.js";
 import type { GL } from "#src/webgl/context.js";
 import type { ShaderBuilder, ShaderProgram } from "#src/webgl/shader.js";
 import { glsl_uint32 } from "#src/webgl/shader_lib.js";
@@ -23,11 +23,11 @@ import { glsl_uint32 } from "#src/webgl/shader_lib.js";
 export class CountingBuffer extends RefCounted {
   length: number | undefined;
   webglType: number | undefined;
-  buffer: Buffer;
+  buffer: GLBuffer;
 
   constructor(public gl: GL) {
     super();
-    this.buffer = this.registerDisposer(new Buffer(gl));
+    this.buffer = this.registerDisposer(new GLBuffer(gl));
   }
 
   resize(length: number) {
@@ -115,7 +115,7 @@ export class IndexBufferAttributeHelper {
     builder.addAttribute("highp uint", this.name);
   }
 
-  bind(buffer: Buffer, shader: ShaderProgram) {
+  bind(buffer: GLBuffer, shader: ShaderProgram) {
     const attrib = shader.attribute(this.name);
     buffer.bindToVertexAttribI(
       attrib,
@@ -130,7 +130,7 @@ export class IndexBufferAttributeHelper {
 }
 
 export function makeIndexBuffer(gl: WebGL2RenderingContext, data: Uint32Array) {
-  return Buffer.fromData(
+  return GLBuffer.fromData(
     gl,
     data,
     WebGL2RenderingContext.ARRAY_BUFFER,

--- a/src/webgl/spheres.ts
+++ b/src/webgl/spheres.ts
@@ -19,7 +19,7 @@
  */
 
 import { RefCounted } from "#src/util/disposable.js";
-import type { Buffer } from "#src/webgl/buffer.js";
+import type { GLBuffer } from "#src/webgl/buffer.js";
 import { getMemoizedBuffer } from "#src/webgl/buffer.js";
 import type { GL } from "#src/webgl/context.js";
 import type { ShaderBuilder, ShaderProgram } from "#src/webgl/shader.js";
@@ -71,8 +71,8 @@ export function getSphereIndexArray(
 }
 
 export class SphereRenderHelper extends RefCounted {
-  private vertexBuffer: Buffer;
-  private indexBuffer: Buffer;
+  private vertexBuffer: GLBuffer;
+  private indexBuffer: GLBuffer;
   private numIndices: number;
 
   constructor(gl: GL, latitudeBands: number, longitudeBands: number) {

--- a/src/webgl/vertex_id.ts
+++ b/src/webgl/vertex_id.ts
@@ -22,7 +22,7 @@
  */
 
 import { RefCounted } from "#src/util/disposable.js";
-import { Buffer } from "#src/webgl/buffer.js";
+import { GLBuffer } from "#src/webgl/buffer.js";
 import type { GL } from "#src/webgl/context.js";
 import type { ShaderBuilder } from "#src/webgl/shader.js";
 
@@ -40,11 +40,11 @@ int getVertexId () {
 
 export class VertexIdHelper extends RefCounted {
   size: number;
-  buffer: Buffer;
+  buffer: GLBuffer;
 
   constructor(gl: WebGL2RenderingContext) {
     super();
-    this.buffer = new Buffer(gl);
+    this.buffer = new GLBuffer(gl);
     this.size = 0;
   }
 

--- a/src/widget/transfer_function.ts
+++ b/src/widget/transfer_function.ts
@@ -51,7 +51,7 @@ import { startRelativeMouseDrag } from "#src/util/mouse_drag.js";
 import { Uint64 } from "#src/util/uint64.js";
 import { getWheelZoomAmount } from "#src/util/wheel_zoom.js";
 import type { WatchableVisibilityPriority } from "#src/visibility_priority/frontend.js";
-import { Buffer, getMemoizedBuffer } from "#src/webgl/buffer.js";
+import { GLBuffer, getMemoizedBuffer } from "#src/webgl/buffer.js";
 import type { GL } from "#src/webgl/context.js";
 import type { HistogramSpecifications } from "#src/webgl/empirical_cdf.js";
 import {
@@ -685,12 +685,12 @@ function getTextureVertexBufferArray() {
  */
 class TransferFunctionPanel extends IndirectRenderedPanel {
   texture: DirectLookupTableTexture;
-  private textureVertexBuffer: Buffer;
-  private controlPointsVertexBuffer: Buffer;
+  private textureVertexBuffer: GLBuffer;
+  private controlPointsVertexBuffer: GLBuffer;
   private controlPointsPositionArray = new Float32Array();
-  private controlPointsColorBuffer: Buffer;
+  private controlPointsColorBuffer: GLBuffer;
   private controlPointsColorArray = new Float32Array();
-  private linePositionBuffer: Buffer;
+  private linePositionBuffer: GLBuffer;
   private linePositionArray = new Float32Array();
   get drawOrder() {
     return 1;
@@ -740,13 +740,13 @@ class TransferFunctionPanel extends IndirectRenderedPanel {
       ),
     ).value;
     this.controlPointsVertexBuffer = this.registerDisposer(
-      new Buffer(gl, WebGL2RenderingContext.ARRAY_BUFFER),
+      new GLBuffer(gl, WebGL2RenderingContext.ARRAY_BUFFER),
     );
     this.controlPointsColorBuffer = this.registerDisposer(
-      new Buffer(gl, WebGL2RenderingContext.ARRAY_BUFFER),
+      new GLBuffer(gl, WebGL2RenderingContext.ARRAY_BUFFER),
     );
     this.linePositionBuffer = this.registerDisposer(
-      new Buffer(gl, WebGL2RenderingContext.ARRAY_BUFFER),
+      new GLBuffer(gl, WebGL2RenderingContext.ARRAY_BUFFER),
     );
   }
 

--- a/tests/kvstore/zip.spec.ts
+++ b/tests/kvstore/zip.spec.ts
@@ -42,7 +42,7 @@ function readAllUsingYauzl(zipPath: string) {
         return;
       }
       zipfile.on("entry", async (entry) => {
-        if (/\/$/.test(entry.fileName)) {
+        if (entry.fileName.endsWith("/")) {
           zipfile.readEntry();
           return;
         }


### PR DESCRIPTION
oxlint is much faster than eslint, completing in about 0.5 seconds, compared to eslint completing in about 15 seconds. It is still missing some important rules, but critically, it supports "import/no-cycle", which is the one rule that is incompatible with per-file caching. Consequently, eslint can now be run with caching enabled, which greatly improves iteration time.