### PR TITLE
fix: allow tool palette dim tool to set playback velocity

### DIFF
--- a/src/widget/position_widget.ts
+++ b/src/widget/position_widget.ts
@@ -1516,7 +1516,6 @@ class DimensionTool<Viewer extends object> extends Tool<Viewer> {
           const velocityInputWidget = context.registerDisposer(
             new NumberInputWidget(velocityModel),
           );
-          velocityInputWidget.inputElement.disabled = true;
           velocityInputWidget.element.insertBefore(
             negateButton,
             velocityInputWidget.element.firstChild,


### PR DESCRIPTION
Previously the tool palette dimension playback velocity input was disabled
<img width="384" height="262" alt="image" src="https://github.com/user-attachments/assets/c5ecf835-0469-43aa-9a54-26593f1fb811" />

I guess this was because the tool which shows on keybind intended to have that input disabled, but I think it's not really possible to change it there anyway from the input