### PR TITLE
feat(url_hash_binding) added settings to rate limit url updates and optionally use session storage

### DIFF
--- a/python/neuroglancer/viewer_config_state.py
+++ b/python/neuroglancer/viewer_config_state.py
@@ -367,6 +367,9 @@ class ConfigState(JsonObjectWrapper):
     show_screenshot_button = showScreenshotButton = wrapped_property(
         "showScreenshotButton", optional(bool, True)
     )
+    show_state_share_button = showStateShareButton = wrapped_property(
+        "showStateShareButton", optional(bool, True)
+    )
     show_tool_palette_button = showToolPaletteButton = wrapped_property(
         "showToolPaletteButton", optional(bool, True)
     )

--- a/src/datasource/state_share.css
+++ b/src/datasource/state_share.css
@@ -1,0 +1,83 @@
+.neuroglancer-state-share-button-container {
+  display: inline-flex;
+  flex-direction: row;
+}
+
+.neuroglancer-state-share-button-container {
+  border-radius: 20%;
+  border: 1px solid transparent;
+}
+
+.neuroglancer-state-share-button-container:hover {
+  background-color: #484848;
+}
+
+.neuroglancer-state-share-button {
+  position: relative;
+  display: flex;
+  flex-direction: row;
+}
+
+.neuroglancer-state-share-dropdown {
+  position: absolute;
+  z-index: 100;
+  min-width: fit-content;
+  border: 1px solid #aaa;
+  background-color: black;
+  padding: 2px;
+}
+
+.neuroglancer-state-share-dropdown > ul {
+  overflow-y: auto;
+  padding: 0px;
+  margin: 0px;
+  display: grid;
+  grid-template-rows: min-content min-content;
+  grid-auto-rows: 1fr;
+  grid-template-columns: min-content min-content min-content;
+  column-gap: 5px;
+  align-items: center;
+}
+
+.neuroglancer-state-share-dropdown > ul > li {
+  height: 100%;
+  display: grid;
+  box-sizing: border-box;
+  grid-column: 1/4;
+  grid-template-columns: subgrid;
+  align-items: center;
+  cursor: pointer;
+  list-style-type: none;
+  padding: 2px;
+  font: 10pt sans-serif;
+  white-space: nowrap;
+}
+
+.neuroglancer-state-share-dropdown-item:hover {
+  background-color: #333;
+}
+
+.neuroglancer-state-share-dropdown-item > *:nth-child(3) {
+  justify-self: end;
+}
+
+.neuroglancer-state-share-dropdown
+  > ul
+  > .neuroglancer-state-share-dropdown-separator {
+  height: 1px;
+  margin-top: 3px;
+  margin-bottom: 3px;
+  padding: 0px;
+  background-color: #ccc;
+}
+
+.neuroglancer-state-share-items {
+  display: flex;
+  flex-direction: column;
+  flex-grow: 1;
+  flex-shrink: 1;
+  flex-basis: 0px;
+  font: 10pt sans-serif;
+  overflow-y: auto;
+  overflow-x: hidden;
+}

--- a/src/datasource/state_share.ts
+++ b/src/datasource/state_share.ts
@@ -1,8 +1,14 @@
+import "#src/datasource/state_share.css";
 import { ReadableHttpKvStore } from "#src/kvstore/http/common.js";
 import { joinBaseUrlAndPath } from "#src/kvstore/url.js";
 import { StatusMessage } from "#src/status.js";
+import { WatchableValue } from "#src/trackable_value.js";
+import { encodeFragment } from "#src/ui/url_hash_binding.js";
 import { RefCounted } from "#src/util/disposable.js";
+import { removeFromParent } from "#src/util/dom.js";
+import { positionRelativeDropdown } from "#src/util/dropdown.js";
 import { bigintToStringJsonReplacer } from "#src/util/json.js";
+import { getCachedJson } from "#src/util/trackable.js";
 import type { Viewer } from "#src/viewer.js";
 import { makeIcon } from "#src/widget/icon.js";
 
