### PR TITLE
feat: Add new polyline annotation type

### DIFF
--- a/python/examples/write_annotations.py
+++ b/python/examples/write_annotations.py
@@ -38,13 +38,13 @@ def write_some_annotations(
         ],
     )
     writer.add_polyline(
-        [[20, 30, 40], [10, 15, 20]],
+        [[25, 10, 20], [10, 15, 20]],
         size=10,
         cell_type=16,
         point_color=(0, 255, 0, 255),
     )
     writer.add_polyline(
-        [[50, 51, 52], [10, 15, 30], [40, 20, 25]],
+        [[5, 17, 29], [10, 15, 30], [40, 20, 25]],
         size=30,
         cell_type=16,
         point_color=(255, 0, 0, 255),
@@ -59,13 +59,8 @@ if __name__ == "__main__":
     neuroglancer.cli.handle_server_arguments(args)
     viewer = neuroglancer.Viewer()
 
-    # tempdir = tempfile.mkdtemp()
-    # tempdir = tempfile.mkdtemp()
-    # atexit.register(shutil.rmtree, tempdir)
-    tempdir = "/tmp/annotations"
-    if not os.path.exists(tempdir):
-        os.makedirs(tempdir)
-    shutil.rmtree(tempdir, ignore_errors=True)
+    tempdir = tempfile.mkdtemp()
+    atexit.register(shutil.rmtree, tempdir)
 
     coordinate_space = neuroglancer.CoordinateSpace(
         names=["x", "y", "z"], units=["nm", "nm", "nm"], scales=[10, 10, 10]
@@ -84,7 +79,7 @@ if __name__ == "__main__":
             ),
         )
         s.layers["points"] = neuroglancer.AnnotationLayer(
-            source=f"precomputed://{server.url + '/point'}",
+            source=f"precomputed://{server.url}/point",
             tab="rendering",
             shader="""
 void main() {
@@ -93,8 +88,8 @@ void main() {
 }
         """,
         )
-        s.layers["polyline"] = neuroglancer.AnnotationLayer(
-            source=f"precomputed://{server.url + '/polyline'}",
+        s.layers["polylines"] = neuroglancer.AnnotationLayer(
+            source=f"precomputed://{server.url}/polyline",
             tab="rendering",
             shader="""
 void main() {

--- a/python/examples/write_annotations.py
+++ b/python/examples/write_annotations.py
@@ -59,10 +59,13 @@ if __name__ == "__main__":
     neuroglancer.cli.handle_server_arguments(args)
     viewer = neuroglancer.Viewer()
 
-    tempdir = tempfile.mkdtemp()
+    # tempdir = tempfile.mkdtemp()
+    # tempdir = tempfile.mkdtemp()
+    # atexit.register(shutil.rmtree, tempdir)
+    tempdir = "/tmp/annotations"
     if not os.path.exists(tempdir):
         os.makedirs(tempdir)
-    atexit.register(shutil.rmtree, tempdir)
+    shutil.rmtree(tempdir, ignore_errors=True)
 
     coordinate_space = neuroglancer.CoordinateSpace(
         names=["x", "y", "z"], units=["nm", "nm", "nm"], scales=[10, 10, 10]

--- a/python/neuroglancer/__init__.py
+++ b/python/neuroglancer/__init__.py
@@ -47,6 +47,7 @@ from .viewer_state import (
     PlaceLineTool,  # noqa: F401
     PlaceBoundingBoxTool,  # noqa: F401
     PlaceEllipsoidTool,  # noqa: F401
+    PlacePolylineTool, # noqa: F401
     BlendTool,  # noqa: F401
     OpacityTool,  # noqa: F401
     VolumeRenderingTool,  # noqa: F401

--- a/python/neuroglancer/viewer_state.py
+++ b/python/neuroglancer/viewer_state.py
@@ -188,6 +188,12 @@ class PlaceEllipsoidTool(Tool):
 
 
 @export_tool
+class PlacePolylineTool(Tool):
+    __slots__ = ()
+    TOOL_TYPE = "annotatePolyline"
+
+
+@export_tool
 class BlendTool(LayerTool):
     __slots__ = ()
     TOOL_TYPE = "blend"

--- a/python/neuroglancer/write_annotations.py
+++ b/python/neuroglancer/write_annotations.py
@@ -51,8 +51,8 @@ AnnotationType = Literal["point", "line", "axis_aligned_bounding_box", "ellipsoi
 def _get_dtype_for_geometry(annotation_type: AnnotationType, rank: int):
     geometry_size = rank if annotation_type == "point" else 2 * rank
     if annotation_type == "polyline":
-        point_size = [("num_points", "<u4")]
-        return [point_size]
+        num_points = [("num_points", "<u4")]
+        return [num_points]
     return [("geometry", "<f4", geometry_size)]
 
 
@@ -112,6 +112,15 @@ class AnnotationWriter:
         self.related_annotations = [{} for _ in self.relationships]
 
     def get_dtype(self, annotation_size=None) -> np.dtype:
+        """
+        Prepares the dtype for the annotations.
+
+        Usually this is fixed, but for polylines we need to know the number of points
+        in the polyline to create the correct dtype.
+
+        Args:
+            annotation_size: The number of points in the polyline. Optional.
+        """
         if self.annotation_type == "polyline" and annotation_size is not None:
             geometry = ("geometry", "<f4", annotation_size)
             num_points = ("num_points", "<u4")

--- a/python/neuroglancer/write_annotations.py
+++ b/python/neuroglancer/write_annotations.py
@@ -185,6 +185,9 @@ class AnnotationWriter:
             )
         if len(points) < 2:
             raise ValueError("Expected at least two points for a polyline")
+        as_array = np.array(points)
+        self.lower_bound = np.minimum(self.lower_bound, as_array.min(axis=0))
+        self.upper_bound = np.maximum(self.upper_bound, as_array.max(axis=0))
         geometry = np.concatenate(points)
         self._add_obj(cast(Sequence[float], geometry), id, **kwargs)
 

--- a/python/neuroglancer/write_annotations.py
+++ b/python/neuroglancer/write_annotations.py
@@ -111,10 +111,13 @@ class AnnotationWriter:
         )
         self.related_annotations = [{} for _ in self.relationships]
 
-    def get_dtype(self, annotation_size = None) -> np.dtype:
+    def get_dtype(self, annotation_size=None) -> np.dtype:
         if self.annotation_type == "polyline" and annotation_size is not None:
             geometry = ("geometry", "<f4", annotation_size)
-            return np.dtype([geometry] + _get_dtype_for_properties(self.properties))
+            num_points = ("num_points", "<u4")
+            return np.dtype(
+                [num_points, geometry] + _get_dtype_for_properties(self.properties)
+            )
         return self._dtype
 
     def add_point(self, point: Sequence[float], id: int | None = None, **kwargs):
@@ -211,7 +214,7 @@ class AnnotationWriter:
         # We need to save the number of points
         encoded = np.zeros(shape=(), dtype=self.get_dtype(len(coords)))
         if self.annotation_type == "polyline":
-            encoded[()]["num_points"] = len(coords) // self.rank
+            encoded[()]["num_points"] = len(coords) // self.rank  # type: ignore[call-overload]
         encoded[()]["geometry"] = coords  # type: ignore[call-overload]
 
         for i, p in enumerate(self.properties):

--- a/python/neuroglancer/write_annotations.py
+++ b/python/neuroglancer/write_annotations.py
@@ -185,7 +185,7 @@ class AnnotationWriter:
             )
         if len(points) < 2:
             raise ValueError("Expected at least two points for a polyline")
-        as_array = np.array(points)
+        as_array = np.asarray(points)
         self.lower_bound = np.minimum(self.lower_bound, as_array.min(axis=0))
         self.upper_bound = np.maximum(self.upper_bound, as_array.max(axis=0))
         geometry = np.concatenate(points)

--- a/python/tests/annotation_properties_test.py
+++ b/python/tests/annotation_properties_test.py
@@ -21,7 +21,11 @@ import pytest
 
 @pytest.mark.parametrize(
     "annotation,annotation_geometry",
-    [(neuroglancer.PointAnnotation, {"point": [0, 0]})],
+    [
+        (neuroglancer.PointAnnotation, {"point": [0, 0]}),
+        (neuroglancer.LineAnnotation, {"pointA": [0, 0], "pointB": [1, 1]}),
+        (neuroglancer.PolyLineAnnotation, {"points": [[0, 0], [1, 1], [-1, 1]]}),
+    ],
 )
 def test_annotate_properties(webdriver, annotation, annotation_geometry):
     kwargs = [
@@ -77,6 +81,7 @@ def test_annotate_properties(webdriver, annotation, annotation_geometry):
 void main() {
   setColor(prop_color());
   setPointMarkerSize(1000.0);
+  setEndpointMarkerSize(1000.0);
 }
 """,
             ),

--- a/python/tests/annotation_properties_test.py
+++ b/python/tests/annotation_properties_test.py
@@ -16,9 +16,20 @@
 import neuroglancer
 import neuroglancer.test_utils
 import numpy as np
+import pytest
 
 
-def test_annotate(webdriver):
+@pytest.mark.parametrize(
+    "annotation,annotation_geometry",
+    [(neuroglancer.PointAnnotation, {"point": [0, 0]})],
+)
+def test_annotate_properties(webdriver, annotation, annotation_geometry):
+    kwargs = [
+        {"id": "1", "segments": [[42], []], "props": ["#0f0"], **annotation_geometry},
+        {"id": "2", "segments": [[], [43]], "props": ["#00f"], **annotation_geometry},
+        {"id": "3", "segments": [[], [44]], "props": ["#0ff"], **annotation_geometry},
+    ]
+
     with webdriver.viewer.txn() as s:
         s.dimensions = neuroglancer.CoordinateSpace(
             names=["x", "y"], units="nm", scales=[1, 1]
@@ -61,26 +72,7 @@ def test_annotate(webdriver):
                         default="red",
                     )
                 ],
