### PR TITLE
modifying annotation schema to match real world examples

### DIFF
--- a/src/datasource/precomputed/json_schema/annotation.yml
+++ b/src/datasource/precomputed/json_schema/annotation.yml
@@ -39,13 +39,9 @@ properties:
       be contained with the bounding box defined by `.lower_bound` and
       `.upper_bound`.
   annotation_type:
-    title: |-
-      Annotation geometry type.
-    enum:
-      - "point"
-      - "line"
-      - "axis_aligned_bounding_box"
-      - "ellipsoid"
+    title: Annotation geometry type.
+    type: string
+    pattern: "^(?i)(point|line|axis_aligned_bounding_box|ellipsoid)$"
   properties:
     title: Additional properties associated with each annotation.
     type: array
@@ -200,9 +196,10 @@ properties:
             sharded format.
       required:
         - key
-        - grid_shape
-        - chunk_shape
         - limit
+      oneOf:
+        - required: ["grid_shape"]
+        - required: ["chunk_shape"]
   segment_properties:
     title: |
       Relative path to the directory containing associated :ref:`segment
@@ -218,6 +215,8 @@ properties:
     type: string
 required:
   - "@type"
-  - vertex_quantization_bits
-  - transform
-  - lod_scale_multiplier
+  - dimensions
+  - lower_bound
+  - upper_bound
+  - annotation_type
+  - properties


### PR DESCRIPTION
I was attempting to build a set of helper functions to facilitate reading precomputed annotations using tensorstore, and I thought i'd utilize the jsonschemas in this repo to facilitate validation. 

In starting to use them on a real world example such as "gs://neuroglancer-20191211_fafbv14_buhmann2019_li20190805" 

i discovered this failed validation for a few reasons, some of which were clear errors, and others that were perhaps oversights or inconsistencies between neuroglancer and the written spec.  I've modified the spec so that this info file passes validation in a way that I think makes sense but feedback is welcome.