### PR TITLE
fix(coordinate_transform): use names from spec when constructing coordinate space transform

### DIFF
--- a/src/coordinate_transform.ts
+++ b/src/coordinate_transform.ts
@@ -1288,7 +1288,7 @@ export class WatchableCoordinateSpaceTransform
       const specDim = newDim - defaultSourceRank + specSourceRank;
       newInputScales[newDim] = specInputOrOutputSpace.scales[specDim];
       newInputUnits[newDim] = specInputOrOutputSpace.units[specDim];
-      newInputNames[newDim] = `${newDim}`;
+      newInputNames[newDim] = specInputOrOutputSpace.names[specDim];
     }
 
     const newTransform = new Float64Array((newRank + 1) ** 2);


### PR DESCRIPTION
Currently the use of the dimension index causes the next set spec to fail the validateDimensionNames check.

You can replicate the issue here by adding an additional output dimension here and reloading the page twice.

https://neuroglancer-demo.appspot.com/#!%7B%22dimensions%22:%7B%22x%22:%5B1.8e-8%2C%22m%22%5D%2C%22y%22:%5B1.8e-8%2C%22m%22%5D%2C%22z%22:%5B4.5e-8%2C%22m%22%5D%7D%2C%22position%22:%5B49263.15234375%2C49176.1328125%2C1694.5%5D%2C%22crossSectionScale%22:1.6791634573917904%2C%22projectionOrientation%22:%5B-0.00024565105559304357%2C-0.11311007291078568%2C0.00002710020635277033%2C0.9935824275016785%5D%2C%22projectionScale%22:131072%2C%22layers%22:%5B%7B%22type%22:%22image%22%2C%22source%22:%22gs://zheng_mouse_hippocampus_production/v2/img_aligned_sharded_18nm/%7Cneuroglancer-precomputed:%22%2C%22tab%22:%22source%22%2C%22name%22:%22img_aligned_sharded_18nm%22%2C%22visible%22:false%7D%5D%2C%22selectedLayer%22:%7B%22size%22:986%2C%22visible%22:true%2C%22layer%22:%22img_aligned_sharded_18nm%22%7D%2C%22layout%22:%224panel-alt%22%7D


The initial input names: `[x', 'y', 'z', '']`
Output names: `['x', 'y', 'z', "test'"]`

On reload, set spec changes input names to `[x', 'y', 'z',  3]` and coordinateTransformSpecificationToJson changes the order to  `['3', 'x', 'y', 'z']` because numerical properties are first and ordered from smallest to largest.


On second reload:
specInputNames = `['3', 'x', 'y', 'z']`
newToSpecDimensionIndices = `[1, 2, -1, 3]`
Which results in newOutputNames = `['y', 'z', 'z', "test'"]` and fails the validateDimensionNames check.


