### PR TITLE
fix(ui/side_panel): ensure panel cross sizes are correctly restored f…

### DIFF
--- a/src/ui/side_panel.ts
+++ b/src/ui/side_panel.ts
@@ -665,7 +665,9 @@ export class SidePanelManager extends RefCounted {
         } else {
           flexGroup.visible = visible;
           flexGroup.minSize = minSize;
-          flexGroup.crossSize = Math.max(flexGroup.crossSize, minSize);
+          if (!visible) {
+            flexGroup.crossSize = -1;
+          }
         }
         function* getCells() {
           yield flexGroup.beginDropZone;
@@ -686,8 +688,13 @@ export class SidePanelManager extends RefCounted {
               cell.registeredPanel = registeredPanel;
             }
             const oldLocation = cell.registeredPanel.location.value;
-            if (flexGroup.crossSize === -1) {
-              flexGroup.crossSize = Math.max(minSize, oldLocation.size);
+            if (oldLocation.visible) {
+              flexGroup.crossSize = Math.max(
+                minSize,
+                flexGroup.crossSize === -1
+                  ? oldLocation.size
+                  : flexGroup.crossSize,
+              );
             }
             if (
               oldLocation[crossKey] !== crossIndex ||


### PR DESCRIPTION
…rom JSON state

A given panel "flex group" (column/row) may contain both visible and non-visible panels.

Previously, the presence of a non-visible panel could result in the size not being correctly restored from the JSON state.

With this change:

- The size of the flex group is taken from the first visible panel, rather than the first visible or non-visible panel.

- When the first visible panel is added to a flex group that was previously hidden (due to not containing any visible panels), its size is set to the size of the newly visible panel.  This means that two panels in the same flex group can maintain different sizes (e.g. the "settings" and "layer list" panels), as long as both are not visible at the same time.  If both become visible at the same time, the second one to become visible will have its size reset to the size of the other panel.

Fixes https://github.com/google/neuroglancer/issues/773.