### PR TITLE
Feat/cc 376

### DIFF
--- a/src/layer_group_viewer.ts
+++ b/src/layer_group_viewer.ts
@@ -537,6 +537,7 @@ export class LayerGroupViewer extends RefCounted {
         this,
         () => this.layout.toJSON(),
         this.options.showLayerHoverValues,
+        this.options.showAllPlotBounds,
       ));
       if (options.showViewerMenu) {
         layerPanel.registerDisposer(makeViewerMenu(layerPanel.element, this));

--- a/src/layer_group_viewer.ts
+++ b/src/layer_group_viewer.ts
@@ -109,7 +109,7 @@ export interface LayerGroupViewerOptions {
   showLayerPanel: WatchableValueInterface<boolean>;
   showViewerMenu: boolean;
   showLayerHoverValues: WatchableValueInterface<boolean>;
-  showAllBounds?: boolean;
+  showAllPlotBounds?: WatchableValueInterface<boolean>;
 }
 
 export const viewerDragType = "neuroglancer-layer-group-viewer";

--- a/src/layer_group_viewer.ts
+++ b/src/layer_group_viewer.ts
@@ -109,6 +109,7 @@ export interface LayerGroupViewerOptions {
   showLayerPanel: WatchableValueInterface<boolean>;
   showViewerMenu: boolean;
   showLayerHoverValues: WatchableValueInterface<boolean>;
+  showAllBounds?: boolean;
 }
 
 export const viewerDragType = "neuroglancer-layer-group-viewer";

--- a/src/layer_groups_layout.ts
+++ b/src/layer_groups_layout.ts
@@ -765,6 +765,7 @@ function makeComponent(container: LayoutComponentContainer, spec: any) {
           showLayerPanel: viewer.uiControlVisibility.showLayerPanel,
           showViewerMenu: true,
           showLayerHoverValues: viewer.uiControlVisibility.showLayerHoverValues,
+          showAllBounds: viewer.showAllDimensionPlotBounds,
         },
       );
       try {

--- a/src/layer_groups_layout.ts
+++ b/src/layer_groups_layout.ts
@@ -410,6 +410,7 @@ function getCommonViewerState(viewer: Viewer) {
     enableAdaptiveDownsampling: viewer.enableAdaptiveDownsampling,
     showScaleBar: viewer.showScaleBar,
     scaleBarOptions: viewer.scaleBarOptions,
+    showAllDimensionPlotBounds: viewer.showAllDimensionPlotBounds,
     showPerspectiveSliceViews: viewer.showPerspectiveSliceViews,
     inputEventBindings: viewer.inputEventBindings,
     visibility: viewer.visibility,
@@ -765,7 +766,7 @@ function makeComponent(container: LayoutComponentContainer, spec: any) {
           showLayerPanel: viewer.uiControlVisibility.showLayerPanel,
           showViewerMenu: true,
           showLayerHoverValues: viewer.uiControlVisibility.showLayerHoverValues,
-          showAllBounds: viewer.showAllDimensionPlotBounds,
+          showAllPlotBounds: viewer.showAllDimensionPlotBounds,
         },
       );
       try {

--- a/src/layer_groups_layout.ts
+++ b/src/layer_groups_layout.ts
@@ -410,7 +410,6 @@ function getCommonViewerState(viewer: Viewer) {
     enableAdaptiveDownsampling: viewer.enableAdaptiveDownsampling,
     showScaleBar: viewer.showScaleBar,
     scaleBarOptions: viewer.scaleBarOptions,
-    showAllDimensionPlotBounds: viewer.showAllDimensionPlotBounds,
     showPerspectiveSliceViews: viewer.showPerspectiveSliceViews,
     inputEventBindings: viewer.inputEventBindings,
     visibility: viewer.visibility,
@@ -766,7 +765,7 @@ function makeComponent(container: LayoutComponentContainer, spec: any) {
           showLayerPanel: viewer.uiControlVisibility.showLayerPanel,
           showViewerMenu: true,
           showLayerHoverValues: viewer.uiControlVisibility.showLayerHoverValues,
-          showAllPlotBounds: viewer.showAllDimensionPlotBounds,
+          showAllPlotBounds: viewer.uiConfiguration.showAllDimensionPlotBounds,
         },
       );
       try {

--- a/src/ui/layer_bar.ts
+++ b/src/ui/layer_bar.ts
@@ -118,6 +118,7 @@ class LayerWidget extends RefCounted {
           copyButton: false,
           velocity: layer.localVelocity,
           getToolBinder: () => layer.layer?.toolBinder,
+          showOnlyMaxBounds: true,
         },
       ),
     );
@@ -225,6 +226,7 @@ export class LayerBar extends RefCounted {
         {
           velocity: this.viewerNavigationState.velocity.velocity,
           getToolBinder: () => this.layerGroupViewer.toolBinder,
+          showOnlyMaxBounds: true,
         },
       ),
     );

