### PR TITLE
Feat(screenshot): Change copy metadata in UI to clipboard to return JSON

### DIFF
--- a/src/ui/screenshot_menu.ts
+++ b/src/ui/screenshot_menu.ts
@@ -28,6 +28,7 @@ import type {
   ScreenshotManager,
 } from "#src/util/screenshot_manager.js";
 import { MAX_RENDER_AREA_PIXELS } from "#src/util/screenshot_manager.js";
+import { parseScale } from "#src/util/si_units.js";
 import { ScreenshotMode } from "#src/util/trackable_screenshot_mode.js";
 import type {
   DimensionResolutionStats,
@@ -40,7 +41,6 @@ import {
 } from "#src/util/viewer_resolution_stats.js";
 import { makeCopyButton } from "#src/widget/copy_button.js";
 import { makeIcon } from "#src/widget/icon.js";
-import { parseScale } from "#src/util/si_units.js";
 
 // If DEBUG_ALLOW_MENU_CLOSE is true, the menu can be closed by clicking the close button
 // Usually the user is locked into the screenshot menu until the screenshot is taken or cancelled
@@ -186,7 +186,6 @@ function formatPixelResolution(panelArea: PanelViewport) {
 
 function resolutionToJson<T extends ResolutionMetadata>(
   fullResolution: string,
-  panelResolution: boolean = true,
 ): T[] {
   const extractScaleAndUnit = (resolution: string) => {
     const [formattedScale, unit = ""] = resolution.split("/");
@@ -208,12 +207,7 @@ function resolutionToJson<T extends ResolutionMetadata>(
   };
 
   if (!fullResolution.includes(" ")) {
-    return [
-      createResolutionData(
-        panelResolution ? "Isotropic" : "Isomorphic",
-        fullResolution,
-      ),
-    ];
+    return [createResolutionData("Isomorphic", fullResolution)];
   }
 
   return fullResolution
@@ -892,7 +886,7 @@ export class ScreenshotDialog extends Overlay {
           width: resolution.width,
           height: resolution.height,
         },
-        physicalScale: resolutionToJson(resolution.resolution, true),
+        physicalScale: resolutionToJson(resolution.resolution),
       };
       panelsJson.push(panelMetadataItem);
     }
@@ -902,7 +896,7 @@ export class ScreenshotDialog extends Overlay {
       const layerMetadataItem: LayerMetadata = {
         name: resolution.name,
         type: resolution.type,
-        voxelResolution: resolutionToJson(resolution.resolution, false),
+        voxelResolution: resolutionToJson(resolution.resolution),
       };
       layersJson.push(layerMetadataItem);
     }

--- a/src/ui/screenshot_menu.ts
+++ b/src/ui/screenshot_menu.ts
@@ -207,7 +207,7 @@ function parseResolution<T extends ResolutionMetadata>(
   };
 
   if (!fullResolution.includes(" ")) {
-    return [createResolutionData("Isomorphic", fullResolution)];
+    return [createResolutionData("Uniform", fullResolution)];
   }
 
   return fullResolution

--- a/src/ui/screenshot_menu.ts
+++ b/src/ui/screenshot_menu.ts
@@ -184,7 +184,7 @@ function formatPixelResolution(panelArea: PanelViewport) {
   return { width, height, type };
 }
 
-function resolutionToJson<T extends ResolutionMetadata>(
+function parseResolution<T extends ResolutionMetadata>(
   fullResolution: string,
 ): T[] {
   const extractScaleAndUnit = (resolution: string) => {
@@ -444,7 +444,7 @@ export class ScreenshotDialog extends Overlay {
     const screenshotCopyButton = makeCopyButton({
       title: "Copy table to clipboard",
       onClick: () => {
-        const result = setClipboard(this.getResolutionText());
+        const result = setClipboard(this.generateScreenshotMetadataJson());
         StatusMessage.showTemporaryMessage(
           result
             ? "Resolution metadata JSON copied to clipboard"
@@ -866,11 +866,7 @@ export class ScreenshotDialog extends Overlay {
     };
   }
 
-  /**
-  Private function to copy the resolution of the screenshot to the clipboard
-  This will be in JSON format.
-    */
-  private getResolutionText() {
+  private generateScreenshotMetadataJson() {
     const screenshotSize = {
       width: this.screenshotWidth,
       height: this.screenshotHeight,
@@ -878,7 +874,7 @@ export class ScreenshotDialog extends Overlay {
     const { panelResolutionData, layerResolutionData } =
       getViewerResolutionMetadata(this.screenshotManager.viewer);
 
-    const panelsJson = [];
+    const panelsMetadata = [];
     for (const resolution of panelResolutionData) {
       const panelMetadataItem: PanelMetadata = {
         type: resolution.type,
@@ -886,27 +882,27 @@ export class ScreenshotDialog extends Overlay {
           width: resolution.width,
           height: resolution.height,
         },
-        physicalScale: resolutionToJson(resolution.resolution),
+        physicalScale: parseResolution(resolution.resolution),
       };
-      panelsJson.push(panelMetadataItem);
+      panelsMetadata.push(panelMetadataItem);
     }
 
-    const layersJson = [];
+    const layersMetadata = [];
     for (const resolution of layerResolutionData) {
       const layerMetadataItem: LayerMetadata = {
         name: resolution.name,
         type: resolution.type,
-        voxelResolution: resolutionToJson(resolution.resolution),
+        voxelResolution: parseResolution(resolution.resolution),
       };
-      layersJson.push(layerMetadataItem);
+      layersMetadata.push(layerMetadataItem);
     }
 
     const screenshotMetadata: ScreenshotMetadata = {
       date: new Date().toISOString(),
       name: this.nameInput.value,
       size: screenshotSize,
-      panels: panelsJson,
-      layers: layersJson,
+      panels: panelsMetadata,
+      layers: layersMetadata,
     };
 
     return JSON.stringify(screenshotMetadata, null, 2);


### PR DESCRIPTION
Roughly, the output is:

1. Date
2. Name
3. Width/height of screenshot
4. For each panel, the panel type and size - and the scale of the panel in XYZ (or just "Uniform" if all the same).
5. For each layer, the layer name and type - and the scale of the voxel data in XYZ (or just "Uniform" if all the same). 

The JSON is like this for example where the view is isotropic and the voxels are cubes:

```json
{
  "date": "2025-02-24T13:33:21.336Z",
  "name": "",
  "size": {
    "width": 1072,
    "height": 878
  },
  "panels": [
    {
      "type": "Slice view (2D)",
      "pixelResolution": {
        "width": 534,
        "height": 437
      },
      "physicalScale": [
        {
          "formattedScale": "40nm",
          "dimension": "Uniform",
          "scale": 4e-8,
          "unit": "m",
          "panelViewportUnit": "px"
        }
      ]
    },
    {
      "type": "Perspective projection (3D)",
      "pixelResolution": {
        "width": 534,
        "height": 437
      },
      "physicalScale": [
        {
          "formattedScale": "18.66µm",
          "dimension": "Uniform",
          "scale": 0.00001866,
          "unit": "m",
          "panelViewportUnit": "vh"
        }
      ]
    }
  ],
  "layers": [
    {
      "name": "allen",
      "type": "ImageRenderLayer",
      "voxelResolution": [
        {
          "formattedScale": "40nm",
          "dimension": "Uniform",
          "scale": 4e-8,
          "unit": "m"
        }
      ]
    },
    {
      "name": "allen",
      "type": "VolumeRenderingRenderLayer",
      "voxelResolution": [
        {
          "formattedScale": "40nm",
          "dimension": "Uniform",
          "scale": 4e-8,
          "unit": "m"
        }
      ]
    }
  ]
}
```
Can also provide a schema if that's helpful, very open to input on the JSON format or anything in the implementation, thanks!

cc @fcollman 