@@ -15,119 +21,240 @@ type StateServers = {
   [name: string]: StateServer;
 };
 
-declare const STATE_SERVERS: StateServers | undefined;
-
+const STATE_SERVERS: StateServers | undefined = {
+  cave: {
+    url: "middleauth+https://global.daf-apis.com/nglstate/api/v1/post",
+    default: true,
+  },
+  cave2: {
+    url: "middleauth+https://global.daf-apis.com/nglstate/api/v1/post",
+    default: true,
+  },
+};
 export const stateShareEnabled =
   typeof STATE_SERVERS !== "undefined" && Object.keys(STATE_SERVERS).length > 0;
 
 export class StateShare extends RefCounted {
-  // call it a widget? no because it doesn't pop out?
   element = document.createElement("div");
   button = makeIcon({ text: "Share", title: "Share State" });
-  selectStateServerElement?: HTMLSelectElement;
 
-  constructor(viewer: Viewer) {
-    super();
+  stateServers: StateServers = STATE_SERVERS ?? ({} as StateServers);
 
-    if (typeof STATE_SERVERS === "undefined") {
-      throw new Error(
-        "Cannot construct StateSare without defining STATE_SERVERS",
-      );
+  countElement = document.createElement("div");
+  dropdownVisible = new WatchableValue<boolean>(false);
+  dropdown: MultiStateShareDropdown | undefined;
+
+  private defaultStateServer_: StateServer | undefined;
+
+  get state() {
+    return this.viewer.state;
+  }
+
+  get stateJSON() {
+    return JSON.stringify(
+      getCachedJson(this.state).value,
+      bigintToStringJsonReplacer,
+    );
+  }
+
+  get defaultStateServer(): StateServer | undefined {
+    return this.defaultStateServer_;
+  }
+
+  set defaultStateServer(newDefault: StateServer) {
+    this.defaultStateServer_ = newDefault;
+    for (const stateServer of Object.values(this.stateServers)) {
+      stateServer.default = stateServer === newDefault;
     }
+  }
 
-    // if more than one state server, add UI so users can select the state server to use
-    if (Object.keys(STATE_SERVERS).length > 1) {
-      const selectEl = document.createElement("select");
-      selectEl.style.marginRight = "5px";
-
-      this.registerDisposer(
-        viewer.selectedStateServer.changed.add(() => {
-          const valueFromState = viewer.selectedStateServer.value;
-          if (
-            Object.values(STATE_SERVERS)
-              .map((s) => s.url)
-              .includes(valueFromState)
-          ) {
-            selectEl.value = valueFromState;
-          }
-        }),
+  shareStateServer(override?: StateServer) {
+    const { viewer, stateJSON, defaultStateServer } = this;
+    const stateServerUrl = (override ?? defaultStateServer)?.url;
+    if (!stateServerUrl) return;
+    const { store, path } =
+      viewer.dataSourceProvider.sharedKvStoreContext.kvStoreContext.getKvStore(
+        stateServerUrl,
       );
-
-      this.registerEventListener(selectEl, "change", () => {
-        viewer.selectedStateServer.value = selectEl.value;
-      });
-
-      for (const [name, stateServer] of Object.entries(STATE_SERVERS)) {
-        const option = document.createElement("option");
-        option.textContent = name;
-        option.value = stateServer.url;
-        option.selected = !!stateServer.default;
-        selectEl.appendChild(option);
-      }
-
-      this.element.appendChild(selectEl);
-      this.selectStateServerElement = selectEl;
+    if (!(store instanceof ReadableHttpKvStore)) {
+      throw new Error(`Non-HTTP protocol not supported: ${stateServerUrl}`);
     }
-
-    this.element.appendChild(this.button);
-
-    this.registerEventListener(this.button, "click", () => {
-      const selectedStateServer = this.selectStateServerElement
-        ? this.selectStateServerElement.value
-        : Object.values(STATE_SERVERS)[0].url;
-
-      const { store, path } =
-        viewer.dataSourceProvider.sharedKvStoreContext.kvStoreContext.getKvStore(
-          selectedStateServer,
-        );
-
-      if (!(store instanceof ReadableHttpKvStore)) {
-        throw new Error(
-          `Non-HTTP protocol not supported: ${selectedStateServer}`,
-        );
-      }
-
-      StatusMessage.forPromise(
-        store
-          .fetchOkImpl(joinBaseUrlAndPath(store.baseUrl, path), {
-            method: "POST",
-            headers: { "Content-Type": "application/json" },
-            body: JSON.stringify(
-              viewer.state.toJSON(),
-              bigintToStringJsonReplacer,
-            ),
-          })
-          .then((response) => response.json())
-          .then((res) => {
-            const stateUrlProtcol = new URL(res).protocol;
-            const stateUrlWithoutProtocol = res.substring(
-              stateUrlProtcol.length,
-            );
-            const protocol = new URL(selectedStateServer).protocol;
-            const link = `${window.location.origin}/#!${protocol}${stateUrlWithoutProtocol}`;
-            navigator.clipboard.writeText(link).then(() => {
-              StatusMessage.showTemporaryMessage(
-                "Share link copied to clipboard",
-              );
-            });
-          })
-          .catch(() => {
+    StatusMessage.forPromise(
+      store
+        .fetchOkImpl(joinBaseUrlAndPath(store.baseUrl, path), {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: stateJSON,
+        })
+        .then((response) => response.json())
+        .then((res) => {
+          const stateUrlProtcol = new URL(res).protocol;
+          const stateUrlWithoutProtocol = res.substring(stateUrlProtcol.length);
+          const protocol = new URL(stateServerUrl).protocol;
+          const link = `${window.location.origin}/#!${protocol}${stateUrlWithoutProtocol}`;
+          history.replaceState(
+            null,
+            "",
+            "#!" + `${protocol}${stateUrlWithoutProtocol}`,
+          );
+          navigator.clipboard.writeText(link).then(() => {
             StatusMessage.showTemporaryMessage(
-              "Could not access state server.",
-              4000,
+              "Share link copied to clipboard",
             );
-          }),
-        {
-          initialMessage: `Posting state to ${selectedStateServer}.`,
-          delay: true,
-          errorPrefix: "",
-        },
-      );
+          });
+        })
+        .catch(() => {
+          StatusMessage.showTemporaryMessage(
+            "Could not access state server.",
+            4000,
+          );
+        }),
+      {
+        initialMessage: `Posting state to ${stateServerUrl}.`,
+        delay: true,
+        errorPrefix: "",
+      },
+    );
+  }
+
+  shareUrl() {
+    const { stateJSON } = this;
+    const encodedStateString = encodeFragment(stateJSON);
+    if (decodeURIComponent(encodedStateString) === "{}") {
+      history.replaceState(null, "", "#");
+    } else {
+      history.replaceState(null, "", "#!" + encodedStateString);
+    }
+    navigator.clipboard.writeText(window.location.href).then(() => {
+      StatusMessage.showTemporaryMessage("Share link copied to clipboard");
+    });
+  }
+
+  constructor(private viewer: Viewer) {
+    super();
+    const { element, stateServers } = this;
+    element.classList.add("neuroglancer-state-share-button");
+    element.classList.add("neuroglancer-sticky-focus");
+    this.button.classList.add("state-share");
+    element.tabIndex = -1;
+    // default to first state server marked as default
+    for (const stateServer of Object.values(stateServers)) {
+      if (!this.defaultStateServer && stateServer.default) {
+        this.defaultStateServer = stateServer;
+      } else {
+        stateServer.default = false;
+      }
+    }
+    // if no default state server, default to first
+    if (stateServers.length && !this.defaultStateServer) {
+      this.defaultStateServer = Object.values(stateServers)[0];
+    }
+    const serverCount = Object.keys(stateServers).length;
+    element.appendChild(this.button);
+    this.registerEventListener(this.button, "click", () => {
+      if (serverCount > 0) {
+        this.shareStateServer();
+      } else {
+        this.shareUrl();
+      }
+    });
+    // if there are state servers, right click becomes share url
+    if (serverCount > 0) {
+      this.registerEventListener(this.button, "contextmenu", () => {
+        this.dropdownVisible.value = !this.dropdownVisible.value;
+      });
+    }
+    this.dropdownVisible.changed.add(() => {
+      const visible = this.dropdownVisible.value;
+      if (!visible) {
+        this.dropdown?.dispose();
+        this.dropdown = undefined;
+      } else {
+        if (this.dropdown === undefined) {
+          this.dropdown = new MultiStateShareDropdown(this);
+          element.appendChild(this.dropdown.element);
+          positionRelativeDropdown(this.dropdown.element, this.element);
+        }
+      }
+    });
+    element.addEventListener("focusout", (event) => {
+      const { relatedTarget } = event;
+      if (relatedTarget instanceof Node && !element.contains(relatedTarget)) {
+        this.dropdownVisible.value = false;
+      }
     });
   }
 
   disposed() {
     this.element.remove();
+    this.dropdown?.dispose();
     super.disposed();
+  }
+}
+
+class StateServerListDropdownItem {
+  element = document.createElement("li");
+  constructor(name: string, stateServer: StateServer) {
+    const { element } = this;
+    element.classList.add("neuroglancer-state-share-dropdown-item");
+    element.innerHTML = `<span>Upload to ${name}</span><span>[${stateServer.url}]</span>`;
+    if (stateServer.default) {
+      const defaultStatus = document.createElement("span");
+      defaultStatus.innerHTML += "<span>(default)</span>";
+      element.appendChild(defaultStatus);
+    } else {
+      const makeDefaultButton = document.createElement("button");
+      makeDefaultButton.textContent = "make default";
+      element.appendChild(makeDefaultButton);
+      makeDefaultButton.addEventListener("click", (evt) => {
+        evt.stopPropagation();
+        element.dispatchEvent(new Event("setdefault"));
+      });
+    }
+  }
+}
+
+export class MultiStateShareDropdown extends RefCounted {
+  element = document.createElement("div");
+  itemContainer = document.createElement("ul");
+  cannedItemSeparator = document.createElement("li");
+  constructor(private stateShare: StateShare) {
+    super();
+    const { element, itemContainer, cannedItemSeparator } = this;
+    element.classList.add("neuroglancer-state-share-dropdown");
+    element.appendChild(itemContainer);
+    cannedItemSeparator.classList.add(
+      "neuroglancer-state-share-dropdown-separator",
+    );
+    this.updateView();
+  }
+
+  updateView() {
+    const { stateShare, cannedItemSeparator } = this;
+    this.itemContainer.replaceChildren();
+    const { stateServers } = stateShare;
+    const shareToUrl = document.createElement("li");
+    shareToUrl.addEventListener("click", stateShare.shareUrl);
+    shareToUrl.classList.add("neuroglancer-state-share-dropdown-item");
+    shareToUrl.textContent = "Copy as URL";
+    this.itemContainer.appendChild(shareToUrl);
+    this.itemContainer.appendChild(cannedItemSeparator);
+    for (const [name, stateServer] of Object.entries(stateServers)) {
+      const item = new StateServerListDropdownItem(name, stateServer);
+      item.element.addEventListener("setdefault", () => {
+        stateShare.defaultStateServer = stateServer;
+        this.updateView();
+        // TODO, make defaultStateServer a watchable value
+      });
+      this.itemContainer.appendChild(item.element);
+      item.element.addEventListener("click", () => {
+        stateShare.shareStateServer(stateServer);
+      });
+    }
+  }
+
+  disposed() {
+    super.disposed();
+    removeFromParent(this.element);
   }
 }

--- a/src/main_python.ts
+++ b/src/main_python.ts
@@ -147,12 +147,7 @@ configState.add("volumeRequests", volumeHandler.requestState);
 let sharedState: Trackable | undefined = viewer.state;
 
 if (window.location.hash) {
-  const hashBinding = viewer.registerDisposer(
-    new UrlHashBinding(
-      viewer.state,
-      viewer.dataSourceProvider.sharedKvStoreContext,
-    ),
-  );
+  const hashBinding = viewer.registerDisposer(new UrlHashBinding(viewer));
   hashBinding.updateFromUrlHash();
   sharedState = undefined;
 }

--- a/src/ui/default_viewer_setup.ts
+++ b/src/ui/default_viewer_setup.ts
@@ -35,16 +35,12 @@ export function setupDefaultViewer(options?: Partial<MinimalViewerOptions>) {
   setDefaultInputEventBindings(viewer.inputEventBindings);
 
   const hashBinding = viewer.registerDisposer(
-    new UrlHashBinding(
-      viewer.state,
-      viewer.dataSourceProvider.sharedKvStoreContext,
-      {
-        defaultFragment:
-          typeof NEUROGLANCER_DEFAULT_STATE_FRAGMENT !== "undefined"
-            ? NEUROGLANCER_DEFAULT_STATE_FRAGMENT
-            : undefined,
-      },
-    ),
+    new UrlHashBinding(viewer, {
+      defaultFragment:
+        typeof NEUROGLANCER_DEFAULT_STATE_FRAGMENT !== "undefined"
+          ? NEUROGLANCER_DEFAULT_STATE_FRAGMENT
+          : undefined,
+    }),
   );
   viewer.registerDisposer(
     hashBinding.parseError.changed.add(() => {

--- a/src/ui/url_hash_binding.ts
+++ b/src/ui/url_hash_binding.ts
@@ -34,7 +34,7 @@ import type { Viewer } from "#src/viewer.js";
 /**
  * Encodes a fragment string robustly.
  */
-function encodeFragment(fragment: string) {
+export function encodeFragment(fragment: string) {
   return encodeURI(fragment).replace(
     /[!'()*;,]/g,
     (c) => "%" + c.charCodeAt(0).toString(16).toUpperCase(),

--- a/src/ui/viewer_settings.ts
+++ b/src/ui/viewer_settings.ts
@@ -102,6 +102,7 @@ export class ViewerSettingsPanel extends SidePanel {
       "Concurrent chunk requests",
       viewer.chunkQueueManager.capacities.download.itemLimit,
     );
+    addLimitWidget("Url update rate limit (ms)", viewer.urlRateLimit);
 
     const addCheckbox = (
       label: string,
@@ -115,6 +116,8 @@ export class ViewerSettingsPanel extends SidePanel {
       labelElement.appendChild(checkbox.element);
       scroll.appendChild(labelElement);
     };
+    addCheckbox("Save state to url", viewer.saveStateUrl);
+    addCheckbox("Save state to session storage", viewer.saveStateSession);
     addCheckbox("Show axis lines", viewer.showAxisLines);
     addCheckbox("Show scale bar", viewer.showScaleBar);
     addCheckbox("Show cross sections in 3-d", viewer.showPerspectiveSliceViews);


### PR DESCRIPTION
also updated state share ui to match the look/feel of the tool pallete dropdown (on right click) along with the new option to copy url.

Sven passed along a suggestion from you, iirc, to use a browser event to update the url when the user clicks into the url bar. The blur event seems to work pretty well. Sometimes I end up getting a partial selection of the url but that might be from a slight movement of the cursor when clicking. Most of the time, it works perfectly, updating the selection with the new state.

With that feature, maybe things like the "copy as url" action in the state share dropdown, are now unnecessary.

<img width="611" alt="Screenshot 2025-06-04 at 1 18 43 PM" src="https://github.com/user-attachments/assets/867e0b2f-375b-4e8c-a159-87639c2c6bf2" />


Also, I can split the state_share changes into a separate PR. There is definitely an opportunity to reuse the dropdown logic/styling between the two.