--- a/src/ui/layer_bar.ts
+++ b/src/ui/layer_bar.ts
@@ -216,6 +216,7 @@ export class LayerBar extends RefCounted {
     public layerGroupViewer: LayerGroupViewer,
     public getLayoutSpecForDrag: () => any,
     public showLayerHoverValues: WatchableValueInterface<boolean>,
+    public showAllPlotBounds?: WatchableValueInterface<boolean>,
   ) {
     super();
     this.positionWidget = this.registerDisposer(
@@ -225,6 +226,7 @@ export class LayerBar extends RefCounted {
         {
           velocity: this.viewerNavigationState.velocity.velocity,
           getToolBinder: () => this.layerGroupViewer.toolBinder,
+          showAllPlotBounds: showAllPlotBounds,
         },
       ),
     );

--- a/src/ui/layer_bar.ts
+++ b/src/ui/layer_bar.ts
@@ -118,7 +118,6 @@ class LayerWidget extends RefCounted {
           copyButton: false,
           velocity: layer.localVelocity,
           getToolBinder: () => layer.layer?.toolBinder,
-          showOnlyMaxBounds: true,
         },
       ),
     );
@@ -226,7 +225,6 @@ export class LayerBar extends RefCounted {
         {
           velocity: this.viewerNavigationState.velocity.velocity,
           getToolBinder: () => this.layerGroupViewer.toolBinder,
-          showOnlyMaxBounds: true,
         },
       ),
     );

--- a/src/viewer.ts
+++ b/src/viewer.ts
@@ -420,6 +420,9 @@ export class Viewer extends RefCounted implements ViewerState {
   );
   showAxisLines = new TrackableBoolean(true, true);
   wireFrame = new TrackableBoolean(false, false);
+  showAllDimensionPlotBounds = new TrackableBoolean(
+    defaultViewerOptions.showAllDimensionPlotBounds,
+  );
   enableAdaptiveDownsampling = new TrackableBoolean(true, true);
   showScaleBar = new TrackableBoolean(true, true);
   showPerspectiveSliceViews = new TrackableBoolean(true, true);
