### PR TITLE
feat: show layer on unarchive layer

### DIFF
--- a/src/layer/index.ts
+++ b/src/layer/index.ts
@@ -787,8 +787,8 @@ export class ManagedUserLayer extends RefCounted {
 
   setArchived(value: boolean) {
     if (this.archived === value) return;
+    this.visible = !value;
     if (value === true) {
-      this.visible = false;
       this.archived = true;
       for (const { layerManager } of this.manager.root.subsets) {
         if (!layerManager.has(this)) continue;


### PR DESCRIPTION
We've been using the archive feature for layers from the side bar, and thought it might be a bit more intuitive if unarchiving the layer also showed the layer.

I think it could be pretty common that a layer is unarchived because you want to see that layer. But very open to thoughts on this behaviour. Thanks!