### PR TITLE
fix: move some attribute initialization from class level to constructor

### DIFF
--- a/src/widget/invlerp.ts
+++ b/src/widget/invlerp.ts
@@ -729,7 +729,7 @@ export function adjustInvlerpBrightnessContrast(
 }
 
 export class InvlerpWidget extends Tab {
-  cdfPanel = this.registerDisposer(new CdfPanel(this));
+  cdfPanel;
   boundElements;
   invertArrows: HTMLElement[];
   autoRangeFinder: AutoRangeFinder;
@@ -751,6 +751,7 @@ export class InvlerpWidget extends Tab {
     public legendShaderOptions: LegendShaderOptions | undefined,
   ) {
     super(visibility);
+    this.cdfPanel = this.registerDisposer(new CdfPanel(this));
     this.boundElements = {
       range: createRangeBoundInputs("range", dataType, trackable),
       window: createRangeBoundInputs("window", dataType, trackable),

--- a/src/widget/transfer_function.ts
+++ b/src/widget/transfer_function.ts
@@ -1602,9 +1602,7 @@ class TransferFunctionController extends RefCounted {
  * Widget for the transfer function. Creates the UI elements required for the transfer function.
  */
 class TransferFunctionWidget extends Tab {
-  private transferFunctionPanel = this.registerDisposer(
-    new TransferFunctionPanel(this),
-  );
+  private transferFunctionPanel = this;
   autoRangeFinder: AutoRangeFinder;
   window = this.createWindowBoundInputs();
 
@@ -1630,6 +1628,9 @@ class TransferFunctionWidget extends Tab {
     public histogramIndex: number,
   ) {
     super(visibility);
+    this.transferFunctionPanel = this.registerDisposer(
+      new TransferFunctionPanel(this),
+    );
     this.registerDisposer(
       histogramSpecifications.visibility.add(this.visibility),
     );

--- a/src/widget/transfer_function.ts
+++ b/src/widget/transfer_function.ts
@@ -1602,7 +1602,7 @@ class TransferFunctionController extends RefCounted {
  * Widget for the transfer function. Creates the UI elements required for the transfer function.
  */
 class TransferFunctionWidget extends Tab {
-  private transferFunctionPanel = this;
+  private transferFunctionPanel;
   autoRangeFinder: AutoRangeFinder;
   window = this.createWindowBoundInputs();
 


### PR DESCRIPTION
## Context

We are using `neuroglancer` as a library in a project. The project is split in two, a main project and a sub-project, the main project uses the sub-project that defines a react wrapper around neuroglancer. This sub-project, setup/built using vite, is the one that uses `neuroglancer` as a library (the main project uses Remix)

## Problem

At some point, when loading an URL with an `img` layer, the panel created try to initialize a invertlp widget. This component tries to access the webgl element from the context, but cannot because the context is undefined. It comes from here (see the screenshot below), in the constructor, there is a call to super(`e.display`), and `e.display` is `undefined`.

![bug2](https://github.com/user-attachments/assets/dc80cd2b-f366-4303-924b-c4d7ca614607)

This comes from the way this caller code is compiled:

```typescript
export class InvlerpWidget extends Tab {
  cdfPanel = this.registerDisposer(new CdfPanel(this));  // Here is the problem
  // ...
  constructor(
    visibility: WatchableVisibilityPriority,
    public display: DisplayContext,
    // ... 
  ) {
    super(visibility);
    // ...
```
![bug1](https://github.com/user-attachments/assets/a4bcfd93-4a76-4477-9fcd-8fad9263b50e)

we can see in the compiled code (screenshot under) that the `cdfPanel` is created as a new instance of `Zu`  (the constructor of `Zu` is the one from the first screenshot), and `this` is passed as parameter to the constructor of `Zu` , but `this.display` is not yet initialized, it's initialized few lines lower: `this.display = t`. 

This PR solves this issue by just moving the initialization in the constructor instead of keeping it at the class level:

```typescript
export class InvlerpWidget extends Tab {
  cdfPanel;
  boundElements;
  // ...
  constructor(
    visibility: WatchableVisibilityPriority,
    public display: DisplayContext,
    // ...
  ) {
    super(visibility);
    this.cdfPanel = this.registerDisposer(new CdfPanel(this)); 
    // ...
```
This fix seems to be related to https://github.com/google/neuroglancer/commit/04ed8f975d6cb5fe5a290015978ab1ec4e2e744d . 