### PR TITLE
fix(AsyncCache): fix bug when freeing an async cache entry

### DIFF
--- a/src/chunk_manager/generic_file_source.ts
+++ b/src/chunk_manager/generic_file_source.ts
@@ -87,7 +87,7 @@ export class SimpleAsyncCache<Key, Value> extends ChunkSourceBase {
           chunk.systemMemoryBytes = size;
           chunk!.queueManager.updateChunkState(
             chunk!,
-            ChunkState.SYSTEM_MEMORY,
+            ChunkState.SYSTEM_MEMORY_WORKER,
           );
           return data;
         } catch (e) {
@@ -96,7 +96,7 @@ export class SimpleAsyncCache<Key, Value> extends ChunkSourceBase {
         }
       });
     }
-    if (chunk.state === ChunkState.SYSTEM_MEMORY) {
+    if (chunk.state === ChunkState.SYSTEM_MEMORY_WORKER) {
       chunk.chunkManager.queueManager.markRecentlyUsed(chunk);
     }
     return chunk.asyncMemoize(options);


### PR DESCRIPTION
This fixes the following error reported at
https://github.com/google/neuroglancer/issues/743

frontend.ts:328 Uncaught TypeError: Cannot read properties of undefined (reading 'chunkManager')
    at updateChunk (frontend.ts:328:31) # webpack://neuroglancer/src/chunk_manager/frontend.ts
    at RPC.<anonymous> (frontend.ts:348:3)
    at RPC.target.onmessage (worker_rpc.ts:174:40)