### PR TITLE
fix: update annotation display units in annotation tab when global/local units change

### DIFF
--- a/src/ui/annotations.ts
+++ b/src/ui/annotations.ts
@@ -76,7 +76,6 @@ import { getDefaultAnnotationListBindings } from "#src/ui/default_input_event_bi
 import { LegacyTool, registerLegacyTool } from "#src/ui/tool.js";
 import { animationFrameDebounce } from "#src/util/animation_frame_debounce.js";
 import type { ArraySpliceOp } from "#src/util/array.js";
-import { arraysEqual } from "#src/util/array.js";
 import { setClipboard } from "#src/util/clipboard.js";
 import {
   serializeColor,
@@ -367,14 +366,9 @@ export class AnnotationLayerView extends Tab {
         localDimensionIndices.push(localDim);
       }
     }
-    if (
-      !arraysEqual(globalDimensionIndices, this.globalDimensionIndices) ||
-      !arraysEqual(localDimensionIndices, this.localDimensionIndices)
-    ) {
-      this.localDimensionIndices = localDimensionIndices;
-      this.globalDimensionIndices = globalDimensionIndices;
-      ++this.curCoordinateSpaceGeneration;
-    }
+    this.localDimensionIndices = localDimensionIndices;
+    this.globalDimensionIndices = globalDimensionIndices;
+    ++this.curCoordinateSpaceGeneration;
   }
 
   constructor(


### PR DESCRIPTION
The annotation tab in the layer side panel is listening for changes in the global or local co-ordinate space, but it doesn't act upon them when the units or scale change in dims because the current check only updates when indices of the global or local co-ordinate space change

Wondering if we could simplify that check as in this PR? I could be missing something for sure, but it would seem that perhaps the co-ordinate spaces don't change often, so we could just update the coordinate space generation every time they change

Previous is like this:

https://github.com/user-attachments/assets/aa817f4a-868c-4a26-bb9c-9bb113ac3824