-                annotations=[
-                    neuroglancer.PointAnnotation(
-                        id="1",
-                        point=[0, 0],
-                        segments=[[42], []],
-                        props=["#0f0"],
-                    ),
-                    neuroglancer.PointAnnotation(
-                        id="2",
-                        point=[0, 0],
-                        segments=[[], [43]],
-                        props=["#00f"],
-                    ),
-                    neuroglancer.PointAnnotation(
-                        id="3",
-                        point=[0, 0],
-                        segments=[[], [44]],
-                        props=["#0ff"],
-                    ),
-                ],
+                annotations=[annotation(**kw) for kw in kwargs],
                 shader="""
 void main() {
   setColor(prop_color());

--- a/python/tests/annotation_tool_test.py
+++ b/python/tests/annotation_tool_test.py
@@ -63,6 +63,12 @@ def setup_viewer(viewer):
             neuroglancer.EllipsoidAnnotation,
             2,
         ),
+        (
+            "annotatePolyline",
+            neuroglancer.PlacePolylineTool,
+            neuroglancer.PolyLineAnnotation,
+            3,
+        ),
     ],
 )
 def test_annotate(webdriver, tool, tool_class, annotation_class, num_clicks):
@@ -84,5 +90,5 @@ def test_annotate(webdriver, tool, tool_class, annotation_class, num_clicks):
     annotations = webdriver.viewer.state.layers["a"].annotations
     assert len(annotations) == 1
     assert isinstance(annotations[0], annotation_class)
-    if tool in ("annotatePoint", "annotateLine"):
+    if tool in ("annotatePoint", "annotateLine", "annotatePolyline"):
         assert list(annotations[0].segments[0]) == [42]

--- a/python/tests/write_annotations_test.py
+++ b/python/tests/write_annotations_test.py
@@ -142,7 +142,6 @@ def test_annotation_writer_polyline(tmp_path: pathlib.Path):
     total = len(lines)
     property_bytes = 12
     for i, (line, id_) in enumerate(zip(lines, ids)):
-        print(offset)
         offset = check_polyline_contents(contents, line, id_, i - total, offset=offset)
         offset += property_bytes
 

--- a/src/annotation/backend.ts
+++ b/src/annotation/backend.ts
@@ -102,7 +102,7 @@ export class AnnotationGeometryData implements SerializedAnnotations {
   typeToOffset: number[];
   typeToIds: string[][];
   typeToIdMaps: Map<string, number>[];
-  idToSizeMaps: Map<string, AnnotationInstanceCount>[];
+  typeToInstanceCounts: number[][];
   typeToSize: number[];
 
   serialize(msg: any, transfers: any[]) {
@@ -110,7 +110,7 @@ export class AnnotationGeometryData implements SerializedAnnotations {
     msg.typeToOffset = this.typeToOffset;
     msg.typeToIds = this.typeToIds;
     msg.typeToIdMaps = this.typeToIdMaps;
-    msg.idToSizeMaps = this.idToSizeMaps;
+    msg.typeToInstanceCounts = this.typeToInstanceCounts;
     msg.typeToSize = this.typeToSize;
     transfers.push(this.data.buffer);
   }

--- a/src/annotation/backend.ts
+++ b/src/annotation/backend.ts
@@ -31,6 +31,7 @@ import {
 import type {
   Annotation,
   AnnotationId,
+  AnnotationInstanceCount,
   SerializedAnnotations,
 } from "#src/annotation/index.js";
 import type { ChunkManager } from "#src/chunk_manager/backend.js";
@@ -101,7 +102,7 @@ export class AnnotationGeometryData implements SerializedAnnotations {
   typeToOffset: number[];
   typeToIds: string[][];
   typeToIdMaps: Map<string, number>[];
-  idToSizeMaps: Map<string, number>[];
+  idToSizeMaps: Map<string, AnnotationInstanceCount>[];
   typeToSize: number[];
 
   serialize(msg: any, transfers: any[]) {

--- a/src/annotation/backend.ts
+++ b/src/annotation/backend.ts
@@ -31,7 +31,6 @@ import {
 import type {
   Annotation,
   AnnotationId,
-  AnnotationInstanceCount,
   SerializedAnnotations,
 } from "#src/annotation/index.js";
 import type { ChunkManager } from "#src/chunk_manager/backend.js";

--- a/src/annotation/frontend_source.browser_test.ts
+++ b/src/annotation/frontend_source.browser_test.ts
@@ -54,7 +54,9 @@ class UpdateTester {
     expect(direct.typeToIds).toEqual(incremental.typeToIds);
     expect(direct.typeToOffset).toEqual(incremental.typeToOffset);
     expect(direct.typeToIdMaps).toEqual(incremental.typeToIdMaps);
-    expect(direct.idToSizeMaps).toEqual(incremental.idToSizeMaps);
+    console.log("direct", direct.typeToInstanceCounts);
+    console.log("incr", incremental.typeToInstanceCounts);
+    expect(direct.typeToInstanceCounts).toEqual(incremental.typeToInstanceCounts);
     expect(direct.typeToSize).toEqual(incremental.typeToSize);
   }
   update(annotation: Annotation) {

--- a/src/annotation/frontend_source.browser_test.ts
+++ b/src/annotation/frontend_source.browser_test.ts
@@ -50,7 +50,6 @@ class UpdateTester {
     for (const annotation of this.annotations) serializer.add(annotation);
     const direct = serializer.serialize();
     const incremental = this.incrementalChunk.data!.serializedAnnotations;
-    console.log(direct, incremental);
     expect(direct.data).toEqual(incremental.data);
     expect(direct.typeToIds).toEqual(incremental.typeToIds);
     expect(direct.typeToOffset).toEqual(incremental.typeToOffset);

--- a/src/annotation/frontend_source.browser_test.ts
+++ b/src/annotation/frontend_source.browser_test.ts
@@ -54,8 +54,6 @@ class UpdateTester {
     expect(direct.typeToIds).toEqual(incremental.typeToIds);
     expect(direct.typeToOffset).toEqual(incremental.typeToOffset);
     expect(direct.typeToIdMaps).toEqual(incremental.typeToIdMaps);
-    console.log("direct", direct.typeToInstanceCounts);
-    console.log("incr", incremental.typeToInstanceCounts);
     expect(direct.typeToInstanceCounts).toEqual(
       incremental.typeToInstanceCounts,
     );

--- a/src/annotation/frontend_source.browser_test.ts
+++ b/src/annotation/frontend_source.browser_test.ts
@@ -50,6 +50,7 @@ class UpdateTester {
     for (const annotation of this.annotations) serializer.add(annotation);
     const direct = serializer.serialize();
     const incremental = this.incrementalChunk.data!.serializedAnnotations;
+    console.log(direct, incremental);
     expect(direct.data).toEqual(incremental.data);
     expect(direct.typeToIds).toEqual(incremental.typeToIds);
     expect(direct.typeToOffset).toEqual(incremental.typeToOffset);
@@ -88,7 +89,6 @@ class UpdateTester {
   }
 }
 
-// TODO (SKM) expand with polyline
 describe("updateAnnotations", () => {
   it("rank 1", () => {
     const tester = new UpdateTester(1, []);

--- a/src/annotation/frontend_source.browser_test.ts
+++ b/src/annotation/frontend_source.browser_test.ts
@@ -56,7 +56,9 @@ class UpdateTester {
     expect(direct.typeToIdMaps).toEqual(incremental.typeToIdMaps);
     console.log("direct", direct.typeToInstanceCounts);
     console.log("incr", incremental.typeToInstanceCounts);
-    expect(direct.typeToInstanceCounts).toEqual(incremental.typeToInstanceCounts);
+    expect(direct.typeToInstanceCounts).toEqual(
+      incremental.typeToInstanceCounts,
+    );
     expect(direct.typeToSize).toEqual(incremental.typeToSize);
   }
   update(annotation: Annotation) {

--- a/src/annotation/frontend_source.ts
+++ b/src/annotation/frontend_source.ts
@@ -383,7 +383,7 @@ export function updateAnnotation(
       /*destCount=*/ index + 1,
     );
     ids.push(annotation.id);
-    typeToSize[type] = ids.length; 
+    typeToSize[type] = ids.length;
     serializedAnnotations.data = newData;
   }
   const bufferOffset = serializedAnnotations.typeToOffset![type];
@@ -845,6 +845,28 @@ export class MultiscaleAnnotationSource
             tempLower[i] = c - r;
             tempUpper[i] = c + r;
           }
+          break;
+        case AnnotationType.POLYLINE:
+          for (const point of annotation.points) {
+            for (let i = 0; i < rank; ++i) {
+              tempLower[i] = Math.min(point[i], tempLower[i]);
+              tempUpper[i] = Math.max(point[i], tempUpper[i]);
+            }
+          }
+          matrix.transformPoint(
+            tempLower,
+            source.multiscaleToChunkTransform,
+            rank + 1,
+            tempLower,
+            rank,
+          );
+          matrix.transformPoint(
+            tempUpper,
+            source.multiscaleToChunkTransform,
+            rank + 1,
+            tempUpper,
+            rank,
+          );
           break;
       }
       let totalChunks = 1;

--- a/src/annotation/frontend_source.ts
+++ b/src/annotation/frontend_source.ts
@@ -27,7 +27,6 @@ import {
 import type {
   Annotation,
   AnnotationId,
-  AnnotationInstanceCount,
   AnnotationPropertySerializer,
   AnnotationPropertySpec,
   AnnotationSourceSignals,

--- a/src/annotation/frontend_source.ts
+++ b/src/annotation/frontend_source.ts
@@ -454,7 +454,7 @@ export function deleteAnnotation(
     /*destCount=*/ ids.length - 1,
   );
   ids.splice(index, 1);
-  typeToSize[type] -= 1;
+  typeToSize[type] = ids.length;
   idMap.delete(id);
   for (let i = index, count = ids.length; i < count; ++i) {
     idMap.set(ids[i], i);

--- a/src/annotation/frontend_source.ts
+++ b/src/annotation/frontend_source.ts
@@ -27,6 +27,7 @@ import {
 import type {
   Annotation,
   AnnotationId,
+  AnnotationInstanceCount,
   AnnotationPropertySerializer,
   AnnotationPropertySpec,
   AnnotationSourceSignals,
@@ -490,7 +491,7 @@ export function makeTemporaryChunk() {
   const typeToIds: string[][] = [];
   const typeToOffset: number[] = [];
   const typeToIdMaps: Map<string, number>[] = [];
-  const idToSizeMaps: Map<string, number>[] = [];
+  const idToSizeMaps: Map<string, AnnotationInstanceCount>[] = [];
   const typeToSize: number[] = [];
 
   for (const annotationType of annotationTypes) {

--- a/src/annotation/frontend_source.ts
+++ b/src/annotation/frontend_source.ts
@@ -358,6 +358,7 @@ export function updateAnnotation(
   const { serializedAnnotations } = chunk;
   const ids = serializedAnnotations.typeToIds[type];
   const idMap = serializedAnnotations.typeToIdMaps[type];
+  const typeToSize = serializedAnnotations.typeToSize;
   const handler = annotationTypeHandlers[type];
   const numBytes = propertySerializers[type].serializedBytes;
   let index = idMap.get(annotation.id);
@@ -382,6 +383,7 @@ export function updateAnnotation(
       /*destCount=*/ index + 1,
     );
     ids.push(annotation.id);
+    typeToSize[type] = ids.length; 
     serializedAnnotations.data = newData;
   }
   const bufferOffset = serializedAnnotations.typeToOffset![type];
@@ -418,6 +420,7 @@ export function deleteAnnotation(
 ): boolean {
   const { serializedAnnotations } = chunk;
   const idMap = serializedAnnotations.typeToIdMaps[type];
+  const typeToSize = serializedAnnotations.typeToSize;
   const index = idMap.get(id);
   if (index === undefined) {
     return false;
@@ -451,6 +454,7 @@ export function deleteAnnotation(
     /*destCount=*/ ids.length - 1,
   );
   ids.splice(index, 1);
+  typeToSize[type] -= 1;
   idMap.delete(id);
   for (let i = index, count = ids.length; i < count; ++i) {
     idMap.set(ids[i], i);

--- a/src/annotation/index.ts
+++ b/src/annotation/index.ts
@@ -948,7 +948,7 @@ export const annotationTypeHandlers: Record<
         let index = 0;
         const max_polyline_verts = 100000;
         while (true && index <= max_polyline_verts) {
-          const isLastLine = buffer.getUint32(offset, isLittleEndian) >> 31;
+          const isLastLine = buffer.getUint32(currOffset, isLittleEndian) >> 31;
           const point = new Float32Array(rank);
           const tempOffset = deserializeFloatVector(
             buffer,

--- a/src/annotation/index.ts
+++ b/src/annotation/index.ts
@@ -89,13 +89,6 @@ export const annotationTypes = [
   AnnotationType.POLYLINE,
 ];
 
-export const oldAnnotationTypes = [
-  AnnotationType.POINT,
-  AnnotationType.LINE,
-  AnnotationType.AXIS_ALIGNED_BOUNDING_BOX,
-  AnnotationType.ELLIPSOID,
-];
-
 export interface AnnotationPropertySpecBase {
   identifier: string;
   description: string | undefined;

--- a/src/annotation/index.ts
+++ b/src/annotation/index.ts
@@ -80,11 +80,6 @@ export enum AnnotationType {
   POLYLINE = 4,
 }
 
-export interface AnnotationInstanceCount {
-  numInstances: number;
-  cumulativeInstances: number;
-}
-
 export const annotationTypes = [
   AnnotationType.POINT,
   AnnotationType.LINE,
@@ -1579,7 +1574,7 @@ function serializeAnnotations(
     const annotations: Annotation[] = allAnnotations[annotationType];
     typeToInstanceCounts[annotationType] = Array.from(
       { length: annotations.length },
-      (_, i) => i
+      (_, i) => i,
     );
     typeToIds[annotationType] = annotations.map((x) => x.id);
     typeToIdMaps[annotationType] = new Map(

--- a/src/annotation/index.ts
+++ b/src/annotation/index.ts
@@ -954,7 +954,7 @@ export const annotationTypeHandlers: Record<
         properties: [
           {
             type: "uint32",
-            identifier: "Point count",
+            identifier: "Num vertices",
             default: 0,
             description: "Number of points in the polyline",
           },

--- a/src/annotation/index.ts
+++ b/src/annotation/index.ts
@@ -716,10 +716,7 @@ export interface AnnotationTypeHandler<T extends Annotation = Annotation> {
     annotation: T,
     callback: (vec: Float32Array, isVector: boolean) => void,
   ) => void;
-  defaultProperties: (
-    annotation: T,
-    scales: vec3,
-  ) => {
+  defaultProperties: (annotation: T) => {
     properties: AnnotationNumericPropertySpec[];
     values: number[];
   };
@@ -866,9 +863,8 @@ export const annotationTypeHandlers: Record<
       callback(annotation.pointA, false);
       callback(annotation.pointB, false);
     },
-    defaultProperties(annotation: Line, scales: vec3) {
+    defaultProperties(annotation: Line) {
       annotation;
-      scales;
       return { properties: [], values: [] };
     },
   },
@@ -948,8 +944,7 @@ export const annotationTypeHandlers: Record<
         callback(point, false);
       }
     },
-    defaultProperties(annotation: PolyLine, scales: vec3) {
-      scales;
+    defaultProperties(annotation: PolyLine) {
       return {
         properties: [
           {
@@ -1006,9 +1001,8 @@ export const annotationTypeHandlers: Record<
     visitGeometry(annotation: Point, callback) {
       callback(annotation.point, false);
     },
-    defaultProperties(annotation: Point, scales: vec3) {
+    defaultProperties(annotation: Point) {
       annotation;
-      scales;
       return { properties: [], values: [] };
     },
   },
@@ -1079,9 +1073,8 @@ export const annotationTypeHandlers: Record<
       callback(annotation.pointA, false);
       callback(annotation.pointB, false);
     },
-    defaultProperties(annotation: AxisAlignedBoundingBox, scales: vec3) {
+    defaultProperties(annotation: AxisAlignedBoundingBox) {
       annotation;
-      scales;
       return { properties: [], values: [] };
     },
   },
@@ -1152,9 +1145,8 @@ export const annotationTypeHandlers: Record<
       callback(annotation.center, false);
       callback(annotation.radii, true);
     },
-    defaultProperties(annotation: Ellipsoid, scales: vec3) {
+    defaultProperties(annotation: Ellipsoid) {
       annotation;
-      scales;
       return { properties: [], values: [] };
     },
   },

--- a/src/annotation/index.ts
+++ b/src/annotation/index.ts
@@ -947,7 +947,7 @@ export const annotationTypeHandlers: Record<
         let currOffset = offset;
         let index = 0;
         const max_polyline_verts = 100000;
-        while (true && index <= max_polyline_verts) {
+        while (index <= max_polyline_verts) {
           const isLastLine = buffer.getUint32(currOffset, isLittleEndian) >> 31;
           const point = new Float32Array(rank);
           const tempOffset = deserializeFloatVector(

--- a/src/annotation/index.ts
+++ b/src/annotation/index.ts
@@ -1480,7 +1480,6 @@ export class LocalAnnotationSource extends AnnotationSource {
     };
 
     for (const annotation of this.annotationMap.values()) {
-      // TODO (SKM) properly handle polyline annotation
       switch (annotation.type) {
         case AnnotationType.POINT:
           annotation.point = mapVector(annotation.point);

--- a/src/annotation/index.ts
+++ b/src/annotation/index.ts
@@ -24,7 +24,7 @@ import type {
   CoordinateSpaceTransform,
   WatchableCoordinateSpaceTransform,
 } from "#src/coordinate_transform.js";
-import { arraysEqual, arraysEqualWithPredicate } from "#src/util/array.js";
+import { arraysEqual } from "#src/util/array.js";
 import {
   packColor,
   parseRGBAColorSpecification,
@@ -907,18 +907,12 @@ export const annotationTypeHandlers: Record<
       // P1 P2 PROPERTIES P3 P4 PROPERTIES ...
       // TODO SKM don't actually need intance index
       let startingOffset = offset + instanceIndex * geometryDataStride;
-      const isClosed = annotation.points.length > 1 && arraysEqualWithPredicate(
-        annotation.points[0],
-        annotation.points[annotation.points.length - 1],
-        (a, b) => Math.abs(a - b) / Math.max(Math.abs(a), Math.abs(b)) < 1e-6,
-      );
       for (let i = 0; i < annotation.points.length - 1; i++) {
-        // 0 for regular points, 1 for last point unless closed
-        const pointType = i === annotation.points.length - 2 ? (isClosed ? 0 : 1) : 0;
-        console.log(isClosed, pointType);
+        // 0 for regular points, 1 for last point
+        const pointType = i === annotation.points.length - 2 ? 1 : 0;
         const tempOffset = startingOffset + i * geometryDataStride;
         // Combine the point type and i into a single uint32
-        buffer.setUint32(tempOffset, pointType << 31 | i, isLittleEndian);
+        buffer.setUint32(tempOffset, (pointType << 31) | i, isLittleEndian);
         const firstPoint = annotation.points[i];
         const secondPoint = annotation.points[i + 1];
         serializeTwoFloatVectors(

--- a/src/annotation/line.ts
+++ b/src/annotation/line.ts
@@ -50,8 +50,8 @@ const PICK_IDS_PER_INSTANCE = ENDPOINTS_PICK_OFFSET + 2;
 
 export function defineNoOpEndpointMarkerSetters(builder: ShaderBuilder) {
   builder.addVertexCode(`
-void setEndpointMarkerSize(float startSize, float endSize) {}
-void setEndpointMarkerBorderWidth(float startSize, float endSize) {}
+void _setEndpointMarkerSize(float startSize, float endSize) {}
+void _setEndpointMarkerBorderWidth(float startSize, float endSize) {}
 void _setEndpointMarkerColor(vec4 startColor, vec4 endColor) {}
 void _setEndpointMarkerBorderColor(vec4 startColor, vec4 endColor) {}
 `);
@@ -139,10 +139,10 @@ float ng_markerBorderWidth;
 int getEndpointIndex() {
   return gl_VertexID / ${VERTICES_PER_CIRCLE};
 }
-void setEndpointMarkerSize(float startSize, float endSize) {
+void _setEndpointMarkerSize(float startSize, float endSize) {
   ng_markerDiameter = mix(startSize, endSize, float(getEndpointIndex()));
 }
-void setEndpointMarkerBorderWidth(float startSize, float endSize) {
+void _setEndpointMarkerBorderWidth(float startSize, float endSize) {
   ng_markerBorderWidth = mix(startSize, endSize, float(getEndpointIndex()));
 }
 void _setEndpointMarkerColor(vec4 startColor, vec4 endColor) {

--- a/src/annotation/line.ts
+++ b/src/annotation/line.ts
@@ -48,23 +48,23 @@ const FULL_OBJECT_PICK_OFFSET = 0;
 const ENDPOINTS_PICK_OFFSET = FULL_OBJECT_PICK_OFFSET + 1;
 const PICK_IDS_PER_INSTANCE = ENDPOINTS_PICK_OFFSET + 2;
 
-export function defineNoOpEndpointMarkerSetters(builder: ShaderBuilder) {
+function defineNoOpEndpointMarkerSetters(builder: ShaderBuilder) {
   builder.addVertexCode(`
-void _setEndpointMarkerSize(float startSize, float endSize) {}
-void _setEndpointMarkerBorderWidth(float startSize, float endSize) {}
-void _setEndpointMarkerColor(vec4 startColor, vec4 endColor) {}
-void _setEndpointMarkerBorderColor(vec4 startColor, vec4 endColor) {}
+void setLineEndpointMarkerSize(float startSize, float endSize) {}
+void setLineEndpointMarkerBorderWidth(float startSize, float endSize) {}
+void setLineEndpointMarkerColor(vec4 startColor, vec4 endColor) {}
+void setLineEndpointMarkerBorderColor(vec4 startColor, vec4 endColor) {}
 `);
 }
 
-export function defineNoOpLineSetters(builder: ShaderBuilder) {
+function defineNoOpLineSetters(builder: ShaderBuilder) {
   builder.addVertexCode(`
-void _setLineWidth(float width) {}
-void _setLineColor(vec4 startColor, vec4 endColor) {}
+void setSingleLineWidth(float width) {}
+void setSingleLineColor(vec4 startColor, vec4 endColor) {}
 `);
 }
 
-export class LineRenderHelper extends AnnotationRenderHelper {
+class RenderHelper extends AnnotationRenderHelper {
   defineShader(builder: ShaderBuilder) {
     defineVertexId(builder);
     // Position of endpoints in model coordinates.
@@ -94,10 +94,10 @@ float ng_LineWidth;
 `);
       defineNoOpEndpointMarkerSetters(builder);
       builder.addVertexCode(`
-void _setLineWidth(float width) {
+void setSingleLineWidth(float width) {
   ng_LineWidth = width;
 }
-void _setLineColor(vec4 startColor, vec4 endColor) {
+void setSingleLineColor(vec4 startColor, vec4 endColor) {
   vColor = mix(startColor, endColor, getLineEndpointCoefficient());
 }
 `);
@@ -139,16 +139,16 @@ float ng_markerBorderWidth;
 int getEndpointIndex() {
   return gl_VertexID / ${VERTICES_PER_CIRCLE};
 }
-void _setEndpointMarkerSize(float startSize, float endSize) {
+void setLineEndpointMarkerSize(float startSize, float endSize) {
   ng_markerDiameter = mix(startSize, endSize, float(getEndpointIndex()));
 }
-void _setEndpointMarkerBorderWidth(float startSize, float endSize) {
+void setLineEndpointMarkerBorderWidth(float startSize, float endSize) {
   ng_markerBorderWidth = mix(startSize, endSize, float(getEndpointIndex()));
 }
-void _setEndpointMarkerColor(vec4 startColor, vec4 endColor) {
+void setLineEndpointMarkerColor(vec4 startColor, vec4 endColor) {
   vColor = mix(startColor, endColor, float(getEndpointIndex()));
 }
-void _setEndpointMarkerBorderColor(vec4 startColor, vec4 endColor) {
+void setLineEndpointMarkerBorderColor(vec4 startColor, vec4 endColor) {
   vBorderColor = mix(startColor, endColor, float(getEndpointIndex()));
 }
 `);
@@ -247,8 +247,8 @@ function snapPositionToEndpoint(
 }
 
 registerAnnotationTypeRenderHandler<Line>(AnnotationType.LINE, {
-  sliceViewRenderHelper: LineRenderHelper,
-  perspectiveViewRenderHelper: LineRenderHelper,
+  sliceViewRenderHelper: RenderHelper,
+  perspectiveViewRenderHelper: RenderHelper,
   defineShaderNoOpSetters(builder) {
     defineNoOpEndpointMarkerSetters(builder);
     defineNoOpLineSetters(builder);

--- a/src/annotation/line.ts
+++ b/src/annotation/line.ts
@@ -53,7 +53,7 @@ export function defineNoOpEndpointMarkerSetters(builder: ShaderBuilder) {
 void setEndpointMarkerSize(float startSize, float endSize) {}
 void setEndpointMarkerBorderWidth(float startSize, float endSize) {}
 void _setEndpointMarkerColor(vec4 startColor, vec4 endColor) {}
-void setEndpointMarkerBorderColor(vec4 startColor, vec4 endColor) {}
+void _setEndpointMarkerBorderColor(vec4 startColor, vec4 endColor) {}
 `);
 }
 
@@ -148,7 +148,7 @@ void setEndpointMarkerBorderWidth(float startSize, float endSize) {
 void _setEndpointMarkerColor(vec4 startColor, vec4 endColor) {
   vColor = mix(startColor, endColor, float(getEndpointIndex()));
 }
-void setEndpointMarkerBorderColor(vec4 startColor, vec4 endColor) {
+void _setEndpointMarkerBorderColor(vec4 startColor, vec4 endColor) {
   vBorderColor = mix(startColor, endColor, float(getEndpointIndex()));
 }
 `);

--- a/src/annotation/line.ts
+++ b/src/annotation/line.ts
@@ -59,7 +59,7 @@ void setEndpointMarkerBorderColor(vec4 startColor, vec4 endColor) {}
 
 export function defineNoOpLineSetters(builder: ShaderBuilder) {
   builder.addVertexCode(`
-void setLineWidth(float width) {}
+void _setLineWidth(float width) {}
 void setLineColor(vec4 startColor, vec4 endColor) {}
 `);
 }
@@ -94,7 +94,7 @@ float ng_LineWidth;
 `);
       defineNoOpEndpointMarkerSetters(builder);
       builder.addVertexCode(`
-void setLineWidth(float width) {
+void _setLineWidth(float width) {
   ng_LineWidth = width;
 }
 void setLineColor(vec4 startColor, vec4 endColor) {

--- a/src/annotation/line.ts
+++ b/src/annotation/line.ts
@@ -60,7 +60,7 @@ void setEndpointMarkerBorderColor(vec4 startColor, vec4 endColor) {}
 export function defineNoOpLineSetters(builder: ShaderBuilder) {
   builder.addVertexCode(`
 void _setLineWidth(float width) {}
-void setLineColor(vec4 startColor, vec4 endColor) {}
+void _setLineColor(vec4 startColor, vec4 endColor) {}
 `);
 }
 
@@ -97,7 +97,7 @@ float ng_LineWidth;
 void _setLineWidth(float width) {
   ng_LineWidth = width;
 }
-void setLineColor(vec4 startColor, vec4 endColor) {
+void _setLineColor(vec4 startColor, vec4 endColor) {
   vColor = mix(startColor, endColor, getLineEndpointCoefficient());
 }
 `);

--- a/src/annotation/line.ts
+++ b/src/annotation/line.ts
@@ -52,7 +52,7 @@ export function defineNoOpEndpointMarkerSetters(builder: ShaderBuilder) {
   builder.addVertexCode(`
 void setEndpointMarkerSize(float startSize, float endSize) {}
 void setEndpointMarkerBorderWidth(float startSize, float endSize) {}
-void setEndpointMarkerColor(vec4 startColor, vec4 endColor) {}
+void _setEndpointMarkerColor(vec4 startColor, vec4 endColor) {}
 void setEndpointMarkerBorderColor(vec4 startColor, vec4 endColor) {}
 `);
 }
@@ -145,7 +145,7 @@ void setEndpointMarkerSize(float startSize, float endSize) {
 void setEndpointMarkerBorderWidth(float startSize, float endSize) {
   ng_markerBorderWidth = mix(startSize, endSize, float(getEndpointIndex()));
 }
-void setEndpointMarkerColor(vec4 startColor, vec4 endColor) {
+void _setEndpointMarkerColor(vec4 startColor, vec4 endColor) {
   vColor = mix(startColor, endColor, float(getEndpointIndex()));
 }
 void setEndpointMarkerBorderColor(vec4 startColor, vec4 endColor) {

--- a/src/annotation/polyline.ts
+++ b/src/annotation/polyline.ts
@@ -309,13 +309,9 @@ registerAnnotationTypeRenderHandler<PolyLine>(AnnotationType.POLYLINE, {
   },
   pickIdsPerInstance: PICK_IDS_PER_INSTANCE,
   snapPosition(position, data, offset, partIndex) {
-    const { linePart, lineIndex } = getPartIndexInfo(partIndex);
+    const { linePart } = getPartIndexInfo(partIndex);
     const rank = position.length;
-    const startingOffset =
-      offset +
-      4 +
-      lineIndex *
-        annotationTypeHandlers[AnnotationType.POLYLINE].serializedBytes(rank);
+    const startingOffset = offset + 4;
     if (linePart !== FULL_OBJECT_PICK_OFFSET) {
       const dataOffset = startingOffset + (linePart - 1) * 4 * rank;
       const point = new Float32Array(data, dataOffset, rank);

--- a/src/annotation/polyline.ts
+++ b/src/annotation/polyline.ts
@@ -84,11 +84,11 @@ class RenderHelper extends AnnotationRenderHelper {
     const type = "uint";
     const name = "aPolyLineNumVertices";
     builder.addAttribute(type, name);
-    // Low 30 bits store number of vertices.
+    // Low 31 bits store number of vertices.
     builder.addVertexCode(
       `${type} getNumRelatedInstances() { return ${name} & 0x7FFFFFFFu; }`,
     );
-    // High 2 bits store where the polyline is started or ended
+    // High bit stores whether the polyline is ended at this line
     builder.addVertexCode(
       `${type} getPolyLineEndpointType() { return ${name} >> 31u; }`,
     );

--- a/src/annotation/polyline.ts
+++ b/src/annotation/polyline.ts
@@ -19,10 +19,7 @@
  */
 
 import type { PolyLine } from "#src/annotation/index.js";
-import {
-  AnnotationType,
-  annotationTypeHandlers,
-} from "#src/annotation/index.js";
+import { AnnotationType } from "#src/annotation/index.js";
 import type {
   AnnotationRenderContext,
   AnnotationShaderGetter,

--- a/src/annotation/polyline.ts
+++ b/src/annotation/polyline.ts
@@ -225,7 +225,6 @@ class RenderHelper extends AnnotationRenderHelper {
   ) {
     super.enable(shaderGetter, context, (shader) => {
       const binder = shader.vertexShaderInputBinders.VertexPosition;
-      // TODO don't really need the countBinder, could do inline here
       const countBinder = shader.vertexShaderInputBinders.aPolyLineNumVertices;
       binder.enable(1);
       countBinder.enable(1);

--- a/src/annotation/rendering.md
+++ b/src/annotation/rendering.md
@@ -165,6 +165,31 @@ void setEndpointMarkerBorderWidth(float startWidth, float endWidth);
 
 Sets separate border widths for the endpoint markers.
 
+#### Polyline annotations
+
+Polyline annotations are rendered as line segments with circles marking the endpoints. Unlike line annotations, there can be multiple segments.
+
+Polyline annotations follow the same API as line annotations. The default behaviour is that setting a parameter for line annotations will also set the same parameter for polyline annotations. To set a parameter for only the polyline, use the `setPoly` prefix. For example:
+
+```glsl
+setLineWidth(2.0);
+setPolyLineWidth(4.0);
+
+setEndpointMarkerSize(1.0, 2.0);
+setPolyEndpointMarkerSize(3.0, 1.0);
+```
+
+All of the names spefically for polylines are as follows for reference, and they have the exact same behaviour as the line annotations (including allowing a reduced set of parameters):
+
+```glsl
+void setPolyLineColor(vec4 startColor, vec4 endColor);
+void setPolyLineWidth(float width);
+void setPolyEndpointMarkerColor(vec4 startColor, vec4 endColor);
+void setPolyEndpointMarkerBorderColor(vec4 startColor, vec4 endColor);
+void setPolyEndpointMarkerSize(float startSize, float endSize);
+void setPolyEndpointMarkerBorderWidth(float startSize, float endSize);
+```
+
 #### Bounding box annotations
 
 ```glsl

--- a/src/annotation/renderlayer.ts
+++ b/src/annotation/renderlayer.ts
@@ -817,7 +817,6 @@ function AnnotationRenderLayer<
     }
 
     transformPickedValue(pickState: PickState) {
-      console.log("Transforming picked value");
       const { pickedAnnotationBuffer } = pickState;
       if (pickedAnnotationBuffer === undefined) return undefined;
       const { properties } = this.base.source;
@@ -825,8 +824,8 @@ function AnnotationRenderLayer<
       const {
         pickedAnnotationBufferBaseOffset,
         pickedAnnotationType,
-        pickedAnnotationIndex,
-        pickedAnnotationCount,
+        pickedAnnotationInstanceIndex,
+        pickedAnnotationInstanceCount,
       } = pickState;
       const { annotationPropertySerializers } = this.base.source;
       // Check if there are any properties.
@@ -834,8 +833,8 @@ function AnnotationRenderLayer<
       annotationPropertySerializers[pickedAnnotationType!].deserialize(
         new DataView(pickedAnnotationBuffer),
         pickedAnnotationBufferBaseOffset!,
-        pickedAnnotationIndex!,
-        pickedAnnotationCount!,
+        pickedAnnotationInstanceIndex!,
+        pickedAnnotationInstanceCount!,
         /*isLittleEndian=*/ Endianness.LITTLE === ENDIANNESS,
         propertyValues,
       );

--- a/src/annotation/renderlayer.ts
+++ b/src/annotation/renderlayer.ts
@@ -739,16 +739,22 @@ function AnnotationRenderLayer<
         const { pickIdsPerInstance } = renderHandler;
         if (pickedOffset < numInstances * pickIdsPerInstance) {
           let partIndex = pickedOffset % pickIdsPerInstance;
-          let annotationIndex: number = -1;
+          let annotationIndex = Math.floor(pickedOffset / pickIdsPerInstance);
           if (annotationType === AnnotationType.POLYLINE) {
             const typeToInstanceCount = typeToInstanceCounts[annotationType];
             annotationIndex = findFirstInSortedArray(
               typeToInstanceCount,
-              (count) => pickedOffset < count,
+              (count) => annotationIndex >= count,
+              "desc",
             );
-            partIndex = pickedOffset - typeToInstanceCount[annotationIndex];
-          } else {
-            annotationIndex = Math.floor(pickedOffset / pickIdsPerInstance);
+            partIndex =
+              pickedOffset -
+              typeToInstanceCount[annotationIndex] * pickIdsPerInstance;
+            console.log(
+              annotationIndex,
+              typeToInstanceCount[annotationIndex],
+              partIndex,
+            );
           }
           const id = ids[annotationIndex];
           mouseState.pickedAnnotationId = id;

--- a/src/annotation/renderlayer.ts
+++ b/src/annotation/renderlayer.ts
@@ -692,7 +692,7 @@ function AnnotationRenderLayer<
                 for (const [id, size] of idToSizeMap) {
                   const tempIndex = idMap.get(id);
                   if (tempIndex !== undefined && tempIndex < index) {
-                    runningCount += size;
+                    runningCount += size.numInstances;
                   }
                 }
                 selectedIndex = runningCount * handler.pickIdsPerInstance;
@@ -717,7 +717,7 @@ function AnnotationRenderLayer<
             for (const [id, size] of idToSizeMap) {
               const tempIndex = idMap.get(id);
               if (tempIndex !== undefined) {
-                runningCount += size;
+                runningCount += size.numInstances;
               }
               if (runningCount > count) {
                 break;
@@ -766,7 +766,7 @@ function AnnotationRenderLayer<
             let count = 0;
             for (let i = 0; i < ids.length; i++) {
               partIndex = pickedOffset - count;
-              count += idToSizeMap.get(ids[i])! * pickIdsPerInstance;
+              count += idToSizeMap.get(ids[i])!.numInstances * pickIdsPerInstance;
               if (pickedOffset < count) {
                 annotationIndex = i;
                 break;

--- a/src/annotation/renderlayer.ts
+++ b/src/annotation/renderlayer.ts
@@ -757,8 +757,8 @@ function AnnotationRenderLayer<
         const numInstances = typeToSize[annotationType];
         const renderHandler = getAnnotationTypeRenderHandler(annotationType);
         const { pickIdsPerInstance } = renderHandler;
-        let partIndex = pickedOffset % pickIdsPerInstance;
         if (pickedOffset < numInstances * pickIdsPerInstance) {
+          let partIndex = pickedOffset % pickIdsPerInstance;
           let annotationIndex: number = -1;
           if (annotationType === AnnotationType.POLYLINE) {
             const idToSizeMap = idToSizeMaps[annotationType];

--- a/src/annotation/renderlayer.ts
+++ b/src/annotation/renderlayer.ts
@@ -740,6 +740,7 @@ function AnnotationRenderLayer<
         if (pickedOffset < numInstances * pickIdsPerInstance) {
           let partIndex = pickedOffset % pickIdsPerInstance;
           let annotationIndex = Math.floor(pickedOffset / pickIdsPerInstance);
+          const annotationInstanceIndex = annotationIndex;
           if (annotationType === AnnotationType.POLYLINE) {
             const typeToInstanceCount = typeToInstanceCounts[annotationType];
             annotationIndex = findFirstInSortedArray(
@@ -750,11 +751,6 @@ function AnnotationRenderLayer<
             partIndex =
               pickedOffset -
               typeToInstanceCount[annotationIndex] * pickIdsPerInstance;
-            console.log(
-              annotationIndex,
-              typeToInstanceCount[annotationIndex],
-              partIndex,
-            );
           }
           const id = ids[annotationIndex];
           mouseState.pickedAnnotationId = id;
@@ -767,6 +763,8 @@ function AnnotationRenderLayer<
             typeToOffset[annotationType];
           mouseState.pickedAnnotationIndex = annotationIndex;
           mouseState.pickedAnnotationCount = ids.length;
+          mouseState.pickedAnnotationInstanceIndex = annotationInstanceIndex;
+          mouseState.pickedAnnotationInstanceCount = numInstances;
           const chunkPosition = this.tempChunkPosition;
           const {
             chunkToLayerTransform,
@@ -793,7 +791,7 @@ function AnnotationRenderLayer<
             chunkPosition,
             mouseState.pickedAnnotationBuffer,
             mouseState.pickedAnnotationBufferBaseOffset +
-              mouseState.pickedAnnotationIndex *
+              mouseState.pickedAnnotationInstanceIndex *
                 propertySerializer.propertyGroupBytes[0],
             partIndex,
           );
@@ -819,6 +817,7 @@ function AnnotationRenderLayer<
     }
 
     transformPickedValue(pickState: PickState) {
+      console.log("Transforming picked value");
       const { pickedAnnotationBuffer } = pickState;
       if (pickedAnnotationBuffer === undefined) return undefined;
       const { properties } = this.base.source;

--- a/src/annotation/renderlayer.ts
+++ b/src/annotation/renderlayer.ts
@@ -757,6 +757,7 @@ function AnnotationRenderLayer<
         const numInstances = typeToSize[annotationType];
         const renderHandler = getAnnotationTypeRenderHandler(annotationType);
         const { pickIdsPerInstance } = renderHandler;
+        let partIndex = pickedOffset % pickIdsPerInstance;
         if (pickedOffset < numInstances * pickIdsPerInstance) {
           let annotationIndex: number = -1;
           if (annotationType === AnnotationType.POLYLINE) {
@@ -764,6 +765,7 @@ function AnnotationRenderLayer<
             // TODO (SKM) replace by binary search, for loop is fine for now
             let count = 0;
             for (let i = 0; i < ids.length; i++) {
+              partIndex = pickedOffset - count;
               count += idToSizeMap.get(ids[i])! * pickIdsPerInstance;
               if (pickedOffset < count) {
                 annotationIndex = i;
@@ -774,7 +776,6 @@ function AnnotationRenderLayer<
             annotationIndex = Math.floor(pickedOffset / pickIdsPerInstance);
           }
           const id = ids[annotationIndex];
-          const partIndex = pickedOffset % pickIdsPerInstance;
           mouseState.pickedAnnotationId = id;
           mouseState.pickedAnnotationLayer = this.base.state;
           mouseState.pickedOffset = partIndex;

--- a/src/annotation/renderlayer.ts
+++ b/src/annotation/renderlayer.ts
@@ -765,7 +765,6 @@ function AnnotationRenderLayer<
           mouseState.pickedAnnotationBufferBaseOffset =
             serializedAnnotations.data.byteOffset +
             typeToOffset[annotationType];
-          console.log("annotation index", annotationIndex);
           mouseState.pickedAnnotationIndex = annotationIndex;
           mouseState.pickedAnnotationCount = ids.length;
           const chunkPosition = this.tempChunkPosition;

--- a/src/annotation/renderlayer.ts
+++ b/src/annotation/renderlayer.ts
@@ -118,11 +118,7 @@ import {
   registerNested,
   registerNestedSync,
 } from "#src/trackable_value.js";
-import {
-  arraysEqual,
-  findClosestMatchInSortedArray,
-  findFirstInSortedArray,
-} from "#src/util/array.js";
+import { arraysEqual, findFirstInSortedArray } from "#src/util/array.js";
 import type { Borrowed, Owned } from "#src/util/disposable.js";
 import { RefCounted } from "#src/util/disposable.js";
 import { Endianness, ENDIANNESS } from "#src/util/endian.js";

--- a/src/annotation/type_handler.ts
+++ b/src/annotation/type_handler.ts
@@ -457,8 +457,8 @@ void setLineWidth(float width) {
 
 void _setEndpointMarkerColor(vec4 startColor, vec4 endColor);
 void _setEndpointMarkerBorderColor(vec4 startColor, vec4 endColor);
-void setEndpointMarkerSize(float startSize, float endSize);
-void setEndpointMarkerBorderWidth(float startSize, float endSize);
+void _setEndpointMarkerSize(float startSize, float endSize);
+void _setEndpointMarkerBorderWidth(float startSize, float endSize);
 
 void setPolyEndpointMarkerColor(vec4 startColor, vec4 endColor);
 void setPolyEndpointMarkerBorderColor(vec4 startColor, vec4 endColor);
@@ -496,7 +496,15 @@ void setEndpointMarkerBorderColor(vec3 startColor, vec3 endColor) {
 }
 void setEndpointMarkerBorderColor(vec3 color) { setEndpointMarkerBorderColor(color, color); }
 void setEndpointMarkerBorderColor(vec4 color) { setEndpointMarkerBorderColor(color, color); }
+void setEndpointMarkerSize(float startSize, float endSize) {
+  _setEndpointMarkerSize(startSize, endSize);
+  setPolyEndpointMarkerSize(startSize, endSize);
+}
 void setEndpointMarkerSize(float size) { setEndpointMarkerSize(size, size); }
+void setEndpointMarkerBorderWidth(float startSize, float endSize) {
+  _setEndpointMarkerBorderWidth(startSize, endSize);
+  setPolyEndpointMarkerBorderWidth(startSize, endSize);
+}
 void setEndpointMarkerBorderWidth(float size) { setEndpointMarkerBorderWidth(size, size); }
 void setLineColor(vec4 startColor, vec4 endColor) {
   _setLineColor(startColor, endColor);
@@ -525,9 +533,7 @@ void setPolyLineColor(vec3 startColor, vec3 endColor) { setPolyLineColor(vec4(st
 void setColor(vec4 color) {
   setPointMarkerColor(color);
   setLineColor(color);
-  setPolyLineColor(color);
   setEndpointMarkerColor(color);
-  setPolyEndpointMarkerColor(color);
   setBoundingBoxBorderColor(color);
   setEllipsoidFillColor(vec4(color.rgb, color.a * (PROJECTION_VIEW ? 1.0 : 0.5)));
 }

--- a/src/annotation/type_handler.ts
+++ b/src/annotation/type_handler.ts
@@ -448,11 +448,12 @@ void ng_discard() {
 }
 void setLineColor(vec4 startColor, vec4 endColor);
 void setPolyLineColor(vec4 startColor, vec4 endColor);
+void _setLineWidth(float width);
+void setPolyLineWidth(float width);
 void setLineWidth(float width) {
   _setLineWidth(width);
   setPolyLineWidth(width);
 }
-void setPolyLineWidth(float width);
 
 void setEndpointMarkerColor(vec4 startColor, vec4 endColor);
 void setEndpointMarkerBorderColor(vec4 startColor, vec4 endColor);
@@ -598,6 +599,7 @@ if (ng_discardValue) {
     callback: (shader: ShaderProgram) => void,
   ) {
     const { shader, parameters } = shaderGetter(context.renderContext.emitter);
+    console.log(shader, parameters);
     if (shader === null) return;
     shader.bind();
     const { gl } = this;

--- a/src/annotation/type_handler.ts
+++ b/src/annotation/type_handler.ts
@@ -456,7 +456,7 @@ void setLineWidth(float width) {
 }
 
 void _setEndpointMarkerColor(vec4 startColor, vec4 endColor);
-void setEndpointMarkerBorderColor(vec4 startColor, vec4 endColor);
+void _setEndpointMarkerBorderColor(vec4 startColor, vec4 endColor);
 void setEndpointMarkerSize(float startSize, float endSize);
 void setEndpointMarkerBorderWidth(float startSize, float endSize);
 
@@ -485,11 +485,15 @@ void setEndpointMarkerColor(vec4 startColor, vec4 endColor) {
 void setEndpointMarkerColor(vec3 startColor, vec3 endColor) {
   setEndpointMarkerColor(vec4(startColor, 1.0), vec4(endColor, 1.0));
 }
+void setEndpointMarkerColor(vec3 color) { setEndpointMarkerColor(color, color); }
+void setEndpointMarkerColor(vec4 color) { setEndpointMarkerColor(color, color); }
+void setEndpointMarkerBorderColor(vec4 startColor, vec4 endColor) {
+  _setEndpointMarkerBorderColor(startColor, endColor);
+  setPolyEndpointMarkerBorderColor(startColor, endColor);
+}
 void setEndpointMarkerBorderColor(vec3 startColor, vec3 endColor) {
   setEndpointMarkerBorderColor(vec4(startColor, 1.0), vec4(endColor, 1.0));
 }
-void setEndpointMarkerColor(vec3 color) { setEndpointMarkerColor(color, color); }
-void setEndpointMarkerColor(vec4 color) { setEndpointMarkerColor(color, color); }
 void setEndpointMarkerBorderColor(vec3 color) { setEndpointMarkerBorderColor(color, color); }
 void setEndpointMarkerBorderColor(vec4 color) { setEndpointMarkerBorderColor(color, color); }
 void setEndpointMarkerSize(float size) { setEndpointMarkerSize(size, size); }
@@ -505,11 +509,11 @@ void setLineColor(vec3 startColor, vec3 endColor) { setLineColor(vec4(startColor
 void setPolyEndpointMarkerColor(vec3 startColor, vec3 endColor) {
   setPolyEndpointMarkerColor(vec4(startColor, 1.0), vec4(endColor, 1.0));
 }
-void setPolyEndpointMarkerBorderColor(vec3 startColor, vec3 endColor) {
-  setEndpointMarkerBorderColor(vec4(startColor, 1.0), vec4(endColor, 1.0));
-}
 void setPolyEndpointMarkerColor(vec3 color) { setPolyEndpointMarkerColor(color, color); }
 void setPolyEndpointMarkerColor(vec4 color) { setPolyEndpointMarkerColor(color, color); }
+void setPolyEndpointMarkerBorderColor(vec3 startColor, vec3 endColor) {
+  setPolyEndpointMarkerBorderColor(vec4(startColor, 1.0), vec4(endColor, 1.0));
+}
 void setPolyEndpointMarkerBorderColor(vec3 color) { setPolyEndpointMarkerBorderColor(color, color); }
 void setPolyEndpointMarkerBorderColor(vec4 color) { setPolyEndpointMarkerBorderColor(color, color); }
 void setPolyEndpointMarkerSize(float size) { setPolyEndpointMarkerSize(size, size); }

--- a/src/annotation/type_handler.ts
+++ b/src/annotation/type_handler.ts
@@ -446,19 +446,19 @@ bool ng_discardValue;
 void ng_discard() {
   ng_discardValue = true;
 }
-void _setLineColor(vec4 startColor, vec4 endColor);
+void setSingleLineColor(vec4 startColor, vec4 endColor);
 void setPolyLineColor(vec4 startColor, vec4 endColor);
-void _setLineWidth(float width);
+void setSingleLineWidth(float width);
 void setPolyLineWidth(float width);
 void setLineWidth(float width) {
-  _setLineWidth(width);
+  setSingleLineWidth(width);
   setPolyLineWidth(width);
 }
 
-void _setEndpointMarkerColor(vec4 startColor, vec4 endColor);
-void _setEndpointMarkerBorderColor(vec4 startColor, vec4 endColor);
-void _setEndpointMarkerSize(float startSize, float endSize);
-void _setEndpointMarkerBorderWidth(float startSize, float endSize);
+void setLineEndpointMarkerColor(vec4 startColor, vec4 endColor);
+void setLineEndpointMarkerBorderColor(vec4 startColor, vec4 endColor);
+void setLineEndpointMarkerSize(float startSize, float endSize);
+void setLineEndpointMarkerBorderWidth(float startSize, float endSize);
 
 void setPolyEndpointMarkerColor(vec4 startColor, vec4 endColor);
 void setPolyEndpointMarkerBorderColor(vec4 startColor, vec4 endColor);
@@ -479,7 +479,7 @@ void setBoundingBoxBorderWidth(float size);
 void setBoundingBoxFillColor(vec4 color);
 
 void setEndpointMarkerColor(vec4 startColor, vec4 endColor) {
-  _setEndpointMarkerColor(startColor, endColor);
+  setLineEndpointMarkerColor(startColor, endColor);
   setPolyEndpointMarkerColor(startColor, endColor);
 }
 void setEndpointMarkerColor(vec3 startColor, vec3 endColor) {
@@ -488,7 +488,7 @@ void setEndpointMarkerColor(vec3 startColor, vec3 endColor) {
 void setEndpointMarkerColor(vec3 color) { setEndpointMarkerColor(color, color); }
 void setEndpointMarkerColor(vec4 color) { setEndpointMarkerColor(color, color); }
 void setEndpointMarkerBorderColor(vec4 startColor, vec4 endColor) {
-  _setEndpointMarkerBorderColor(startColor, endColor);
+  setLineEndpointMarkerBorderColor(startColor, endColor);
   setPolyEndpointMarkerBorderColor(startColor, endColor);
 }
 void setEndpointMarkerBorderColor(vec3 startColor, vec3 endColor) {
@@ -497,17 +497,17 @@ void setEndpointMarkerBorderColor(vec3 startColor, vec3 endColor) {
 void setEndpointMarkerBorderColor(vec3 color) { setEndpointMarkerBorderColor(color, color); }
 void setEndpointMarkerBorderColor(vec4 color) { setEndpointMarkerBorderColor(color, color); }
 void setEndpointMarkerSize(float startSize, float endSize) {
-  _setEndpointMarkerSize(startSize, endSize);
+  setLineEndpointMarkerSize(startSize, endSize);
   setPolyEndpointMarkerSize(startSize, endSize);
 }
 void setEndpointMarkerSize(float size) { setEndpointMarkerSize(size, size); }
 void setEndpointMarkerBorderWidth(float startSize, float endSize) {
-  _setEndpointMarkerBorderWidth(startSize, endSize);
+  setLineEndpointMarkerBorderWidth(startSize, endSize);
   setPolyEndpointMarkerBorderWidth(startSize, endSize);
 }
 void setEndpointMarkerBorderWidth(float size) { setEndpointMarkerBorderWidth(size, size); }
 void setLineColor(vec4 startColor, vec4 endColor) {
-  _setLineColor(startColor, endColor);
+  setSingleLineColor(startColor, endColor);
   setPolyLineColor(startColor, endColor);
 }
 void setLineColor(vec4 color) { setLineColor(color, color); }

--- a/src/annotation/type_handler.ts
+++ b/src/annotation/type_handler.ts
@@ -455,7 +455,7 @@ void setLineWidth(float width) {
   setPolyLineWidth(width);
 }
 
-void setEndpointMarkerColor(vec4 startColor, vec4 endColor);
+void _setEndpointMarkerColor(vec4 startColor, vec4 endColor);
 void setEndpointMarkerBorderColor(vec4 startColor, vec4 endColor);
 void setEndpointMarkerSize(float startSize, float endSize);
 void setEndpointMarkerBorderWidth(float startSize, float endSize);
@@ -478,6 +478,10 @@ void setBoundingBoxBorderColor(vec4 color);
 void setBoundingBoxBorderWidth(float size);
 void setBoundingBoxFillColor(vec4 color);
 
+void setEndpointMarkerColor(vec4 startColor, vec4 endColor) {
+  _setEndpointMarkerColor(startColor, endColor);
+  setPolyEndpointMarkerColor(startColor, endColor);
+}
 void setEndpointMarkerColor(vec3 startColor, vec3 endColor) {
   setEndpointMarkerColor(vec4(startColor, 1.0), vec4(endColor, 1.0));
 }
@@ -499,7 +503,7 @@ void setLineColor(vec3 color) { setLineColor(vec4(color, 1.0)); }
 void setLineColor(vec3 startColor, vec3 endColor) { setLineColor(vec4(startColor, 1.0), vec4(endColor, 1.0)); }
 
 void setPolyEndpointMarkerColor(vec3 startColor, vec3 endColor) {
-  setEndpointMarkerColor(vec4(startColor, 1.0), vec4(endColor, 1.0));
+  setPolyEndpointMarkerColor(vec4(startColor, 1.0), vec4(endColor, 1.0));
 }
 void setPolyEndpointMarkerBorderColor(vec3 startColor, vec3 endColor) {
   setEndpointMarkerBorderColor(vec4(startColor, 1.0), vec4(endColor, 1.0));

--- a/src/annotation/type_handler.ts
+++ b/src/annotation/type_handler.ts
@@ -446,7 +446,7 @@ bool ng_discardValue;
 void ng_discard() {
   ng_discardValue = true;
 }
-void setLineColor(vec4 startColor, vec4 endColor);
+void _setLineColor(vec4 startColor, vec4 endColor);
 void setPolyLineColor(vec4 startColor, vec4 endColor);
 void _setLineWidth(float width);
 void setPolyLineWidth(float width);
@@ -490,6 +490,10 @@ void setEndpointMarkerBorderColor(vec3 color) { setEndpointMarkerBorderColor(col
 void setEndpointMarkerBorderColor(vec4 color) { setEndpointMarkerBorderColor(color, color); }
 void setEndpointMarkerSize(float size) { setEndpointMarkerSize(size, size); }
 void setEndpointMarkerBorderWidth(float size) { setEndpointMarkerBorderWidth(size, size); }
+void setLineColor(vec4 startColor, vec4 endColor) {
+  _setLineColor(startColor, endColor);
+  setPolyLineColor(startColor, endColor);
+}
 void setLineColor(vec4 color) { setLineColor(color, color); }
 void setLineColor(vec3 color) { setLineColor(vec4(color, 1.0)); }
 void setLineColor(vec3 startColor, vec3 endColor) { setLineColor(vec4(startColor, 1.0), vec4(endColor, 1.0)); }

--- a/src/annotation/type_handler.ts
+++ b/src/annotation/type_handler.ts
@@ -448,7 +448,11 @@ void ng_discard() {
 }
 void setLineColor(vec4 startColor, vec4 endColor);
 void setPolyLineColor(vec4 startColor, vec4 endColor);
-void setLineWidth(float width);
+void setLineWidth(float width) {
+  _setLineWidth(width);
+  setPolyLineWidth(width);
+}
+void setPolyLineWidth(float width);
 
 void setEndpointMarkerColor(vec4 startColor, vec4 endColor);
 void setEndpointMarkerBorderColor(vec4 startColor, vec4 endColor);

--- a/src/annotation/type_handler.ts
+++ b/src/annotation/type_handler.ts
@@ -599,7 +599,6 @@ if (ng_discardValue) {
     callback: (shader: ShaderProgram) => void,
   ) {
     const { shader, parameters } = shaderGetter(context.renderContext.emitter);
-    console.log(shader, parameters);
     if (shader === null) return;
     shader.bind();
     const { gl } = this;

--- a/src/annotation/type_handler.ts
+++ b/src/annotation/type_handler.ts
@@ -14,12 +14,12 @@
  * limitations under the License.
  */
 
-import {
+import type {
   Annotation,
   AnnotationPropertySpec,
-  AnnotationType,
 } from "#src/annotation/index.js";
 import {
+  AnnotationType,
   annotationTypeHandlers,
   getPropertyOffsets,
   propertyTypeDataType,
@@ -583,7 +583,10 @@ ${partIndexExpressions
   highp uint selectedIndex = uSelectedIndex;
   highp uint relatedInstancePickOffset = getNumRelatedInstances() * uint(${this.pickIdsPerInstance});
 if (selectedIndex + relatedInstancePickOffset == pickBaseOffset${partIndexExpressions
-      .map((_, i) => ` || selectedIndex + relatedInstancePickOffset == pickOffset${i}`)
+      .map(
+        (_, i) =>
+          ` || selectedIndex + relatedInstancePickOffset == pickOffset${i}`,
+      )
       .join("")}) {
     vColor = vec4(mix(vColor.rgb, vec3(1.0, 1.0, 1.0), 0.75), vColor.a);
   }

--- a/src/datasource/precomputed/annotation.rst
+++ b/src/datasource/precomputed/annotation.rst
@@ -10,6 +10,7 @@ n-dimensional coordinate space and one of the following four geometry types:
 - Line segments (represented by the two endpoint positions)
 - Axis-aligned bounding boxes (represented by two positions)
 - Axis-aligned ellipsoids (represented by a center position and radii vector)
+- Polylines (represented by a list of at least two positions)
 
 All annotations within the annotation collection have the same geometry type.
 
@@ -78,6 +79,8 @@ Within the annotation id index, each annotation is encoded in the following bina
   - For :json:`"line"` type, the first endpoint position followed by the second endpoint position.
   - For :json:`"axis_aligned_bounding_box"` type, the first position followed by the second position.
   - For :json:`"ellipsoid"` type, the center position followed by the radii vector.
+  - For :json:`"polyline"` type, first the number of positions as a uint32le value,
+    followed by the position vectors as float32le.
 
 - For each property of type :json:`"uint32"`, :json:`"int32"`, or
   :json:`"float32"`: the value encoded as a little endian value.

--- a/src/datasource/precomputed/annotations.md
+++ b/src/datasource/precomputed/annotations.md
@@ -109,6 +109,7 @@ Within the annotation id index, each annotation is encoded in the following bina
   - For `"LINE"` type, the first endpoint position followed by the second endpoint position.
   - For `"AXIS_ALIGNED_BOUNDING_BOX"` type, the first position followed by the second position.
   - For `"ELLIPSOID"` type, the center position followed by the radii vector.
+  - For `"POLYLINE"` type, the number of points as a uint32le value, followed by the position vectors of each point as float32le.
 - For each property of type `uint32`, `int32`, or `float32`: the value encoded as a little endian value.
 - For each property of type `uint16` or `int16`: the value encoded as a little endian value.
 - For each property of type `uint8`, `int8`, `rgb`, or `rgba`: the encoded value.

--- a/src/datasource/precomputed/backend.ts
+++ b/src/datasource/precomputed/backend.ts
@@ -622,7 +622,7 @@ function parseAnnotations(
       const numPoints = dv.getUint32(offset, /*littleEndian=*/ true);
       const numGlInstances = numPoints - 1;
       const numGeometryBytes = numPoints * parameters.rank * 4;
-      offset = numBytes - 2 * parameters.rank * 4 + numGeometryBytes;
+      offset += numBytes - 2 * parameters.rank * 4 + numGeometryBytes;
       runningSize += numBytes * numGlInstances;
       runningNumInstances += numGlInstances;
     }

--- a/src/datasource/precomputed/backend.ts
+++ b/src/datasource/precomputed/backend.ts
@@ -731,12 +731,12 @@ function restructureAnnotationData(
   if (propertyGroupBytes.length > 1) {
     let origOffset = 0;
     let groupOffset = 0;
-    let runningTotalInstances = 0;
     for (
       let groupIndex = 0;
       groupIndex < propertyGroupBytes.length;
       ++groupIndex
     ) {
+      let runningTotalInstances = 0;
       const groupBytesPerAnnotation = propertyGroupBytes[groupIndex];
       for (
         let annotationIndex = 0;

--- a/src/datasource/precomputed/backend.ts
+++ b/src/datasource/precomputed/backend.ts
@@ -24,10 +24,7 @@ import {
   AnnotationSource,
   AnnotationGeometryChunkSourceBackend,
 } from "#src/annotation/backend.js";
-import type {
-  Annotation,
-  AnnotationInstanceCount,
-} from "#src/annotation/index.js";
+import type { Annotation } from "#src/annotation/index.js";
 import {
   AnnotationPropertySerializer,
   AnnotationType,

--- a/src/datasource/precomputed/backend.ts
+++ b/src/datasource/precomputed/backend.ts
@@ -600,7 +600,6 @@ function parseAnnotations(
   parameters: AnnotationSourceParameters,
   propertySerializer: AnnotationPropertySerializer,
 ): AnnotationGeometryData {
-  console.log("Parsing annotations", parameters);
   const dv = new DataView(buffer);
   const isLittleEndian = true;
   // First, compute simple sanity checks for sizes etc. to verify that the buffer is well-formed.
@@ -655,7 +654,6 @@ function parseAnnotations(
     Map<string, number>
   >(annotationTypes.length));
   idToSizeMaps.fill(new Map());
-  console.log("Starting to parse annotations", parameters);
   if (
     propertyGroupBytes.length > 1 ||
     annotationType === AnnotationType.POLYLINE
@@ -679,7 +677,7 @@ function parseAnnotations(
       // numPointsInPolyK, Point1, Point2, ..., PointN, Properties
       // So we need to shift the data around a bit
       // Start by looping through the data and shifting the points
-      let offset = 8;
+      let offset = 0;
       let runningOffset = 0;
       idToSizeMaps[parameters.type] = new Map();
       const annotationSizeMap = idToSizeMaps[annotationType];
@@ -687,9 +685,10 @@ function parseAnnotations(
       const pointOffset = parameters.rank * 4;
       const numPropertyBytes =
         propertySerializer.serializedBytes - 2 * pointOffset - numPointsOffset;
+      const numAnnotationsOffset = 8;
 
       for (let i = 0; i < countLow; ++i) {
-        const numPoints = dataView.getUint32(offset, isLittleEndian);
+        const numPoints = dataView.getUint32(offset + numAnnotationsOffset, isLittleEndian);
         offset += numPointsOffset; // Move past the number of points
         const numGlInstances = numPoints - 1;
         const origPropertyBase = offset + numPoints * pointOffset;
@@ -701,7 +700,6 @@ function parseAnnotations(
           // last bit is actually whether to draw the endpoint cap
           const bitCap = j === numGlInstances - 1 ? 1 : 0;
           const numPointsWithBitCap = numPoints | (bitCap << 31);
-          data[0];
           newDataView.setUint32(
             runningOffset,
             numPointsWithBitCap,
@@ -816,7 +814,6 @@ function parseAnnotations(
   typeToIdMaps[parameters.type] = new Map(ids.map((id, i) => [id, i]));
   typeToSize.fill(0);
   typeToSize[parameters.type] = totalNumInstances;
-  console.log(annotationType, geometryData);
   return geometryData;
 }
 

--- a/src/datasource/precomputed/backend.ts
+++ b/src/datasource/precomputed/backend.ts
@@ -728,6 +728,10 @@ function restructureAnnotationData(
 
   // Places all the properties that can't be put in the first group into their own
   // group at the end of the buffer
+  let dataToTransform = inputData;
+  if (annotationType === AnnotationType.POLYLINE) {
+    dataToTransform = new Uint8Array(outputData);
+  }
   if (propertyGroupBytes.length > 1) {
     let origOffset = 0;
     let groupOffset = 0;
@@ -765,7 +769,7 @@ function restructureAnnotationData(
           const newBase =
             groupOffset + runningTotalInstances * groupBytesPerAnnotation;
           outputData.set(
-            inputData.subarray(origBase, origBase + groupBytesPerAnnotation),
+            dataToTransform.subarray(origBase, origBase + groupBytesPerAnnotation),
             newBase,
           );
           ++runningTotalInstances;

--- a/src/datasource/precomputed/backend.ts
+++ b/src/datasource/precomputed/backend.ts
@@ -665,17 +665,22 @@ function parseAnnotations(
     if (annotationType === AnnotationType.POLYLINE) {
       const dataView = new DataView(buffer);
       const newDataView = new DataView(data.buffer);
-      // The GL buffer data is laid out as follows:
-      // numPointsInPoly, Point1, Point2, Properties
-      // numPointsInPoly, Point2, Point3, Properties
+      // We need to shift the data around a bit
+      // The input data is:
+      // numPointsInPoly1, Point1_1, Point1_2, ..., Point1_N1, Properties1
+      // numPointsInPoly2, Point2_1, Point2_2, ..., Point2_N2, Properties2
       // ...
-      // numPointsInPolyK, PointN, PointN+1, Properties
-      // While the input data is a little different:
-      // numPointsInPoly1, Point1, Point2, ..., PointN, Properties
-      // numPointsInPoly2, Point1, Point2, ..., PointN, Properties
+      // numPointsInPolyK, PointK_1, PointK_2, ..., PointK_Nk, PropertiesK
+      // While the GL buffer data is laid out as follows:
+      // numPointsInPoly1, Point1_1, Point1_2, Properties1
+      // numPointsInPoly1, Point1_2, Point1_3, Properties1
       // ...
-      // numPointsInPolyK, Point1, Point2, ..., PointN, Properties
-      // So we need to shift the data around a bit
+      // numPointsInPoly1, Point1_N1-1, Point1_N1, Properties1
+      // ...
+      // numPointsInPolyK, PointK_1, PointK_2, PropertiesK
+      // ...
+      // numPointsInPolyK, PointK_Nk-1, PointK_Nk, PropertiesK
+
       // Start by looping through the data and shifting the points
       let offset = 0;
       let runningOffset = 0;

--- a/src/datasource/precomputed/backend.ts
+++ b/src/datasource/precomputed/backend.ts
@@ -769,7 +769,10 @@ function restructureAnnotationData(
           const newBase =
             groupOffset + runningTotalInstances * groupBytesPerAnnotation;
           outputData.set(
-            dataToTransform.subarray(origBase, origBase + groupBytesPerAnnotation),
+            dataToTransform.subarray(
+              origBase,
+              origBase + groupBytesPerAnnotation,
+            ),
             newBase,
           );
           ++runningTotalInstances;

--- a/src/datasource/precomputed/backend.ts
+++ b/src/datasource/precomputed/backend.ts
@@ -672,14 +672,14 @@ function parseAnnotations(
       // ...
       // numPointsInPolyK, PointK_1, PointK_2, ..., PointK_Nk, PropertiesK
       // While the GL buffer data is laid out as follows:
-      // numPointsInPoly1, Point1_1, Point1_2, Properties1
-      // numPointsInPoly1, Point1_2, Point1_3, Properties1
+      // polyLineIndex1_1, Point1_1, Point1_2, Properties1
+      // polyLineIndex1_2, Point1_2, Point1_3, Properties1
       // ...
-      // numPointsInPoly1, Point1_N1-1, Point1_N1, Properties1
+      // polyLineIndex1_N-1, Point1_N1-1, Point1_N1, Properties1
       // ...
-      // numPointsInPolyK, PointK_1, PointK_2, PropertiesK
+      // polyLineIndexK_1, PointK_1, PointK_2, PropertiesK
       // ...
-      // numPointsInPolyK, PointK_Nk-1, PointK_Nk, PropertiesK
+      // polyLineIndexK_Nk-1, PointK_Nk-1, PointK_Nk, PropertiesK
 
       // Start by looping through the data and shifting the points
       let offset = 0;
@@ -860,6 +860,7 @@ function parseSingleAnnotation(
     /*isLittleEndian=*/ true,
     parameters.rank,
     id,
+    0
   );
   propertySerializer.deserialize(
     dv,

--- a/src/datasource/precomputed/backend.ts
+++ b/src/datasource/precomputed/backend.ts
@@ -743,14 +743,21 @@ function restructureAnnotationData(
         annotationIndex < numAnnotations;
         ++annotationIndex
       ) {
-        let numGLInstances = 1;
+        let numGlInstances = 1;
         if (annotationType === AnnotationType.POLYLINE) {
-          numGLInstances =
-            inputDataView.getUint32(origOffset, isLittleEndian) - 1;
+          // Use the polyline instance count to get the number of instances
+          if (annotationIndex === numAnnotations - 1) {
+            numGlInstances =
+              numInstances - polylineInstanceCounts[annotationIndex];
+          } else {
+            numGlInstances =
+              polylineInstanceCounts[annotationIndex + 1] -
+              polylineInstanceCounts[annotationIndex];
+          }
         }
         for (
           let instanceIndex = 0;
-          instanceIndex < numGLInstances;
+          instanceIndex < numGlInstances;
           ++instanceIndex
         ) {
           const origBase =

--- a/src/datasource/precomputed/backend.ts
+++ b/src/datasource/precomputed/backend.ts
@@ -699,10 +699,10 @@ function parseAnnotations(
           // First, we need to set the number of points, where the
           // last bit is actually whether to draw the endpoint cap
           const bitCap = j === numGlInstances - 1 ? 1 : 0;
-          const numPointsWithBitCap = numPoints | (bitCap << 31);
+          const instanceIndexWithBitCap = j | (bitCap << 31);
           newDataView.setUint32(
             runningOffset,
-            numPointsWithBitCap,
+            instanceIndexWithBitCap,
             isLittleEndian,
           );
           // Copy the geometry data for two points

--- a/src/datasource/precomputed/json_schema/annotation.yml
+++ b/src/datasource/precomputed/json_schema/annotation.yml
@@ -46,6 +46,7 @@ properties:
       - "line"
       - "axis_aligned_bounding_box"
       - "ellipsoid"
+      - "polyline"
   properties:
     title: Additional properties associated with each annotation.
     type: array

--- a/src/layer/index.ts
+++ b/src/layer/index.ts
@@ -206,6 +206,8 @@ export class UserLayer extends RefCounted {
     state.annotationSourceIndex = undefined;
     state.annotationSubsource = undefined;
     state.annotationPartIndex = undefined;
+    state.annotationInstanceIndex = undefined;
+    state.annotationInstanceCount = undefined;
     state.value = undefined;
   }
 
@@ -332,6 +334,8 @@ export class UserLayer extends RefCounted {
     dest.annotationBuffer = source.annotationBuffer;
     dest.annotationIndex = source.annotationIndex;
     dest.annotationCount = source.annotationCount;
+    dest.annotationInstanceCount = source.annotationInstanceCount;
+    dest.annotationInstanceIndex = source.annotationInstanceIndex;
     dest.annotationSourceIndex = source.annotationSourceIndex;
     dest.annotationSubsource = source.annotationSubsource;
     dest.annotationPartIndex = source.annotationPartIndex;

--- a/src/layer/index.ts
+++ b/src/layer/index.ts
@@ -135,6 +135,8 @@ export interface UserLayerSelectionState {
   annotationBuffer: Uint8Array | undefined;
   annotationIndex: number | undefined;
   annotationCount: number | undefined;
+  annotationInstanceIndex: number | undefined;
+  annotationInstanceCount: number | undefined;
   annotationSourceIndex: number | undefined;
   annotationSubsource: string | undefined;
   annotationSubsubsourceId: string | undefined;
@@ -1084,6 +1086,8 @@ export interface PickState {
   pickedAnnotationIndex: number | undefined;
   pickedAnnotationCount: number | undefined;
   pickedAnnotationType: AnnotationType | undefined;
+  pickedAnnotationInstanceIndex: number | undefined;
+  pickedAnnotationInstanceCount: number | undefined;
 }
 
 export class MouseSelectionState implements PickState {

--- a/src/layer/index.ts
+++ b/src/layer/index.ts
@@ -1104,7 +1104,10 @@ export class MouseSelectionState implements PickState {
   pickedAnnotationBufferBaseOffset: number | undefined = undefined;
   // Index (out of a total of `pickedAnnotationCount`) of the picked annotation.
   pickedAnnotationIndex: number | undefined = undefined;
+  // Index (out of a total of `pickedAnnotationInstanceCount`) of the picked annotation
+  pickedAnnotationInstanceIndex: number | undefined = undefined;
   pickedAnnotationCount: number | undefined = undefined;
+  pickedAnnotationInstanceCount: number | undefined = undefined;
   pickedAnnotationType: AnnotationType | undefined = undefined;
   pageX: number;
   pageY: number;

--- a/src/object_picking.ts
+++ b/src/object_picking.ts
@@ -109,7 +109,9 @@ export class PickIDManager {
     mouseState.pickedAnnotationBuffer = undefined;
     mouseState.pickedAnnotationBufferBaseOffset = undefined;
     mouseState.pickedAnnotationIndex = undefined;
+    mouseState.pickedAnnotationInstanceIndex = undefined;
     mouseState.pickedAnnotationCount = undefined;
+    mouseState.pickedAnnotationInstanceCount = undefined;
     mouseState.pickedAnnotationType = undefined;
     const data = this.pickData[lower];
     if (pickedRenderLayer !== null) {

--- a/src/rendered_data_panel.ts
+++ b/src/rendered_data_panel.ts
@@ -775,6 +775,33 @@ export abstract class RenderedDataPanel extends RenderedPanel {
       annotationTool.complete();
     });
 
+    registerActionListener(element, "undo-annotation-step", () => {
+      const selectedLayer = this.viewer.selectedLayer.layer;
+      if (selectedLayer === undefined) {
+        return;
+      }
+      const userLayer = selectedLayer.layer;
+      if (userLayer === null || userLayer.tool.value === undefined) {
+        return;
+      }
+      const annotationTool = userLayer.tool.value;
+      if (
+        !annotationTool ||
+        !(
+          "undo" in annotationTool &&
+          typeof annotationTool.undo === "function"
+        )
+      ) {
+        StatusMessage.showTemporaryMessage(
+          `The selected layer (${JSON.stringify(
+            selectedLayer.name,
+          )}) does not have annotation tool with complete step.`,
+        );
+        return;
+      }
+      annotationTool.undo();
+    })
+
     registerActionListener(
       element,
       "zoom-via-touchpinch",

--- a/src/rendered_data_panel.ts
+++ b/src/rendered_data_panel.ts
@@ -27,6 +27,7 @@ import {
   displayToLayerCoordinates,
   layerToDisplayCoordinates,
 } from "#src/render_coordinate_transform.js";
+import { StatusMessage } from "#src/status.js";
 import { AutomaticallyFocusedElement } from "#src/util/automatic_focus.js";
 import type { Borrowed } from "#src/util/disposable.js";
 import type {
@@ -46,7 +47,6 @@ import type {
 import { TouchEventBinder } from "#src/util/touch_bindings.js";
 import { getWheelZoomAmount } from "#src/util/wheel_zoom.js";
 import type { ViewerState } from "#src/viewer_state.js";
-import { StatusMessage } from "#src/status.js";
 
 declare let NEUROGLANCER_SHOW_OBJECT_SELECTION_TOOLTIP: boolean | undefined;
 
@@ -787,10 +787,7 @@ export abstract class RenderedDataPanel extends RenderedPanel {
       const annotationTool = userLayer.tool.value;
       if (
         !annotationTool ||
-        !(
-          "undo" in annotationTool &&
-          typeof annotationTool.undo === "function"
-        )
+        !("undo" in annotationTool && typeof annotationTool.undo === "function")
       ) {
         StatusMessage.showTemporaryMessage(
           `The selected layer (${JSON.stringify(
@@ -800,7 +797,7 @@ export abstract class RenderedDataPanel extends RenderedPanel {
         return;
       }
       annotationTool.undo();
-    })
+    });
 
     registerActionListener(
       element,

--- a/src/rendered_data_panel.ts
+++ b/src/rendered_data_panel.ts
@@ -652,6 +652,8 @@ export abstract class RenderedDataPanel extends RenderedPanel {
             const annotationRef =
               annotationLayer.source.getReference(selectedAnnotationId)!;
             const ann = <Annotation>annotationRef.value;
+            // Quit out if still waiting or if the annotation has been deleted.
+            if (ann === undefined || ann === null) return;
 
             const handler = getAnnotationTypeRenderHandler(ann.type);
             const pickedOffset = mouseState.pickedOffset;

--- a/src/rendered_data_panel.ts
+++ b/src/rendered_data_panel.ts
@@ -46,6 +46,7 @@ import type {
 import { TouchEventBinder } from "#src/util/touch_bindings.js";
 import { getWheelZoomAmount } from "#src/util/wheel_zoom.js";
 import type { ViewerState } from "#src/viewer_state.js";
+import { StatusMessage } from "#src/status.js";
 
 declare let NEUROGLANCER_SHOW_OBJECT_SELECTION_TOOLTIP: boolean | undefined;
 
@@ -745,6 +746,33 @@ export abstract class RenderedDataPanel extends RenderedPanel {
           ref.dispose();
         }
       }
+    });
+
+    registerActionListener(element, "finish-annotation", () => {
+      const selectedLayer = this.viewer.selectedLayer.layer;
+      if (selectedLayer === undefined) {
+        return;
+      }
+      const userLayer = selectedLayer.layer;
+      if (userLayer === null || userLayer.tool.value === undefined) {
+        return;
+      }
+      const annotationTool = userLayer.tool.value;
+      if (
+        !annotationTool ||
+        !(
+          "complete" in annotationTool &&
+          typeof annotationTool.complete === "function"
+        )
+      ) {
+        StatusMessage.showTemporaryMessage(
+          `The selected layer (${JSON.stringify(
+            selectedLayer.name,
+          )}) does not have annotation tool with complete step.`,
+        );
+        return;
+      }
+      annotationTool.complete();
     });
 
     registerActionListener(

--- a/src/ui/annotations.ts
+++ b/src/ui/annotations.ts
@@ -2131,14 +2131,9 @@ export function UserLayerWithAnnotationsMixin<
 
                 const { relationships, properties } = annotationLayer.source;
                 const sourceReadonly = annotationLayer.source.readonly;
-                const globalCoordinateSpace =
-                  this.manager.root.coordinateSpace.value;
-                const scales = new Float32Array(
-                  globalCoordinateSpace.scales.map((x) => x / 1e-9),
-                ) as vec3;
                 const defaultProperties = annotationTypeHandlers[
                   annotation.type
-                ].defaultProperties(annotation, scales);
+                ].defaultProperties(annotation);
                 const allProperties = [
                   ...defaultProperties.properties,
                   ...properties,

--- a/src/ui/annotations.ts
+++ b/src/ui/annotations.ts
@@ -181,11 +181,9 @@ function getCenterPosition(center: Float32Array, annotation: Annotation) {
       vector.scale(center, center, 0.5);
       break;
     case AnnotationType.POLYLINE:
-      // Return the centroid of the polyline.
-      for (const point of annotation.points) {
-        vector.add(center, center, point);
-      }
-      vector.scale(center, center, 1 / annotation.points.length);
+      // Return the first line of the polyline
+      vector.add(center, annotation.points[0], annotation.points[1]);
+      vector.scale(center, center, 0.5);
       break;
     case AnnotationType.POINT:
       center.set(annotation.point);

--- a/src/ui/annotations.ts
+++ b/src/ui/annotations.ts
@@ -2131,9 +2131,10 @@ export function UserLayerWithAnnotationsMixin<
 
                 const { relationships, properties } = annotationLayer.source;
                 const sourceReadonly = annotationLayer.source.readonly;
-                const defaultProperties = annotationTypeHandlers[
-                  annotation.type
-                ].defaultProperties(annotation);
+                const defaultProperties =
+                  annotationTypeHandlers[annotation.type].defaultProperties(
+                    annotation,
+                  );
                 const allProperties = [
                   ...defaultProperties.properties,
                   ...properties,

--- a/src/ui/annotations.ts
+++ b/src/ui/annotations.ts
@@ -1998,7 +1998,6 @@ export function UserLayerWithAnnotationsMixin<
             ),
             ({ annotation, chunkTransform }, parent, context) => {
               let statusText: string | undefined;
-              console.log("Display state", annotation);
               if (annotation == null) {
                 if (
                   state.annotationType !== undefined &&

--- a/src/ui/annotations.ts
+++ b/src/ui/annotations.ts
@@ -180,6 +180,13 @@ function getCenterPosition(center: Float32Array, annotation: Annotation) {
       vector.add(center, annotation.pointA, annotation.pointB);
       vector.scale(center, center, 0.5);
       break;
+    case AnnotationType.POLYLINE:
+      // Return the centroid of the polyline.
+      for (const point of annotation.points) {
+        vector.add(center, center, point);
+      }
+      vector.scale(center, center, 1 / annotation.points.length);
+      break;
     case AnnotationType.POINT:
       center.set(annotation.point);
       break;

--- a/src/ui/annotations.ts
+++ b/src/ui/annotations.ts
@@ -1963,8 +1963,8 @@ export function UserLayerWithAnnotationsMixin<
       );
       state.annotationIndex = mouseState.pickedAnnotationIndex!;
       state.annotationCount = mouseState.pickedAnnotationCount!;
-      state.annotationInstanceIndex = mouseState.pickedAnnotationInstanceIndex;
-      state.annotationInstanceCount = mouseState.pickedAnnotationInstanceCount;
+      state.annotationInstanceIndex = mouseState.pickedAnnotationInstanceIndex!;
+      state.annotationInstanceCount = mouseState.pickedAnnotationInstanceCount!;
       state.annotationPartIndex = mouseState.pickedOffset;
       state.annotationSourceIndex = annotationLayer.sourceIndex;
       state.annotationSubsource = annotationLayer.subsourceId;
@@ -2017,8 +2017,8 @@ export function UserLayerWithAnnotationsMixin<
                       numGeometryBytes,
                       properties,
                     );
-                  const annotationIndex = state.annotationIndex!;
-                  const annotationCount = state.annotationCount!;
+                  const annotationIndex = state.annotationInstanceIndex!;
+                  const annotationCount = state.annotationInstanceCount!;
                   annotation = handler.deserialize(
                     dataView,
                     baseOffset +
@@ -2027,6 +2027,7 @@ export function UserLayerWithAnnotationsMixin<
                     isLittleEndian,
                     rank,
                     state.annotationId!,
+                    annotationPropertySerializer.propertyGroupBytes[0],
                   );
                   annotationPropertySerializer.deserialize(
                     dataView,

--- a/src/ui/annotations.ts
+++ b/src/ui/annotations.ts
@@ -1484,7 +1484,7 @@ class PlacePolylineTool extends MultiStepAnnotationTool {
     );
     if (point === undefined)
       return { newAnnotation: oldAnnotation, finished: false };
-  
+
     // 1. Show a preview of the point being added until a click is triggered.
     if (!triggered) {
       return {
@@ -1499,15 +1499,16 @@ class PlacePolylineTool extends MultiStepAnnotationTool {
       oldAnnotation.points[oldAnnotation.points.length - 2];
     const finished = arraysEqual(lastPoint, secondLastPoint);
     if (finished) {
-      return {
-        newAnnotation: annotationWithoutLastPoint(oldAnnotation),
-        finished: true,
-      };
+      const newAnnotation =
+        oldAnnotation.points.length > 2
+          ? annotationWithoutLastPoint(oldAnnotation)
+          : oldAnnotation;
+      return { newAnnotation, finished };
     }
     // 3. Add the point to the annotation.
     return {
       newAnnotation: annotationWithNewPoint(oldAnnotation, point),
-      finished: finished,
+      finished,
     };
   }
   get description() {

--- a/src/ui/annotations.ts
+++ b/src/ui/annotations.ts
@@ -1963,6 +1963,8 @@ export function UserLayerWithAnnotationsMixin<
       );
       state.annotationIndex = mouseState.pickedAnnotationIndex!;
       state.annotationCount = mouseState.pickedAnnotationCount!;
+      state.annotationInstanceIndex = mouseState.pickedAnnotationInstanceIndex;
+      state.annotationInstanceCount = mouseState.pickedAnnotationInstanceCount;
       state.annotationPartIndex = mouseState.pickedOffset;
       state.annotationSourceIndex = annotationLayer.sourceIndex;
       state.annotationSubsource = annotationLayer.subsourceId;
@@ -1996,6 +1998,7 @@ export function UserLayerWithAnnotationsMixin<
             ),
             ({ annotation, chunkTransform }, parent, context) => {
               let statusText: string | undefined;
+              console.log("Display state", annotation);
               if (annotation == null) {
                 if (
                   state.annotationType !== undefined &&

--- a/src/ui/annotations.ts
+++ b/src/ui/annotations.ts
@@ -1225,6 +1225,8 @@ abstract class MultiStepAnnotationTool extends PlaceAnnotationTool {
     state.disposer();
     this.inProgressAnnotation.value = undefined;
   }
+
+  abstract undo(): void;
 }
 
 abstract class TwoStepAnnotationTool extends PlaceAnnotationTool {
@@ -1541,14 +1543,14 @@ class PlacePolylineTool extends MultiStepAnnotationTool {
       // Otherwise just show a preview
       this.storedRelationships = newAnnotation.relatedSegments;
     }
-    return {newAnnotation, finished};
+    return { newAnnotation, finished };
   }
 
   toJSON() {
     return ANNOTATE_POLYLINE_TOOL_ID;
   }
 
-  complete() {
+  private removeLastPointFromAnnotation() {
     function annotationWithoutLastPoint(annotation: PolyLine) {
       return <PolyLine>{
         ...annotation,
@@ -1567,7 +1569,15 @@ class PlacePolylineTool extends MultiStepAnnotationTool {
     }
     // If preferred, could use this to prevent polylines that are a single point.
     // state.annotationLayer.source.delete(state.reference);
+  }
+
+  complete() {
+    this.removeLastPointFromAnnotation();
     super.complete();
+  }
+
+  undo() {
+    this.removeLastPointFromAnnotation();
   }
 }
 

--- a/src/ui/default_input_event_bindings.ts
+++ b/src/ui/default_input_event_bindings.ts
@@ -116,6 +116,7 @@ export function getDefaultRenderedDataPanelBindings() {
         "at:mousedown2": "move-to-mouse-position",
         "at:alt+mousedown0": "move-annotation",
         "at:control+alt+mousedown2": "delete-annotation",
+        enter: "finish-annotation",
         "at:touchpinch": "zoom-via-touchpinch",
         "at:touchrotate": "rotate-in-plane-via-touchrotate",
         "at:touchtranslate2": "translate-in-plane-via-touchtranslate",

--- a/src/ui/default_input_event_bindings.ts
+++ b/src/ui/default_input_event_bindings.ts
@@ -117,6 +117,7 @@ export function getDefaultRenderedDataPanelBindings() {
         "at:alt+mousedown0": "move-annotation",
         "at:control+alt+mousedown2": "delete-annotation",
         enter: "finish-annotation",
+        backspace: "undo-annotation-step",
         "at:touchpinch": "zoom-via-touchpinch",
         "at:touchrotate": "rotate-in-plane-via-touchrotate",
         "at:touchtranslate2": "translate-in-plane-via-touchtranslate",

--- a/src/util/array.spec.ts
+++ b/src/util/array.spec.ts
@@ -23,6 +23,7 @@ import {
   tile2dArray,
   transposeArray2d,
   findClosestMatchInSortedArray,
+  findFirstInSortedArray,
 } from "#src/util/array.js";
 
 describe("partitionArray", () => {
@@ -226,5 +227,78 @@ describe("findClosestMatchInSortedArray", () => {
     expect(findClosestMatchInSortedArray([0, 1, 2, 3], 1.6, compare)).toEqual(
       2,
     );
+  });
+});
+
+describe("findFirst", () => {
+  it("returns -1 for an empty array", () => {
+    expect(findFirstInSortedArray([], (x) => x === 5)).toEqual(-1);
+  });
+
+  describe("ascending direction (default)", () => {
+    it("finds the first item >= 3", () => {
+      const arr = [1, 2, 3, 3, 4, 5];
+      expect(findFirstInSortedArray(arr, (x) => x >= 3)).toEqual(2);
+    });
+
+    it("finds the first item > 4", () => {
+      const arr = [1, 2, 3, 4, 5];
+      expect(findFirstInSortedArray(arr, (x) => x > 4)).toEqual(4);
+    });
+
+    it("returns -1 if no item matches", () => {
+      const arr = [1, 2, 3];
+      expect(findFirstInSortedArray(arr, (x) => x > 10)).toEqual(-1);
+    });
+
+    it("returns 0 if first item matches", () => {
+      const arr = [5, 6, 7];
+      expect(findFirstInSortedArray(arr, (x) => x >= 5)).toEqual(0);
+    });
+
+    it("respects custom bounds", () => {
+      const arr = [0, 1, 2, 3, 4, 0, 5, 6, 7];
+      expect(findFirstInSortedArray(arr, (x) => x >= 4, "asc", 5, 8)).toEqual(6);
+    });
+
+  });
+
+  describe("descending direction", () => {
+    it("finds the first item < 4 from the right", () => {
+      const arr = [1, 2, 3, 4, 5];
+      expect(findFirstInSortedArray(arr, (x) => x < 4, "desc")).toEqual(2);
+    });
+
+    it("finds the first item <= 3 from the right", () => {
+      const arr = [1, 2, 3, 3, 4, 5];
+      expect(findFirstInSortedArray(arr, (x) => x <= 3, "desc")).toEqual(3);
+    });
+
+    it("returns -1 if no match", () => {
+      const arr = [5, 6, 7];
+      expect(findFirstInSortedArray(arr, (x) => x < 5, "desc")).toEqual(-1);
+    });
+
+    it("respects custom bounds", () => {
+      const arr = [1, 2, 3, 4, 5, 6];
+      expect(findFirstInSortedArray(arr, (x) => x <= 4, "desc", 1, 3)).toEqual(2);
+    });
+  });
+
+  describe("complex predicates", () => {
+    it("works with object arrays", () => {
+      const arr = [{ v: 1 }, { v: 2 }, { v: 3 }];
+      expect(findFirstInSortedArray(arr, (x) => x.v >= 2)).toEqual(1);
+    });
+
+    it("handles multiple matches, returns first in 'asc'", () => {
+      const arr = [1, 2, 2, 2, 3];
+      expect(findFirstInSortedArray(arr, (x) => x === 2, "asc")).toEqual(1);
+    });
+
+    it("handles multiple matches, returns last in 'desc'", () => {
+      const arr = [1, 2, 2, 2, 3];
+      expect(findFirstInSortedArray(arr, (x) => x === 2, "desc")).toEqual(3);
+    });
   });
 });

--- a/src/util/array.spec.ts
+++ b/src/util/array.spec.ts
@@ -258,9 +258,10 @@ describe("findFirst", () => {
 
     it("respects custom bounds", () => {
       const arr = [0, 1, 2, 3, 4, 0, 5, 6, 7];
-      expect(findFirstInSortedArray(arr, (x) => x >= 4, "asc", 5, 8)).toEqual(6);
+      expect(findFirstInSortedArray(arr, (x) => x >= 4, "asc", 5, 8)).toEqual(
+        6,
+      );
     });
-
   });
 
   describe("descending direction", () => {
@@ -281,7 +282,9 @@ describe("findFirst", () => {
 
     it("respects custom bounds", () => {
       const arr = [1, 2, 3, 4, 5, 6];
-      expect(findFirstInSortedArray(arr, (x) => x <= 4, "desc", 1, 3)).toEqual(2);
+      expect(findFirstInSortedArray(arr, (x) => x <= 4, "desc", 1, 3)).toEqual(
+        2,
+      );
     });
   });
 

--- a/src/util/array.ts
+++ b/src/util/array.ts
@@ -292,11 +292,10 @@ export function findFirstLessThanInSortedArray<T>(
   while (low < high) {
     const mid = (low + high) >> 1;
     if (compare(haystack[mid], needle) < 0) {
-      // haystack[mid] < needle, it's a candidate
       result = mid;
-      low = mid + 1; // try to find a larger one that's still < needle
+      low = mid + 1;
     } else {
-      high = mid; // eliminate this and all higher values
+      high = mid;
     }
   }
   return result;

--- a/src/util/array.ts
+++ b/src/util/array.ts
@@ -256,7 +256,7 @@ export function findClosestMatchInSortedArray<T>(
 export function findFirstInSortedArray<T>(
   haystack: ArrayLike<T>,
   predicate: (item: T) => boolean,
-  direction: 'asc' | 'desc' = 'asc',
+  direction: "asc" | "desc" = "asc",
   low: number = 0,
   high: number = haystack.length,
 ): number {
@@ -268,9 +268,9 @@ export function findFirstInSortedArray<T>(
 
     if (match) {
       result = mid;
-      direction === 'asc' ? (high = mid) : (low = mid + 1);
+      direction === "asc" ? (high = mid) : (low = mid + 1);
     } else {
-      direction === 'asc' ? (low = mid + 1) : (high = mid);
+      direction === "asc" ? (low = mid + 1) : (high = mid);
     }
   }
 

--- a/src/util/array.ts
+++ b/src/util/array.ts
@@ -246,6 +246,63 @@ export function findClosestMatchInSortedArray<T>(
 }
 
 /**
+ * Performs a directional binary search to find the index of the first element in `haystack`
+ * that satisfies the given `predicate`.
+ *
+ * @param direction - 'asc' to find the lowest qualifying index (default),
+ *                    'desc' to find the highest qualifying index.
+ * @returns The index of the matching element, or -1 if none found.
+ */
+export function findFirstInSortedArray<T>(
+  haystack: ArrayLike<T>,
+  predicate: (item: T) => boolean,
+  direction: 'asc' | 'desc' = 'asc',
+  low: number = 0,
+  high: number = haystack.length,
+): number {
+  let result = -1;
+
+  while (low < high) {
+    const mid = (low + high - 1) >> 1;
+    const match = predicate(haystack[mid]);
+
+    if (match) {
+      result = mid;
+      direction === 'asc' ? (high = mid) : (low = mid + 1);
+    } else {
+      direction === 'asc' ? (low = mid + 1) : (high = mid);
+    }
+  }
+
+  return result;
+}
+
+/**
+ * Returns the index of the first element in `haystack` that is less than `needle`, according to
+ * `compare`. If no such element exists, returns -1.
+ */
+export function findFirstLessThanInSortedArray<T>(
+  haystack: ArrayLike<T>,
+  needle: T,
+  compare: (a: T, b: T) => number,
+  low = 0,
+  high = haystack.length,
+): number {
+  let result = -1;
+  while (low < high) {
+    const mid = (low + high) >> 1;
+    if (compare(haystack[mid], needle) < 0) {
+      // haystack[mid] < needle, it's a candidate
+      result = mid;
+      low = mid + 1; // try to find a larger one that's still < needle
+    } else {
+      high = mid; // eliminate this and all higher values
+    }
+  }
+  return result;
+}
+
+/**
  * Returns the first index in `[begin, end)` for which `predicate` is `true`, or returns `end` if no
  * such index exists.
  *

--- a/src/util/array.ts
+++ b/src/util/array.ts
@@ -278,30 +278,6 @@ export function findFirstInSortedArray<T>(
 }
 
 /**
- * Returns the index of the first element in `haystack` that is less than `needle`, according to
- * `compare`. If no such element exists, returns -1.
- */
-export function findFirstLessThanInSortedArray<T>(
-  haystack: ArrayLike<T>,
-  needle: T,
-  compare: (a: T, b: T) => number,
-  low = 0,
-  high = haystack.length,
-): number {
-  let result = -1;
-  while (low < high) {
-    const mid = (low + high) >> 1;
-    if (compare(haystack[mid], needle) < 0) {
-      result = mid;
-      low = mid + 1;
-    } else {
-      high = mid;
-    }
-  }
-  return result;
-}
-
-/**
  * Returns the first index in `[begin, end)` for which `predicate` is `true`, or returns `end` if no
  * such index exists.
  *


### PR DESCRIPTION
A polyline is a single annotation that contains one or more lines. They can be added from the UI or from the precomputed format

## UI placement

Polylines can be added in the UI via:

1. Creating a local annotation layer
2. Selecting the polyline tool
3. Clicking to place the points as normal with other tools
4. To indicate completion of the polyline, place two points at the same location, or hit `enter`
5. Note, during placing a polyline you can delete a vertex via `backspace`

After placing a polyline, deleting vertices is currently not supported. You can move a single vertex via alt clicking on that vertex, or the whole polyline by clicking on any line in the polyline.

## Precomputed format

Polylines are stored slightly differently to other precomputed format annotations. They require an additional piece of information, which is the number of vertices in the polyline. As such, the storage format for a single polyline is:

```
NUM_POINTS_UINT32, POINT1_FLOAT32, POINT2_FLOAT32, ..., POINTK_FLOAT32, PROPERTIES
```

## Technical note - handling a variable length annotation

Because all previous annotations were both:
1. Of fixed size given the rank
2. In the same storage format in the precomputed file and buffer for rendering (outside of possibly shuffling properties to the end of the buffer with lots of properties)

There were a few changes needed for variable length annotations. The strategy chosen in the PR right now is generally that each instance for rendering is a fixed size, but not the annotation itself. So a polyline would have a variable number of instances depending on the length of the polyline, but each of those instances is a fixed size for the buffer.
This leads to a bit of data duplication in the buffer, as the properties for a polyline are per polyline, not per vertex or per line -- but those properties are copied per line instance of the polyline.

As such, changes across the annotation handling are setup for polylines specifically. Perhaps if another variable length annotation type is added in the future, this polyline handling could be made a little more generic and a variable length annotation handling could be added. In some places, this has already been setup in a generic way, but didn't want to risk an overdesign for a possible future addition