### PR TITLE
fix(python/prefetch): use non-zero width/height for prefetching

### DIFF
--- a/src/display_context.ts
+++ b/src/display_context.ts
@@ -643,8 +643,8 @@ export class DisplayContext extends RefCounted implements FrameNumberCounter {
       orderedPanels.sort((a, b) => a.drawOrder - b.drawOrder);
     }
     for (const panel of orderedPanels) {
-      if (!panel.shouldDraw) continue;
       panel.ensureBoundsUpdated();
+      if (!panel.shouldDraw) continue;
       const { renderViewport } = panel;
       if (renderViewport.width === 0 || renderViewport.height === 0) continue;
       panel.draw();


### PR DESCRIPTION
Previously, panels for Python prefetch states inadvertently did not have their bounds correctly calculated, leading to a width and height of zero, which meant that data was not correctly prefetched.