### PR TITLE
Remove EventAction import to resolve dev-server compilation error

### DIFF
--- a/src/widget/position_widget.ts
+++ b/src/widget/position_widget.ts
@@ -84,7 +84,6 @@ import { EnumSelectWidget } from "#src/widget/enum_widget.js";
 import { makeIcon } from "#src/widget/icon.js";
 import { NumberInputWidget } from "#src/widget/number_input_widget.js";
 import { PositionPlot } from "#src/widget/position_plot.js";
-import { EventAction } from "#src/util/event_action_map.js";
 
 export const positionDragType = "neuroglancer-position";
 


### PR DESCRIPTION
`EventAction` is an unused import -- in which type-checking fails when running `npm run dev-server` locally -- simple PR to remove import until it is either used or intentionally removed

This issue persisted when trying on [node >= 22](https://github.com/google/neuroglancer/blob/master/package.json#L10-L12) (verified locally via `nvm use 22` and `nvm use 23`)

<img width="974" alt="Screenshot 2025-01-27 at 2 23 16 PM" src="https://github.com/user-attachments/assets/a851d955-d36f-46f4-a71d-366692c78a9e" />

Cc @kabilar