### PR TITLE
fix(kvstore): override query+fragment from path if they exist when joining with base url

### DIFF
--- a/src/kvstore/url.ts
+++ b/src/kvstore/url.ts
@@ -203,7 +203,13 @@ export function encodePathForUrl(path: string) {
 
 export function joinBaseUrlAndPath(baseUrl: string, path: string) {
   const { base, queryAndFragment } = extractQueryAndFragment(baseUrl);
-  return base + encodePathForUrl(path) + queryAndFragment;
+  const { base: pathBase, queryAndFragment: pathQueryAndFragment } =
+    extractQueryAndFragment(path);
+  return (
+    base +
+    encodePathForUrl(pathBase) +
+    (pathQueryAndFragment || queryAndFragment)
+  );
 }
 
 export function getBaseHttpUrlAndPath(url: string) {


### PR DESCRIPTION
Here is a proposed fix for the following issue:

Currently HttpKvStore assumes the query and fragment are in the baseUrl when constructing the full url with `joinBaseUrlAndPath`. If it exists in the path, encodePathForUrl causes an incorrect url because the query character is encoded.

https://github.com/google/neuroglancer/blob/35a4af79bfbdbb7c07ed1ad6db8158970e34cf1e/src/kvstore/url.ts#L205

Graphene currently uses the fragment when constructing the path for two endpoints:

https://github.com/google/neuroglancer/blob/35a4af79bfbdbb7c07ed1ad6db8158970e34cf1e/src/datasource/graphene/backend.ts#L152
https://github.com/google/neuroglancer/blob/35a4af79bfbdbb7c07ed1ad6db8158970e34cf1e/src/datasource/graphene/backend.ts#L278

For simplicity, I'm just assuming if query/fragment are in the path, we can ignore if the base url contains either.