### PR TITLE
feat(help/input_event_bindings): Simplify input event binding help display

### DIFF
--- a/src/util/event_action_map.ts
+++ b/src/util/event_action_map.ts
@@ -309,7 +309,7 @@ export function normalizeEventAction(
 }
 
 // Strips the phase and optional modifiers.
-function friendlyEventIdentifier(identifier: string): string {
+export function friendlyEventIdentifier(identifier: string): string {
   identifier = identifier.replace(
     /^(?:at|bubble|capture)|(?:(?:shift|control|alt|meta)\?\+)/g,
     "",


### PR DESCRIPTION
Previously, optional modifiers in a binding like
"alt?+control?+shift+keya" would result in 4 separate help entries for each of the 4 combinations.

With this change, the optional modifiers are excluded altogether, as they already were from the binding tooltips, resulting in a single help entry for "shift+keya".

Additionally, patterns like "shift+key[a-z]" -> "tool-[A-Z]" and "[1-9]" -> "toggle-layer-[1-9]" resulted in each binding being displayed separately.  With this change, the pattern is recognized and displayed as a single entry.

These changes together make the help display much, much more concise.