### PR TITLE
changing VOLUME_RENDERING from string to integer

### DIFF
--- a/src/sliceview/volume/image_renderlayer.ts
+++ b/src/sliceview/volume/image_renderlayer.ts
@@ -62,7 +62,7 @@ export function defineImageLayerShader(
   shaderBuilderState: ShaderControlsBuilderState,
 ) {
   builder.addFragmentCode(`
-#define VOLUME_RENDERING false
+#define VOLUME_RENDERING 0
 
 void emitRGBA(vec4 rgba) {
   emit(vec4(rgba.rgb, rgba.a * uOpacity));

--- a/src/volume_rendering/README.md
+++ b/src/volume_rendering/README.md
@@ -62,10 +62,10 @@ void main() {
 
 ### Volume rendering mode switching
 
-In some cases, the shader code may need to be aware of the volume rendering mode. This can be done via the `VOLUME_RENDERING` flag. For example:
+In some cases, the shader code may need to be aware of the volume rendering mode. This can be done via the `VOLUME_RENDERING` flag, which is set to 1 if doing Volume rendering, and 0 otherwise. For example:
 
 ```glsl
-if (VOLUME_RENDERING) {
+if (VOLUME_RENDERING==1) {
   // Volume rendering code
 } else {
   // Slice rendering code

--- a/src/volume_rendering/volume_render_layer.ts
+++ b/src/volume_rendering/volume_render_layer.ts
@@ -192,7 +192,7 @@ export function getVolumeRenderingDepthSamplesBoundsLogScale(): [
 ] {
   const logScaleMax = Math.round(
     VOLUME_RENDERING_DEPTH_SAMPLES_LOG_SCALE_ORIGIN +
-      numRenderScaleHistogramBins * renderScaleHistogramBinSize,
+    numRenderScaleHistogramBins * renderScaleHistogramBinSize,
   );
   return [VOLUME_RENDERING_DEPTH_SAMPLES_LOG_SCALE_ORIGIN, logScaleMax];
 }
@@ -321,7 +321,7 @@ export class VolumeRenderingRenderLayer extends PerspectiveViewRenderLayer {
           }
           defineVertexId(builder);
           builder.addFragmentCode(`
-#define VOLUME_RENDERING true
+#define VOLUME_RENDERING 1
 `);
           let glsl_rgbaEmit = glsl_emitRGBAVolumeRendering;
           let glsl_finalEmit = `
@@ -527,8 +527,8 @@ void main() {
           addControlsToBuilder(shaderBuilderState, builder);
           builder.addFragmentCode(
             "\n#define main userMain\n" +
-              shaderCodeWithLineDirective(shaderBuilderState.parseResult.code) +
-              "\n#undef main\n",
+            shaderCodeWithLineDirective(shaderBuilderState.parseResult.code) +
+            "\n#undef main\n",
           );
         },
       },
@@ -1335,7 +1335,7 @@ outputValue = vec4(1.0, 1.0, 1.0, 1.0);
       this.localPosition.value,
       this.depthSamplesTarget.value,
       allSources[0],
-      () => {},
+      () => { },
       (tsource) => {
         const chunk = tsource.source.chunks.get(
           tsource.curPositionInChunks.join(),

--- a/src/volume_rendering/volume_render_layer.ts
+++ b/src/volume_rendering/volume_render_layer.ts
@@ -192,7 +192,7 @@ export function getVolumeRenderingDepthSamplesBoundsLogScale(): [
 ] {
   const logScaleMax = Math.round(
     VOLUME_RENDERING_DEPTH_SAMPLES_LOG_SCALE_ORIGIN +
-    numRenderScaleHistogramBins * renderScaleHistogramBinSize,
+      numRenderScaleHistogramBins * renderScaleHistogramBinSize,
   );
   return [VOLUME_RENDERING_DEPTH_SAMPLES_LOG_SCALE_ORIGIN, logScaleMax];
 }
@@ -527,8 +527,8 @@ void main() {
           addControlsToBuilder(shaderBuilderState, builder);
           builder.addFragmentCode(
             "\n#define main userMain\n" +
-            shaderCodeWithLineDirective(shaderBuilderState.parseResult.code) +
-            "\n#undef main\n",
+              shaderCodeWithLineDirective(shaderBuilderState.parseResult.code) +
+              "\n#undef main\n",
           );
         },
       },
@@ -1335,7 +1335,7 @@ outputValue = vec4(1.0, 1.0, 1.0, 1.0);
       this.localPosition.value,
       this.depthSamplesTarget.value,
       allSources[0],
-      () => { },
+      () => {},
       (tsource) => {
         const chunk = tsource.source.chunks.get(
           tsource.curPositionInChunks.join(),


### PR DESCRIPTION
I wanted to make a shader that did a variable local maximum projection in the slice view (with color coding for depth).  Like this... but to make the shader compiliation not balk, i have to avoid using variables that are not defined during the volume rendering pass.  Without modifying the source code of neuroglancer, I think i have to do this with header macros, but the current VOLUME_RENDERING header is a string 'true' or 'false' which means i can't use to do conditional pre-compilation macros myself.

Perhaps there is another workaround for this case, but it seemed to me that if we switched to using simple integers for VOLUME_RENDERING, this would let me do what i needed to accomplish this shader. 

I'm submitting this as PR/issue to see what @jbms and @seankmartin think is the best approach here. 

```
#uicontrol int zrange slider(min=0, max=15)
#uicontrol invlerp normalized
#if VOLUME_RENDERING
    // If VOLUME_RENDERING is defined at compile time,
    // use curChunkPosition
    #define CHUNK_POSITION curChunkPosition
    #define PLANE_NORMAL vec3(1.0,0.0,0.0)
#else
    // Otherwise, use vChunkPosition
    #define CHUNK_POSITION vChunkPosition
    #define PLANE_NORMAL uPlaneNormal
#endif
  
void main() {
    if (VOLUME_RENDERING==1){
        float norm = normalized();
        emitRGBA(vec4(norm, norm, norm, norm));
    }
  else{
    ivec3 p = ivec3(max(vec3(0.0), 
                        min(floor(CHUNK_POSITION), uChunkDataSize - 1.0)));
    uint channel0_data = getDataValueAt(p).value;
    
    // We'll hold the best intensity and best offset
    uint best_val = channel0_data;
    int max_z = 0;  // offset found for the best value
    
    // If zrange > 0, do the searching; if zrange == 0, skip
    if (zrange > 0) {
        // Search "above" or plus side
        vec3 p_tmp = vec3(p);
        for(int i = 1; i <= zrange; i++) {
            p_tmp += PLANE_NORMAL;  // or -=, depending on your orientation
            ivec3 p_check = ivec3(max(vec3(0.0), p_tmp));
            uint val = getDataValueAt(p_check).value;
            if (val > best_val) {
                best_val = val;
                max_z = i;
            }
        }

        // Search "below" or minus side
        p_tmp = vec3(p);
        for(int i = 1; i <= zrange; i++) {
            p_tmp -= PLANE_NORMAL;  // opposite direction
            ivec3 p_check = ivec3(max(vec3(0.0), p_tmp));
            uint val = getDataValueAt(p_check).value;
            if (val > best_val) {
                best_val = val;
                max_z = -i;
            }
        }
    }
    else {
        // zrange = 0, so we do NOT search;
        // keep best_val = channel0_data and max_z = 0
    }
    
    // ratio in [-1, 1]
    float ratio = 0.0;
    if (zrange != 0) {
        ratio = float(max_z) / float(zrange);
    }
    ratio = clamp(ratio, -1.0, 1.0);

    // Define key colors
    vec3 white = vec3(1.0, 1.0, 1.0);
    vec3 red   = vec3(1.0, 0.0, 0.0);
    vec3 blue  = vec3(0.0, 0.0, 1.0);

    // Map ratio to color
    vec3 color;
    if (ratio > 0.0) {
        color = mix(white, red, ratio);
    } else if (ratio < 0.0) {
        color = mix(white, blue, -ratio); 
    } else {
        color = white;  // ratio == 0
    }

    // Use the data value for brightness/alpha
    float alpha = normalized(best_val);

    emitRGBA(vec4(color * alpha, alpha));
  }
}
```
this works locally quite nicely..

![image](https://github.com/user-attachments/assets/9bd8a4d9-710b-4f13-ad89-a38b5a0ff943)
