### PR TITLE
fix: camera screenshot icon can hide like other icons in top bar

### DIFF
--- a/python/neuroglancer/viewer_config_state.py
+++ b/python/neuroglancer/viewer_config_state.py
@@ -363,6 +363,9 @@ class ConfigState(JsonObjectWrapper):
     show_layer_side_panel_button = showLayerSidePanelButton = wrapped_property(
         "showLayerSidePanelButton", optional(bool, True)
     )
+    show_screenshot_button = showScreenshotButton = wrapped_property(
+        "showScreenshotButton", optional(bool, True)
+    )
     show_tool_palette_button = showToolPaletteButton = wrapped_property(
         "showToolPaletteButton", optional(bool, True)
     )

--- a/src/viewer.ts
+++ b/src/viewer.ts
@@ -163,6 +163,7 @@ export const VIEWER_TOP_ROW_CONFIG_OPTIONS = [
   "showHelpButton",
   "showSettingsButton",
   "showEditStateButton",
+  "showScreenshotButton",
   "showToolPaletteButton",
   "showLayerListPanelButton",
   "showSelectionPanelButton",
@@ -853,6 +854,12 @@ export class Viewer extends RefCounted implements ViewerState {
       this.registerEventListener(button, "click", () => {
         this.showScreenshotDialog();
       });
+      this.registerDisposer(
+        new ElementVisibilityFromTrackableBoolean(
+          this.uiControlVisibility.showScreenshotButton,
+          button,
+        ),
+      );
       topRow.appendChild(button);
     }
 


### PR DESCRIPTION
Accidentally the ability to hide the screenshot button was left out when we made the PR for the screenshot from the UI.

I've updated this to allow for it to be hidden, and also hidden from Python. Please let me know if there is anything else that should change for this, and sorry it was left out in the first place!