@@ -501,7 +504,6 @@ export class Viewer extends RefCounted implements ViewerState {
 
   showLayerDialog: boolean;
   resetStateWhenEmpty: boolean;
-  showAllDimensionPlotBounds: boolean;
 
   get inputEventMap() {
     return this.inputEventBindings.global;
@@ -514,6 +516,7 @@ export class Viewer extends RefCounted implements ViewerState {
     options: Partial<ViewerOptions> = {},
   ) {
     super();
+    this.showAllDimensionPlotBounds = new TrackableBoolean(true);
     this.screenshotHandler = this.registerDisposer(new ScreenshotHandler(this));
     this.screenshotManager = this.registerDisposer(new ScreenshotManager(this));
     const {
@@ -566,8 +569,7 @@ export class Viewer extends RefCounted implements ViewerState {
     setViewerUiConfiguration(uiConfiguration, options);
 
     const optionsWithDefaults = { ...defaultViewerOptions, ...options };
-    const { resetStateWhenEmpty, showLayerDialog, showAllDimensionPlotBounds } =
-      optionsWithDefaults;
+    const { resetStateWhenEmpty, showLayerDialog } = optionsWithDefaults;
 
     for (const key of VIEWER_UI_CONTROL_CONFIG_OPTIONS) {
       this.uiControlVisibility[key] = this.makeUiControlVisibilityState(key);
@@ -580,7 +582,6 @@ export class Viewer extends RefCounted implements ViewerState {
 
     this.showLayerDialog = showLayerDialog;
     this.resetStateWhenEmpty = resetStateWhenEmpty;
-    this.showAllDimensionPlotBounds = showAllDimensionPlotBounds;
 
     this.layerSpecification = new TopLevelLayerListSpecification(
       this.display,
@@ -703,7 +704,7 @@ export class Viewer extends RefCounted implements ViewerState {
         {
           velocity: this.velocity,
           getToolBinder: () => this.toolBinder,
-          showAllBounds: this.showAllDimensionPlotBounds,
+          showAllPlotBounds: this.showAllDimensionPlotBounds,
         },
       ),
     );

--- a/src/viewer.ts
+++ b/src/viewer.ts
@@ -183,6 +183,7 @@ export const VIEWER_UI_CONFIG_OPTIONS = [
   "showTopBar",
   "showUIControls",
   "showPanelBorders",
+  "showAllDimensionPlotBounds",
 ] as const;
 
 export type ViewerUIOptions = {
@@ -230,7 +231,6 @@ const defaultViewerOptions =
     : {
         showLayerDialog: true,
         resetStateWhenEmpty: true,
-        showAllDimensionPlotBounds: false,
       };
 
 class TrackableViewerState extends CompoundTrackable {
@@ -420,9 +420,6 @@ export class Viewer extends RefCounted implements ViewerState {
   );
   showAxisLines = new TrackableBoolean(true, true);
   wireFrame = new TrackableBoolean(false, false);
-  showAllDimensionPlotBounds = new TrackableBoolean(
-    defaultViewerOptions.showAllDimensionPlotBounds,
-  );
   enableAdaptiveDownsampling = new TrackableBoolean(true, true);
   showScaleBar = new TrackableBoolean(true, true);
   showPerspectiveSliceViews = new TrackableBoolean(true, true);
@@ -516,7 +513,6 @@ export class Viewer extends RefCounted implements ViewerState {
     options: Partial<ViewerOptions> = {},
   ) {
     super();
-    this.showAllDimensionPlotBounds = new TrackableBoolean(true);
     this.screenshotHandler = this.registerDisposer(new ScreenshotHandler(this));
     this.screenshotManager = this.registerDisposer(new ScreenshotManager(this));
     const {
@@ -704,7 +700,7 @@ export class Viewer extends RefCounted implements ViewerState {
         {
           velocity: this.velocity,
           getToolBinder: () => this.toolBinder,
-          showAllPlotBounds: this.showAllDimensionPlotBounds,
+          showAllPlotBounds: this.uiConfiguration.showAllDimensionPlotBounds,
         },
       ),
     );

--- a/src/viewer.ts
+++ b/src/viewer.ts
@@ -230,6 +230,7 @@ const defaultViewerOptions =
     : {
         showLayerDialog: true,
         resetStateWhenEmpty: true,
+        showAllDimensionPlotBounds: false,
       };
 
 class TrackableViewerState extends CompoundTrackable {
@@ -500,6 +501,7 @@ export class Viewer extends RefCounted implements ViewerState {
 
   showLayerDialog: boolean;
   resetStateWhenEmpty: boolean;
+  showAllDimensionPlotBounds: boolean;
 
   get inputEventMap() {
     return this.inputEventBindings.global;
@@ -564,7 +566,8 @@ export class Viewer extends RefCounted implements ViewerState {
     setViewerUiConfiguration(uiConfiguration, options);
 
     const optionsWithDefaults = { ...defaultViewerOptions, ...options };
-    const { resetStateWhenEmpty, showLayerDialog } = optionsWithDefaults;
+    const { resetStateWhenEmpty, showLayerDialog, showAllDimensionPlotBounds } =
+      optionsWithDefaults;
 
     for (const key of VIEWER_UI_CONTROL_CONFIG_OPTIONS) {
       this.uiControlVisibility[key] = this.makeUiControlVisibilityState(key);
@@ -577,6 +580,7 @@ export class Viewer extends RefCounted implements ViewerState {
 
     this.showLayerDialog = showLayerDialog;
     this.resetStateWhenEmpty = resetStateWhenEmpty;
+    this.showAllDimensionPlotBounds = showAllDimensionPlotBounds;
 
     this.layerSpecification = new TopLevelLayerListSpecification(
       this.display,
@@ -699,7 +703,7 @@ export class Viewer extends RefCounted implements ViewerState {
         {
           velocity: this.velocity,
           getToolBinder: () => this.toolBinder,
-          showOnlyMaxBounds: true,
+          showAllBounds: this.showAllDimensionPlotBounds,
         },
       ),
     );

--- a/src/viewer.ts
+++ b/src/viewer.ts
@@ -699,6 +699,7 @@ export class Viewer extends RefCounted implements ViewerState {
         {
           velocity: this.velocity,
           getToolBinder: () => this.toolBinder,
+          showOnlyMaxBounds: true,
         },
       ),
     );

--- a/src/widget/position_plot.ts
+++ b/src/widget/position_plot.ts
@@ -164,7 +164,7 @@ export class PositionPlot extends RefCounted {
         canvas.height = this.canvasWidth;
       }
 
-      let normalizedDimensionBounds = getNormalizedDimensionBounds(
+      const normalizedDimensionBounds = getNormalizedDimensionBounds(
         coordinateSpace,
         dimensionIndex,
         canvasHeight,
@@ -182,7 +182,10 @@ export class PositionPlot extends RefCounted {
         // Find the maximal normalized bounds.
         let minLowerBound: number | undefined = undefined;
         let maxUpperBound: number | undefined = undefined;
-        for (const { lower, upper } of normalizedDimensionBounds.normalizedBounds) {
+        for (const {
+          lower,
+          upper,
+        } of normalizedDimensionBounds.normalizedBounds) {
           if (minLowerBound === undefined || lower < minLowerBound) {
             minLowerBound = lower;
           }

--- a/src/widget/position_plot.ts
+++ b/src/widget/position_plot.ts
@@ -25,7 +25,10 @@ import {
   getDisplayLowerUpperBounds,
 } from "#src/coordinate_transform.js";
 import type { Position } from "#src/navigation_state.js";
-import { WatchableValue } from "#src/trackable_value.js";
+import {
+  WatchableValue,
+  WatchableValueInterface,
+} from "#src/trackable_value.js";
 import { animationFrameDebounce } from "#src/util/animation_frame_debounce.js";
 import { filterArrayInplace } from "#src/util/array.js";
 import { RefCounted } from "#src/util/disposable.js";
@@ -106,8 +109,8 @@ export class PositionPlot extends RefCounted {
   constructor(
     public position: Position,
     public dimensionId: DimensionId,
+    private showAllBounds?: WatchableValueInterface<boolean>,
     public orientation: "row" | "column" = "column",
-    private showAllBounds: boolean = false,
   ) {
     super();
     this.tickWidth = orientation === "column" ? 10 : 5;
@@ -178,7 +181,7 @@ export class PositionPlot extends RefCounted {
         this.visible = false;
         return;
       }
-      if (!this.showAllBounds) {
+      if (this.showAllBounds !== undefined && !this.showAllBounds.value) {
         // Find the maximal normalized bounds.
         let minLowerBound: number | undefined = undefined;
         let maxUpperBound: number | undefined = undefined;
@@ -305,6 +308,9 @@ export class PositionPlot extends RefCounted {
       animationFrameDebounce(updateView),
     );
     this.registerDisposer(this.position.changed.add(scheduleUpdateView));
+    if (this.showAllBounds !== undefined) {
+      this.registerDisposer(this.showAllBounds.changed.add(scheduleUpdateView));
+    }
     const getPositionFromMouseEvent = (
       event: MouseEvent,
     ): number | undefined => {

--- a/src/widget/position_plot.ts
+++ b/src/widget/position_plot.ts
@@ -107,6 +107,7 @@ export class PositionPlot extends RefCounted {
     public position: Position,
     public dimensionId: DimensionId,
     public orientation: "row" | "column" = "column",
+    private showOnlyMaxBounds: boolean = false,
   ) {
     super();
     this.tickWidth = orientation === "column" ? 10 : 5;
@@ -163,7 +164,7 @@ export class PositionPlot extends RefCounted {
         canvas.height = this.canvasWidth;
       }
 
-      const normalizedDimensionBounds = getNormalizedDimensionBounds(
+      let normalizedDimensionBounds = getNormalizedDimensionBounds(
         coordinateSpace,
         dimensionIndex,
         canvasHeight,
@@ -176,6 +177,25 @@ export class PositionPlot extends RefCounted {
         this.element.style.display = "none";
         this.visible = false;
         return;
+      }
+      if (this.showOnlyMaxBounds) {
+        // Find the maximal normalized bounds.
+        let minLowerBound: number | undefined = undefined;
+        let maxUpperBound: number | undefined = undefined;
+        for (const { lower, upper } of normalizedDimensionBounds.normalizedBounds) {
+          if (minLowerBound === undefined || lower < minLowerBound) {
+            minLowerBound = lower;
+          }
+          if (maxUpperBound === undefined || upper > maxUpperBound) {
+            maxUpperBound = upper;
+          }
+        }
+        normalizedDimensionBounds.normalizedBounds = [
+          {
+            lower: minLowerBound || 0,
+            upper: maxUpperBound || 0,
+          },
+        ];
       }
       this.element.style.display = "";
       this.visible = true;

--- a/src/widget/position_plot.ts
+++ b/src/widget/position_plot.ts
@@ -181,25 +181,22 @@ export class PositionPlot extends RefCounted {
         this.visible = false;
         return;
       }
-      if (this.showAllBounds !== undefined && !this.showAllBounds.value) {
-        // Find the maximal normalized bounds.
-        let minLowerBound: number | undefined = undefined;
-        let maxUpperBound: number | undefined = undefined;
+      if (this.showAllBounds?.value === false) {
+        let minLowerBound = Infinity;
+        let maxUpperBound = -Infinity;
+
         for (const {
           lower,
           upper,
         } of normalizedDimensionBounds.normalizedBounds) {
-          if (minLowerBound === undefined || lower < minLowerBound) {
-            minLowerBound = lower;
-          }
-          if (maxUpperBound === undefined || upper > maxUpperBound) {
-            maxUpperBound = upper;
-          }
+          if (lower < minLowerBound) minLowerBound = lower;
+          if (upper > maxUpperBound) maxUpperBound = upper;
         }
+
         normalizedDimensionBounds.normalizedBounds = [
           {
-            lower: minLowerBound || 0,
-            upper: maxUpperBound || 0,
+            lower: isFinite(minLowerBound) ? minLowerBound : 0,
+            upper: isFinite(maxUpperBound) ? maxUpperBound : 1,
           },
         ];
       }

--- a/src/widget/position_plot.ts
+++ b/src/widget/position_plot.ts
@@ -107,7 +107,7 @@ export class PositionPlot extends RefCounted {
     public position: Position,
     public dimensionId: DimensionId,
     public orientation: "row" | "column" = "column",
-    private showOnlyMaxBounds: boolean = false,
+    private showAllBounds: boolean = false,
   ) {
     super();
     this.tickWidth = orientation === "column" ? 10 : 5;
@@ -178,7 +178,7 @@ export class PositionPlot extends RefCounted {
         this.visible = false;
         return;
       }
-      if (this.showOnlyMaxBounds) {
+      if (!this.showAllBounds) {
         // Find the maximal normalized bounds.
         let minLowerBound: number | undefined = undefined;
         let maxUpperBound: number | undefined = undefined;

--- a/src/widget/position_widget.ts
+++ b/src/widget/position_widget.ts
@@ -303,6 +303,7 @@ export class PositionWidget extends RefCounted {
   private allowFocus: boolean;
   private showPlayback: boolean;
   private showDropdown: boolean;
+  private showOnlyMaxBounds: boolean;
 
   private dimensionWidgets = new Map<DimensionId, DimensionWidget>();
   private dimensionWidgetList: DimensionWidget[] = [];
@@ -332,7 +333,7 @@ export class PositionWidget extends RefCounted {
     }
 
     const plot = dropdownOwner.registerDisposer(
-      new PositionPlot(this.position, widget.id),
+      new PositionPlot(this.position, widget.id, undefined, this.showOnlyMaxBounds),
     );
     dropdown.appendChild(plot.element);
 
@@ -1040,6 +1041,7 @@ export class PositionWidget extends RefCounted {
       allowFocus = true,
       showPlayback = true,
       showDropdown = true,
+      showOnlyMaxBounds = false,
     }: {
       copyButton?: boolean;
       velocity?: CoordinateSpacePlaybackVelocity;
@@ -1048,6 +1050,7 @@ export class PositionWidget extends RefCounted {
       allowFocus?: boolean;
       showPlayback?: boolean;
       showDropdown?: boolean;
+      showOnlyMaxBounds?: boolean;
     } = {},
   ) {
     super();
@@ -1058,6 +1061,7 @@ export class PositionWidget extends RefCounted {
     this.allowFocus = allowFocus;
     this.showPlayback = showPlayback;
     this.showDropdown = showDropdown;
+    this.showOnlyMaxBounds = showOnlyMaxBounds;
     this.registerDisposer(
       position.coordinateSpace.changed.add(
         this.registerCancellable(
@@ -1452,12 +1456,13 @@ class DimensionTool<Viewer extends object> extends Tool<Viewer> {
         allowFocus: inPalette,
         showPlayback: false,
         showDropdown: false,
+        showOnlyMaxBounds: true,
       },
     );
     positionWidget.element.style.userSelect = "none";
     content.appendChild(activation.registerDisposer(positionWidget).element);
     const plot = activation.registerDisposer(
-      new PositionPlot(viewer.position, this.dimensionId, "row"),
+      new PositionPlot(viewer.position, this.dimensionId, "row", true),
     );
     plot.element.style.flex = "1";
     content.appendChild(plot.element);

--- a/src/widget/position_widget.ts
+++ b/src/widget/position_widget.ts
@@ -33,7 +33,7 @@ import {
   makeCoordinateSpace,
 } from "#src/coordinate_transform.js";
 import type { MouseSelectionState, UserLayer } from "#src/layer/index.js";
-import type { LayerGroupViewer } from "#src/layer_group_viewer.js";
+import { LayerGroupViewer } from "#src/layer_group_viewer.js";
 import type {
   CoordinateSpacePlaybackVelocity,
   Position,

--- a/src/widget/position_widget.ts
+++ b/src/widget/position_widget.ts
@@ -332,7 +332,6 @@ export class PositionWidget extends RefCounted {
       dropdown.appendChild(toolButton);
     }
 
-    console.log("widget", this.showAllPlotBounds);
     const plot = dropdownOwner.registerDisposer(
       new PositionPlot(this.position, widget.id, this.showAllPlotBounds),
     );
@@ -1671,7 +1670,8 @@ export function registerDimensionToolForViewer(contextType: typeof Viewer) {
           coordinateSpaceCombiner:
             viewer.layerSpecification.coordinateSpaceCombiner,
           toolBinder: viewer.toolBinder,
-          showAllDimensionPlotBounds: viewer.showAllDimensionPlotBounds,
+          showAllDimensionPlotBounds:
+            viewer.uiConfiguration.showAllDimensionPlotBounds,
         },
         obj,
       ),

--- a/src/widget/position_widget.ts
+++ b/src/widget/position_widget.ts
@@ -303,7 +303,7 @@ export class PositionWidget extends RefCounted {
   private allowFocus: boolean;
   private showPlayback: boolean;
   private showDropdown: boolean;
-  private showAllBounds: boolean;
+  private showAllPlotBounds: WatchableValueInterface<boolean> | undefined;
 
   private dimensionWidgets = new Map<DimensionId, DimensionWidget>();
   private dimensionWidgetList: DimensionWidget[] = [];
@@ -332,8 +332,9 @@ export class PositionWidget extends RefCounted {
       dropdown.appendChild(toolButton);
     }
 
+    console.log("widget", this.showAllPlotBounds);
     const plot = dropdownOwner.registerDisposer(
-      new PositionPlot(this.position, widget.id, undefined, this.showAllBounds),
+      new PositionPlot(this.position, widget.id, this.showAllPlotBounds),
     );
     dropdown.appendChild(plot.element);
 
@@ -1041,7 +1042,7 @@ export class PositionWidget extends RefCounted {
       allowFocus = true,
       showPlayback = true,
       showDropdown = true,
-      showAllBounds = true,
+      showAllPlotBounds = undefined,
     }: {
       copyButton?: boolean;
       velocity?: CoordinateSpacePlaybackVelocity;
@@ -1050,7 +1051,7 @@ export class PositionWidget extends RefCounted {
       allowFocus?: boolean;
       showPlayback?: boolean;
       showDropdown?: boolean;
-      showAllBounds?: boolean;
+      showAllPlotBounds?: WatchableValueInterface<boolean>;
     } = {},
   ) {
     super();
@@ -1061,7 +1062,7 @@ export class PositionWidget extends RefCounted {
     this.allowFocus = allowFocus;
     this.showPlayback = showPlayback;
     this.showDropdown = showDropdown;
-    this.showAllBounds = showAllBounds;
+    this.showAllPlotBounds = showAllPlotBounds;
     this.registerDisposer(
       position.coordinateSpace.changed.add(
         this.registerCancellable(
@@ -1364,7 +1365,7 @@ interface SupportsDimensionTool<ToolContext extends object = object> {
   velocity: CoordinateSpacePlaybackVelocity;
   coordinateSpaceCombiner: CoordinateSpaceCombiner;
   toolBinder: LocalToolBinder<ToolContext>;
-  showAllBounds: boolean;
+  showAllDimensionPlotBounds: WatchableValueInterface<boolean>;
 }
 
 const TOOL_INPUT_EVENT_MAP = EventActionMap.fromObject({
@@ -1457,7 +1458,7 @@ class DimensionTool<Viewer extends object> extends Tool<Viewer> {
         allowFocus: inPalette,
         showPlayback: false,
         showDropdown: false,
-        showAllBounds: viewer.showAllBounds,
+        showAllPlotBounds: viewer.showAllDimensionPlotBounds,
       },
     );
     positionWidget.element.style.userSelect = "none";
@@ -1466,8 +1467,8 @@ class DimensionTool<Viewer extends object> extends Tool<Viewer> {
       new PositionPlot(
         viewer.position,
         this.dimensionId,
+        viewer.showAllDimensionPlotBounds,
         "row",
-        viewer.showAllBounds,
       ),
     );
     plot.element.style.flex = "1";
@@ -1670,7 +1671,7 @@ export function registerDimensionToolForViewer(contextType: typeof Viewer) {
           coordinateSpaceCombiner:
             viewer.layerSpecification.coordinateSpaceCombiner,
           toolBinder: viewer.toolBinder,
-          showAllBounds: viewer.showAllDimensionPlotBounds,
+          showAllDimensionPlotBounds: viewer.showAllDimensionPlotBounds,
         },
         obj,
       ),
@@ -1691,7 +1692,7 @@ export function registerDimensionToolForUserLayer(
           velocity: layer.localVelocity,
           coordinateSpaceCombiner: layer.localCoordinateSpaceCombiner,
           toolBinder: layer.toolBinder,
-          showAllBounds: true,
+          showAllDimensionPlotBounds: new WatchableValue(true),
         },
         obj,
       ),
@@ -1711,7 +1712,7 @@ export function registerDimensionToolForLayerGroupViewer(
         coordinateSpaceCombiner:
           layerGroupViewer.layerSpecification.root.coordinateSpaceCombiner,
         toolBinder: layerGroupViewer.toolBinder,
-        showAllBounds: true,
+        showAllDimensionPlotBounds: new WatchableValue(true),
       },
       obj,
     ),

--- a/src/widget/position_widget.ts
+++ b/src/widget/position_widget.ts
@@ -303,7 +303,7 @@ export class PositionWidget extends RefCounted {
   private allowFocus: boolean;
   private showPlayback: boolean;
   private showDropdown: boolean;
-  private showOnlyMaxBounds: boolean;
+  private showAllBounds: boolean;
 
   private dimensionWidgets = new Map<DimensionId, DimensionWidget>();
   private dimensionWidgetList: DimensionWidget[] = [];
@@ -333,7 +333,7 @@ export class PositionWidget extends RefCounted {
     }
 
     const plot = dropdownOwner.registerDisposer(
-      new PositionPlot(this.position, widget.id, undefined, this.showOnlyMaxBounds),
+      new PositionPlot(this.position, widget.id, undefined, this.showAllBounds),
     );
     dropdown.appendChild(plot.element);
 
@@ -1041,7 +1041,7 @@ export class PositionWidget extends RefCounted {
       allowFocus = true,
       showPlayback = true,
       showDropdown = true,
-      showOnlyMaxBounds = false,
+      showAllBounds = true,
     }: {
       copyButton?: boolean;
       velocity?: CoordinateSpacePlaybackVelocity;
@@ -1050,7 +1050,7 @@ export class PositionWidget extends RefCounted {
       allowFocus?: boolean;
       showPlayback?: boolean;
       showDropdown?: boolean;
-      showOnlyMaxBounds?: boolean;
+      showAllBounds?: boolean;
     } = {},
   ) {
     super();
@@ -1061,7 +1061,7 @@ export class PositionWidget extends RefCounted {
     this.allowFocus = allowFocus;
     this.showPlayback = showPlayback;
     this.showDropdown = showDropdown;
-    this.showOnlyMaxBounds = showOnlyMaxBounds;
+    this.showAllBounds = showAllBounds;
     this.registerDisposer(
       position.coordinateSpace.changed.add(
         this.registerCancellable(
@@ -1364,6 +1364,7 @@ interface SupportsDimensionTool<ToolContext extends object = object> {
   velocity: CoordinateSpacePlaybackVelocity;
   coordinateSpaceCombiner: CoordinateSpaceCombiner;
   toolBinder: LocalToolBinder<ToolContext>;
+  showAllBounds: boolean;
 }
 
 const TOOL_INPUT_EVENT_MAP = EventActionMap.fromObject({
@@ -1456,13 +1457,13 @@ class DimensionTool<Viewer extends object> extends Tool<Viewer> {
         allowFocus: inPalette,
         showPlayback: false,
         showDropdown: false,
-        showOnlyMaxBounds: true,
+        showAllBounds: viewer.showAllBounds,
       },
     );
     positionWidget.element.style.userSelect = "none";
     content.appendChild(activation.registerDisposer(positionWidget).element);
     const plot = activation.registerDisposer(
-      new PositionPlot(viewer.position, this.dimensionId, "row", true),
+      new PositionPlot(viewer.position, this.dimensionId, "row", viewer.showAllBounds),
     );
     plot.element.style.flex = "1";
     content.appendChild(plot.element);
@@ -1664,6 +1665,7 @@ export function registerDimensionToolForViewer(contextType: typeof Viewer) {
           coordinateSpaceCombiner:
             viewer.layerSpecification.coordinateSpaceCombiner,
           toolBinder: viewer.toolBinder,
+          showAllBounds: viewer.showAllDimensionPlotBounds,
         },
         obj,
       ),
@@ -1684,6 +1686,7 @@ export function registerDimensionToolForUserLayer(
           velocity: layer.localVelocity,
           coordinateSpaceCombiner: layer.localCoordinateSpaceCombiner,
           toolBinder: layer.toolBinder,
+          showAllBounds: true,
         },
         obj,
       ),
@@ -1703,6 +1706,7 @@ export function registerDimensionToolForLayerGroupViewer(
         coordinateSpaceCombiner:
           layerGroupViewer.layerSpecification.root.coordinateSpaceCombiner,
         toolBinder: layerGroupViewer.toolBinder,
+        showAllBounds: true,
       },
       obj,
     ),

--- a/src/widget/position_widget.ts
+++ b/src/widget/position_widget.ts
@@ -33,7 +33,7 @@ import {
   makeCoordinateSpace,
 } from "#src/coordinate_transform.js";
 import type { MouseSelectionState, UserLayer } from "#src/layer/index.js";
-import { LayerGroupViewer } from "#src/layer_group_viewer.js";
+import type { LayerGroupViewer } from "#src/layer_group_viewer.js";
 import type {
   CoordinateSpacePlaybackVelocity,
   Position,
@@ -1463,7 +1463,12 @@ class DimensionTool<Viewer extends object> extends Tool<Viewer> {
     positionWidget.element.style.userSelect = "none";
     content.appendChild(activation.registerDisposer(positionWidget).element);
     const plot = activation.registerDisposer(
-      new PositionPlot(viewer.position, this.dimensionId, "row", viewer.showAllBounds),
+      new PositionPlot(
+        viewer.position,
+        this.dimensionId,
+        "row",
+        viewer.showAllBounds,
+      ),
     );
     plot.element.style.flex = "1";
     content.appendChild(plot.element);


### PR DESCRIPTION
Relates to https://github.com/google/neuroglancer/issues/782. This PR would allow the position plots to only show the min/max bounds of the data optionally, and not all the unique bounds as is the current behaviour.

The proposed solution here is to allow a new watchable value in the `viewer.uiConfiguration` which is called `showAllDimensionPlotBounds`. So you could see only the min/max dimension bounds by calling `viewer.uiConfiguration.showAllDimensionPlotBounds.value = false`. That would look like:
![image](https://github.com/user-attachments/assets/beba0d76-e4b1-48aa-9a2f-fb1d74e7049f)

In contrast to:
![image](https://github.com/user-attachments/assets/a115ceaf-da1b-4bf2-88f4-96b455791428)

The setting should apply to the global viewer position plots, and also to position plots that are made from new layer groups which don't have their position linked to the global position.

I also considered this being in the settings that the user can change, so it would be in the state. But I think it is more in line with other UI change patterns that this is part of the `uiConfiguration`.