### PR TITLE
fix(datasource/graphene) fix multicut annotation list not appearing in graph tab

### DIFF
--- a/src/datasource/graphene/frontend.ts
+++ b/src/datasource/graphene/frontend.ts
@@ -1964,14 +1964,11 @@ const GRAPHENE_MULTICUT_SEGMENTS_TOOL_ID = "grapheneMulticutSegments";
 const GRAPHENE_MERGE_SEGMENTS_TOOL_ID = "grapheneMergeSegments";
 
 class MulticutAnnotationLayerView extends AnnotationLayerView {
-  private _annotationStates: MergedAnnotationStates;
-
   constructor(
     public layer: SegmentationUserLayer,
     public displayState: AnnotationDisplayState,
   ) {
-    super(layer, displayState);
-
+    super(layer, displayState, new MergedAnnotationStates());
     const {
       graphConnection: { value: graphConnection },
     } = layer;
@@ -1980,15 +1977,6 @@ class MulticutAnnotationLayerView extends AnnotationLayerView {
         this.annotationStates.add(state);
       }
     }
-  }
-
-  get annotationStates() {
-    if (this._annotationStates === undefined) {
-      this._annotationStates = this.registerDisposer(
-        new MergedAnnotationStates(),
-      );
-    }
-    return this._annotationStates;
   }
 }
 

--- a/src/ui/annotations.ts
+++ b/src/ui/annotations.ts
@@ -256,10 +256,6 @@ export class AnnotationLayerView extends Tab {
   private mutableControls = document.createElement("div");
   private headerRow = document.createElement("div");
 
-  get annotationStates() {
-    return this.layer.annotationStates;
-  }
-
   private attachedAnnotationStates = new Map<
     AnnotationLayerState,
     AnnotationLayerViewAttachedState
@@ -379,6 +375,7 @@ export class AnnotationLayerView extends Tab {
   constructor(
     public layer: Borrowed<UserLayerWithAnnotations>,
     public displayState: AnnotationDisplayState,
+    protected readonly annotationStates: MergedAnnotationStates = layer.annotationStates,
   ) {
     super();
     this.element.classList.add("neuroglancer-annotation-layer-view");


### PR DESCRIPTION
My testing has shown this feature was broken in https://github.com/google/neuroglancer/commit/04ed8f975d6cb5fe5a290015978ab1ec4e2e744d

My original implementation was a way to get around having to modify AnnotationLayerView by overriding `get annotationStates()` in the graphene derived class.

What I observe is that the private property _annotationStates is not shared when annotationStates is called from the base class and from the derived class, it needs to be initialized twice.

It makes sense it would break in this commit because `useDefineForClassFields` is very much related to base and derived classes but if I set `useDefineForClassFields` to false and `"target"` back to to "ES2017", it doesn't fix the issue. Do you have any idea why? I'd like to understand it better.