### PR TITLE
fix(UI - layer_list_panel): Change layer number width spacing to consider archived layers

### DIFF
--- a/src/ui/layer_list_panel.css
+++ b/src/ui/layer_list_panel.css
@@ -67,8 +67,6 @@
   display: inline-block;
   text-align: left;
   line-height: 18px;
-  width: auto !important;
-  min-width: 2ch;
 }
 
 .neuroglancer-layer-list-panel-item:not(:hover)

--- a/src/ui/layer_list_panel.css
+++ b/src/ui/layer_list_panel.css
@@ -65,7 +65,7 @@
   color: white;
   font-weight: bold;
   display: inline-block;
-  text-align: left;
+  text-align: right;
   line-height: 18px;
 }
 

--- a/src/ui/layer_list_panel.css
+++ b/src/ui/layer_list_panel.css
@@ -65,8 +65,10 @@
   color: white;
   font-weight: bold;
   display: inline-block;
-  text-align: right;
+  text-align: left;
   line-height: 18px;
+  width: auto !important;
+  min-width: 2ch;
 }
 
 .neuroglancer-layer-list-panel-item:not(:hover)

--- a/src/ui/layer_list_panel.ts
+++ b/src/ui/layer_list_panel.ts
@@ -275,9 +275,7 @@ export class LayerListPanel extends SidePanel {
       for (const layer of self.layerManager.managedLayers) {
         if (!layer.archived) ++numNonArchivedLayers;
       }
-      const numberElementWidth = `${
-        (numNonArchivedLayers + 1).toString().length
-      }ch`;
+      const numberElementWidth = `${numNonArchivedLayers.toString().length}ch`;
       for (const layer of self.layerManager.managedLayers) {
         if (layer.visible) {
           ++numVisible;

--- a/src/ui/layer_list_panel.ts
+++ b/src/ui/layer_list_panel.ts
@@ -271,8 +271,13 @@ export class LayerListPanel extends SidePanel {
     this.layerManager.updateNonArchivedLayerIndices();
     function* getItems() {
       const { items } = self;
-      const numLayers = self.layerManager.managedLayers.length;
-      const numberElementWidth = `${numLayers.toString().length}ch`;
+      let numNonArchivedLayers = 0;
+      for (const layer of self.layerManager.managedLayers) {
+        if (!layer.archived) ++numNonArchivedLayers;
+      }
+      const numberElementWidth = `${
+        (numNonArchivedLayers + 1).toString().length
+      }ch`;
       for (const layer of self.layerManager.managedLayers) {
         if (layer.visible) {
           ++numVisible;

--- a/src/ui/layer_list_panel.ts
+++ b/src/ui/layer_list_panel.ts
@@ -271,12 +271,9 @@ export class LayerListPanel extends SidePanel {
     this.layerManager.updateNonArchivedLayerIndices();
     function* getItems() {
       const { items } = self;
-      let numNonArchivedLayers = 0;
-      for (const layer of self.layerManager.managedLayers) {
-        if (!layer.archived) ++numNonArchivedLayers;
-      }
+      const numLayers = self.layerManager.managedLayers.length;
       const numberElementWidth = `${
-        (numNonArchivedLayers + 1).toString().length
+        (numLayers).toString().length
       }ch`;
       for (const layer of self.layerManager.managedLayers) {
         if (layer.visible) {

--- a/src/ui/layer_list_panel.ts
+++ b/src/ui/layer_list_panel.ts
@@ -272,9 +272,7 @@ export class LayerListPanel extends SidePanel {
     function* getItems() {
       const { items } = self;
       const numLayers = self.layerManager.managedLayers.length;
-      const numberElementWidth = `${
-        (numLayers).toString().length
-      }ch`;
+      const numberElementWidth = `${numLayers.toString().length}ch`;
       for (const layer of self.layerManager.managedLayers) {
         if (layer.visible) {
           ++numVisible;

--- a/src/ui/layer_list_panel.ts
+++ b/src/ui/layer_list_panel.ts
@@ -296,7 +296,7 @@ export class LayerListPanel extends SidePanel {
         }
         const { nonArchivedLayerIndex } = layer;
         item.numberElement.style.width = numberElementWidth;
-        if (nonArchivedLayerIndex === -1) {
+        if (layer.archived) {
           item.numberElement.style.visibility = "hidden";
         } else {
           item.numberElement.style.visibility = "";


### PR DESCRIPTION
The layer list panel number width is determined by the number of characters in the highest number non-archived layer. Since archived layers didn't contribute to the layer count for determining the width for the layer list panel numbers, it could result in cases like this where the number would overlap the visibility icon for archived layers:

![image](https://github.com/user-attachments/assets/4674b56c-92f8-4fb2-a23d-8bb2be438017)

We're thinking to change the count here to take all layers into account so that archived layer numbers don't overlap the visibility icon and be like this:

![image](https://github.com/user-attachments/assets/f4056204-a0bd-4ac3-a03f-e73591671af8)

Maybe there is some reason though that archived layers were previously excluded for the number width count that we should be considering here? For example, maybe the layer numbers were intended to be hidden for all archived layers. If so, happy to amend this to account for that, thanks