### PR TITLE
feat: ability to show/hide the whole top bar in one setting

### DIFF
--- a/python/neuroglancer/viewer_config_state.py
+++ b/python/neuroglancer/viewer_config_state.py
@@ -348,6 +348,7 @@ class ConfigState(JsonObjectWrapper):
     show_ui_controls = showUIControls = wrapped_property(
         "showUIControls", optional(bool, True)
     )
+    show_top_bar = showTopBar = wrapped_property("showTopBar", optional(bool, True))
     show_location = showLocation = wrapped_property(
         "showLocation", optional(bool, True)
     )

--- a/src/viewer.ts
+++ b/src/viewer.ts
@@ -179,6 +179,7 @@ export const VIEWER_UI_CONTROL_CONFIG_OPTIONS = [
 
 export const VIEWER_UI_CONFIG_OPTIONS = [
   ...VIEWER_UI_CONTROL_CONFIG_OPTIONS,
+  "showTopBar",
   "showUIControls",
   "showPanelBorders",
 ] as const;
@@ -472,9 +473,20 @@ export class Viewer extends RefCounted implements ViewerState {
 
   private makeUiControlVisibilityState(key: keyof ViewerUIOptions) {
     const showUIControls = this.uiConfiguration.showUIControls;
+    const showTopBar = this.uiConfiguration.showTopBar;
     const option = this.uiConfiguration[key];
+    const isTopBarControl = (
+      VIEWER_TOP_ROW_CONFIG_OPTIONS as readonly string[]
+    ).includes(key as string);
     return this.registerDisposer(
-      makeDerivedWatchableValue((a, b) => a && b, showUIControls, option),
+      makeDerivedWatchableValue(
+        (a, b, c) => {
+          return a && (!isTopBarControl || b) && c;
+        },
+        showUIControls,
+        showTopBar,
+        option,
+      ),
     );
   }
 


### PR DESCRIPTION
During the creation of the changes for the screenshot show/hide from UI that were left out, I noticed https://github.com/google/neuroglancer/issues/439

The idea of a `showTopBar` came up there, which would show/hide the entire top bar as opposed to have to individually set each control visibility.

Maybe this would enable that behaviour in the intended way? Let me know what you think