### PR TITLE
fix: move attribute initialization from class level to constructor

### DIFF
--- a/src/display_context.ts
+++ b/src/display_context.ts
@@ -117,9 +117,8 @@ export abstract class RenderedPanel extends RefCounted {
   canvasRelativeLogicalLeft = 0;
   canvasRelativeLogicalTop = 0;
 
-  renderViewport = new RenderViewport();
-
-  boundsUpdated = new NullarySignal();
+  renderViewport;
+  boundsUpdated;
 
   private monitorState: PanelMonitorState = { isIntersecting: true };
 
@@ -130,6 +129,8 @@ export abstract class RenderedPanel extends RefCounted {
   ) {
     super();
     this.gl = context.gl;
+    this.renderViewport = new RenderViewport();
+    this.boundsUpdated = new NullarySignal();
     context.addPanel(this);
   }
 


### PR DESCRIPTION
This PR is a following of https://github.com/google/neuroglancer/pull/764, we identified in our build the `renderViewport` leading to a problematic compilation with remix/esbuild. I moved also the initialization of `boundsUpdated` for sake of harmony.