### PR TITLE
feat: Show/hide the shadder properties for the annotation layer depending on the code visibility

### DIFF
--- a/src/layer/annotation/index.ts
+++ b/src/layer/annotation/index.ts
@@ -44,6 +44,7 @@ import { getWatchableRenderLayerTransform } from "#src/render_coordinate_transfo
 import { RenderLayerRole } from "#src/renderlayer.js";
 import type { SegmentationDisplayState } from "#src/segmentation_display_state/frontend.js";
 import {
+  ElementVisibilityFromTrackableBoolean,
   TrackableBoolean,
   TrackableBooleanCheckbox,
 } from "#src/trackable_boolean.js";
@@ -793,6 +794,13 @@ class RenderingOptionsTab extends Tab {
         },
       ),
     ).element;
+
+    layer.registerDisposer(
+      new ElementVisibilityFromTrackableBoolean(
+        layer.codeVisible,
+        shaderProperties,
+      ),
+    );
 
     element.appendChild(shaderProperties);
     element.appendChild(


### PR DESCRIPTION
## Context

The show/hide code viewer feature for the shadder for annotations is not hidding the properties of the shadder when hidding the code editor.

![without](https://github.com/user-attachments/assets/10b2c0d2-7789-4e05-94e1-0d9256d8ab36)

This PR hides also the shadder properties when the shadder code editor is hidden

![with](https://github.com/user-attachments/assets/9e9d5392-0587-4b57-a41a-0c638ca5d3a6)
