### PR TITLE
Fix state share copy to clipboard in insecure context (http)

### DIFF
--- a/src/datasource/state_share.ts
+++ b/src/datasource/state_share.ts
@@ -6,6 +6,30 @@ import { bigintToStringJsonReplacer } from "#src/util/json.js";
 import type { Viewer } from "#src/viewer.js";
 import { makeIcon } from "#src/widget/icon.js";
 
+
+function copyToClipboard(textToCopy) {
+  // navigator clipboard api needs a secure context (https)
+  if (navigator.clipboard && window.isSecureContext) {
+    return navigator.clipboard.writeText(textToCopy);
+  } else {
+    // text area method for insecure context (http)
+    const textArea = document.createElement("textarea");
+    textArea.value = textToCopy;
+    // text area out of viewport
+    textArea.style.position = "fixed";
+    textArea.style.left = "-999999px";
+    textArea.style.top = "-999999px";
+    document.body.appendChild(textArea);
+    textArea.focus();
+    textArea.select();
+    return new Promise((res, rej) => {
+      document.execCommand("copy") ? res() : rej();
+      textArea.remove();
+    });
+  }
+}
+
+
 type StateServer = {
   url: string;
   default?: boolean;
@@ -104,8 +128,9 @@ export class StateShare extends RefCounted {
               stateUrlProtcol.length,
             );
             const protocol = new URL(selectedStateServer).protocol;
-            const link = `${window.location.origin}/#!${protocol}${stateUrlWithoutProtocol}`;
-            navigator.clipboard.writeText(link).then(() => {
+            const link = `${window.location.origin}${window.location.pathname}#!${protocol}${stateUrlWithoutProtocol}`;
+
+            copyToClipboard(link).then(() => {
               StatusMessage.showTemporaryMessage(
                 "Share link copied to clipboard",
               );


### PR DESCRIPTION
Using the "Share" button to post to a state server on an http deployment on most browsers will send the correct request, but quietly fail copying the link to the clipboard because the navigator requires a secure context.

In this commit I introduce a function that replicates the original behavior in the secure context, while providing a workaround when the original method would fail.  I also modify the returned link to include the pathname, which I believe was leading to incompatible copied links when being serving on a subpath.

It's not uncommon to want to stand up http versions of neuroglancer to talk to custom state servers or view local http data sources -- I think this makes deployment easier for those cases and hopefully eliminates some confusion -- let me know what you think.

Thanks!
Russel