### PR TITLE
fix(ui): bump z-index for data source to make it go over tool palettes

### DIFF
--- a/src/ui/layer_data_sources_tab.css
+++ b/src/ui/layer_data_sources_tab.css
@@ -25,7 +25,7 @@
   flex-direction: column;
   flex: 1;
   height: 0px;
-  z-index: 1;
+  z-index: 2;
 }
 
 .neuroglancer-layer-data-source-url-input input.autocomplete-input {


### PR DESCRIPTION
With a tool palette open and a layer side panel above it, clicking the data source dropdown causes it to overlap with the group name because it is with the same z-index and sticky

![Image](https://github.com/user-attachments/assets/1b84680a-aa1c-4170-b891-e277463bcea3)

![Image](https://github.com/user-attachments/assets/c9198dfb-0d92-45d9-9099-8461526cde38)

I've bumped up the z-index on the data source here to make it sit over it

![image](https://github.com/user-attachments/assets/8958d04b-408c-43a7-b4d7-aa8508d84cb2)
