### PR TITLE
fix(python): annotation writer uses default values

### DIFF
--- a/python/examples/write_annotations.py
+++ b/python/examples/write_annotations.py
@@ -13,18 +13,112 @@ import numpy as np
 def write_some_annotations(
     output_dir: str, coordinate_space: neuroglancer.CoordinateSpace
 ):
+    # Id and type are required for each property. Everything else is optional.
+    properties = [
+        neuroglancer.AnnotationPropertySpec(
+            id="point_color",
+            description="Color of the annotation",
+            type="rgb",
+            default="#ffff00",
+        ),
+        neuroglancer.AnnotationPropertySpec(
+            id="size",
+            description="Size of the annotation",
+            type="float32",
+            default=14.0,
+        ),
+        neuroglancer.AnnotationPropertySpec(
+            id="p_int8",
+            type="int8",
+            default=10,
+        ),
+        neuroglancer.AnnotationPropertySpec(
+            id="p_uint8",
+            type="uint8",
+        ),
+        neuroglancer.AnnotationPropertySpec(
+            id="rgba_color",
+            type="rgba",
+            default="#00ff00ff",  # default value colors MUST be hex strings
+        ),
+        neuroglancer.AnnotationPropertySpec(
+            id="p_enum1",
+            type="uint16",
+            default=0,
+            enum_values=[0, 1, 2, 3],
+            enum_labels=[
+                "Option 0",
+                "Option 1",
+                "Option 2",
+                "Option 3",
+            ],
+        ),
+        neuroglancer.AnnotationPropertySpec(
+            id="p_fnum32",
+            type="float32",
+            default=0.0,
+            description="A float number property",
+            enum_values=[0.0, 1.5, 2.6, 3.0],
+            enum_labels=[
+                "Zero",
+                "One and a half",
+                "Two point six",
+                "Three",
+            ],
+        ),
+        neuroglancer.AnnotationPropertySpec(
+            id="p_boola",
+            type="uint16",
+            default=1,
+            description="A boolean property",
+            enum_values=[0, 1],
+            enum_labels=["False", "True"],
+        ),
+    ]
+
     writer = neuroglancer.write_annotations.AnnotationWriter(
         coordinate_space=coordinate_space,
         annotation_type="point",
-        properties=[
-            neuroglancer.AnnotationPropertySpec(id="size", type="float32"),
-            neuroglancer.AnnotationPropertySpec(id="cell_type", type="uint16"),
-            neuroglancer.AnnotationPropertySpec(id="point_color", type="rgba"),
-        ],
+        properties=properties,
     )
 
-    writer.add_point([20, 30, 40], size=10, cell_type=16, point_color=(0, 255, 0, 255))
-    writer.add_point([50, 51, 52], size=30, cell_type=16, point_color=(255, 0, 0, 255))
+    # Colors during writing can be int tuples or hex strings.
+    # You can specify as many properties as you like, but the
+    # properties must be defined in the AnnotationPropertySpec above.
+    # Any property not specified will use the default value defined
+    # in the AnnotationPropertySpec.
+    writer.add_point(
+        [20, 30, 40],
+        point_color=(0, 255, 0),
+        size=10,
+        p_int8=1,
+        p_uint8=2,
+        rgba_color=(0, 255, 0, 255),
+        p_enum1=1,
+        p_fnum32=1.5,
+    )
+    writer.add_point(
+        [50, 51, 52],
+        point_color=(255, 0, 0),
+        size=9.5,
+        p_int8=2,
+        p_uint8=3,
+        rgba_color="#ff0000ff",
+        p_enum1=2,
+        p_fnum32=2.6,
+    )
+    writer.add_point(
+        [40, 50, 20],
+        point_color="#0000ff",
+        size=20,
+        p_int8=3,
+        p_uint8=4,
+        rgba_color=(0, 200, 255, 14),
+        p_enum1=3,
+        p_fnum32=3.0,
+        p_boola=0,
+    )
+    writer.add_point([40, 20, 24])
     writer.write(output_dir)
 
 

--- a/python/neuroglancer/write_annotations.py
+++ b/python/neuroglancer/write_annotations.py
@@ -91,6 +91,26 @@ def _get_dtype_for_properties(
     return dtype
 
 
+def _convert_rgb_to_uint8(rgb: str) -> tuple[int, int, int]:
+    """Convert an RGB hex string to a tuple of uint8 values."""
+    if rgb.startswith("#"):
+        rgb = rgb[1:]
+    if len(rgb) != 6:
+        raise ValueError(f"Invalid RGB format: {rgb}")
+    return tuple(int(rgb[i : i + 2], 16) for i in (0, 2, 4))
+
+
+def _convert_rgba_to_uint8(rgba: str) -> tuple[int, int, int, int]:
+    """Convert an RGBA hex string to a tuple of uint8 values."""
+    if rgba.startswith("#"):
+        rgba = rgba[1:]
+    if len(rgba) != 8:
+        raise ValueError(f"Invalid RGBA format: {rgba}")
+    color = _convert_rgb_to_uint8(rgba[:6])
+    alpha = int(rgba[6:8], 16)
+    return (*color, alpha)
+
+
 class AnnotationWriter:
     annotations: list[Annotation]
     related_annotations: list[dict[int, list[Annotation]]]
@@ -189,8 +209,16 @@ class AnnotationWriter:
         encoded[()]["geometry"] = coords  # type: ignore[call-overload]
 
         for i, p in enumerate(self.properties):
+            default_value = p.default
             if p.id in kwargs:
-                encoded[()][f"property{i}"] = kwargs.pop(p.id)  # type: ignore[call-overload]
+                default_value = kwargs.pop(p.id)
+            if isinstance(default_value, str) and p.type in ("rgb", "rgba"):
+                if p.type == "rgb":
+                    default_value = _convert_rgb_to_uint8(default_value)
+                else:
+                    default_value = _convert_rgba_to_uint8(default_value)
+            if default_value is not None:
+                encoded[()][f"property{i}"] = default_value  # type: ignore[call-overload]
 
         related_ids = []
         for relationship in self.relationships:

--- a/python/neuroglancer/write_annotations.py
+++ b/python/neuroglancer/write_annotations.py
@@ -97,7 +97,7 @@ def _convert_rgb_to_uint8(rgb: str) -> tuple[int, int, int]:
         rgb = rgb[1:]
     if len(rgb) != 6:
         raise ValueError(f"Invalid RGB format: {rgb}")
-    return tuple(int(rgb[i : i + 2], 16) for i in (0, 2, 4))
+    return (int(rgb[0:2], 16), int(rgb[2:4], 16), int(rgb[4:6], 16))
 
 
 def _convert_rgba_to_uint8(rgba: str) -> tuple[int, int, int, int]:


### PR DESCRIPTION
You could specify the defaults in the property spec but then from what I can see they didn't inform the property values when using the writer.

Here, the idea is that the defaults are the starting point for the values, and if the user specifies a new value when adding an object that property is overridden.

One thing that was a little awkward was that you had to specify the default of a color type in the spec as a string, but then when you used that property (such as in `add_point`) you had to provide a tuple of uint8s. This was a bit confusing, so now you can pass hex strings when using `add_point` or similar. You still have to define the default value as a hex string though.

Also updates the writer example to show more properties being written.