### PR TITLE
fix(python): Add swapVisibleSegmentsOnMove parameter to AnnotationLayer in neuroglancer-python

### DIFF
--- a/python/neuroglancer/viewer_state.py
+++ b/python/neuroglancer/viewer_state.py
@@ -1164,6 +1164,9 @@ class AnnotationLayer(Layer, _AnnotationLayerOptions):
     shader_controls = shaderControls = wrapped_property(
         "shaderControls", ShaderControls
     )
+    swap_visible_segments_on_move = swapVisbleSegmentsOnMove = wrapped_property(
+        "swapVisibleSegmentsOnMove", optional(bool, True)
+    )
 
     @staticmethod
     def interpolate(a, b, t):

--- a/python/neuroglancer/viewer_state.py
+++ b/python/neuroglancer/viewer_state.py
@@ -1164,7 +1164,7 @@ class AnnotationLayer(Layer, _AnnotationLayerOptions):
     shader_controls = shaderControls = wrapped_property(
         "shaderControls", ShaderControls
     )
-    swap_visible_segments_on_move = swapVisbleSegmentsOnMove = wrapped_property(
+    swap_visible_segments_on_move = swapVisibleSegmentsOnMove = wrapped_property(
         "swapVisibleSegmentsOnMove", optional(bool, True)
     )
 


### PR DESCRIPTION
The parameter `swap_visible_segments_on_move` is part of an annotation layer's state, but was not added as an argument for the AnnotationLayer python class. This change simply adds this parameter.