### PR TITLE
fix(ui): correct tool palette checkbox enable disable title

### DIFF
--- a/src/trackable_boolean.ts
+++ b/src/trackable_boolean.ts
@@ -57,13 +57,18 @@ export class TrackableBoolean implements Trackable {
   }
 }
 
+/**
+ * @param model: A watchable value that is used to track the checkbox state.
+ * @param options.enabledTitle: Optional title to show when the checkbox is checked.
+ * @param options.disabledTitle: Optional title to show when the checkbox is unchecked.
+ */
 export class TrackableBooleanCheckbox extends RefCounted {
   element = document.createElement("input");
   constructor(
     public model: WatchableValueInterface<boolean>,
     options: {
-      enableTitle?: string;
-      disableTitle?: string;
+      enabledTitle?: string;
+      disabledTitle?: string;
     } = {},
   ) {
     super();
@@ -74,11 +79,11 @@ export class TrackableBooleanCheckbox extends RefCounted {
       const value = this.model.value;
       this.element.checked = value;
       if (
-        options.enableTitle !== undefined ||
-        options.disableTitle !== undefined
+        options.enabledTitle !== undefined ||
+        options.disabledTitle !== undefined
       ) {
         this.element.title =
-          (value ? options.enableTitle : options.disableTitle) ?? "";
+          (value ? options.enabledTitle : options.disabledTitle) ?? "";
       }
     };
 

--- a/src/ui/layer_list_panel.ts
+++ b/src/ui/layer_list_panel.ts
@@ -163,7 +163,8 @@ class LayerListItem extends RefCounted {
             changed: layer.layerChanged,
           },
           {
-            enabledTitle: "Archive layer (disable and remove from layer groups)",
+            enabledTitle:
+              "Archive layer (disable and remove from layer groups)",
             disabledTitle:
               "Unarchive layer (enable and add to all layer groups)",
           },

--- a/src/ui/layer_list_panel.ts
+++ b/src/ui/layer_list_panel.ts
@@ -163,8 +163,8 @@ class LayerListItem extends RefCounted {
             changed: layer.layerChanged,
           },
           {
-            enableTitle: "Archive layer (disable and remove from layer groups)",
-            disableTitle:
+            enabledTitle: "Archive layer (disable and remove from layer groups)",
+            disabledTitle:
               "Unarchive layer (enable and add to all layer groups)",
           },
         ),

--- a/src/ui/tool_palette.ts
+++ b/src/ui/tool_palette.ts
@@ -1124,8 +1124,8 @@ export class PaletteListDropdownItem extends RefCounted {
     element.appendChild(
       this.registerDisposer(
         new TrackableBooleanCheckbox(state.location.watchableVisible, {
-          enableTitle: "Show tool palette",
-          disableTitle: "Hide tool palette",
+          enabledTitle: "Hide tool palette",
+          disabledTitle: "Show tool palette",
         }),
       ).element,
     );


### PR DESCRIPTION
Also clarify intended behaviour of message. Current was probably mixed up because `enableTitle` could reasonably be interpreted as the title when enabled or the message shown to indicate how to enable