### PR TITLE
feat(skeleton): display available shader properties above the skeleton shader editor to match annotation layer behavior

### DIFF
--- a/src/layer/annotation/index.ts
+++ b/src/layer/annotation/index.ts
@@ -753,6 +753,40 @@ class ShaderCodeOverlay extends Overlay {
   }
 }
 
+type ShaderPropertyListMetadata = {
+  type: string;
+  identifier: string;
+  description?: string;
+};
+
+export const buildShaderPropertyList = (
+  properties: readonly Readonly<ShaderPropertyListMetadata>[],
+  parent: HTMLElement,
+) => {
+  const propertyList = document.createElement("div");
+  parent.appendChild(propertyList);
+  propertyList.classList.add("neuroglancer-annotation-shader-property-list");
+  for (const property of properties) {
+    const div = document.createElement("div");
+    div.classList.add("neuroglancer-annotation-shader-property");
+    const typeElement = document.createElement("span");
+    typeElement.classList.add("neuroglancer-annotation-shader-property-type");
+    typeElement.textContent = property.type;
+    const nameElement = document.createElement("span");
+    nameElement.classList.add(
+      "neuroglancer-annotation-shader-property-identifier",
+    );
+    nameElement.textContent = `prop_${property.identifier}`;
+    div.appendChild(typeElement);
+    div.appendChild(nameElement);
+    const { description } = property;
+    if (description !== undefined) {
+      div.title = description;
+    }
+    propertyList.appendChild(div);
+  }
+};
+
 class RenderingOptionsTab extends Tab {
   codeWidget: ShaderCodeWidget;
   constructor(public layer: AnnotationUserLayer) {
@@ -765,32 +799,7 @@ class RenderingOptionsTab extends Tab {
         layer.annotationDisplayState.annotationProperties,
         (properties, parent) => {
           if (properties === undefined || properties.length === 0) return;
-          const propertyList = document.createElement("div");
-          parent.appendChild(propertyList);
-          propertyList.classList.add(
-            "neuroglancer-annotation-shader-property-list",
-          );
-          for (const property of properties) {
-            const div = document.createElement("div");
-            div.classList.add("neuroglancer-annotation-shader-property");
-            const typeElement = document.createElement("span");
-            typeElement.classList.add(
-              "neuroglancer-annotation-shader-property-type",
-            );
-            typeElement.textContent = property.type;
-            const nameElement = document.createElement("span");
-            nameElement.classList.add(
-              "neuroglancer-annotation-shader-property-identifier",
-            );
-            nameElement.textContent = `prop_${property.identifier}`;
-            div.appendChild(typeElement);
-            div.appendChild(nameElement);
-            const { description } = property;
-            if (description !== undefined) {
-              div.title = description;
-            }
-            propertyList.appendChild(div);
-          }
+          buildShaderPropertyList(properties, parent);
         },
       ),
     ).element;

--- a/src/layer/segmentation/index.ts
+++ b/src/layer/segmentation/index.ts
@@ -741,6 +741,15 @@ export class SegmentationUserLayer extends Base {
     ),
   );
 
+  readonly getSkeletonLayer = () => {
+    for (const layer of this.renderLayers) {
+      if (layer instanceof PerspectiveViewSkeletonLayer) {
+        return layer.base;
+      }
+    }
+    return undefined;
+  };
+
   activateDataSubsources(subsources: Iterable<LoadedDataSubsource>) {
     const updatedSegmentPropertyMaps: SegmentPropertyMap[] = [];
     const isGroupRoot =

--- a/src/skeleton/frontend.ts
+++ b/src/skeleton/frontend.ts
@@ -194,6 +194,9 @@ void emitDefault() {
             builder.addVarying(`highp ${info.glslDataType}`, `vCustom${i}`);
             vertexMain += `vCustom${i} = readAttribute${i}(vertexIndex);\n`;
             builder.addFragmentCode(`#define ${info.name} vCustom${i}\n`);
+            builder.addFragmentCode(
+              `#define prop_${info.name}() vCustom${i}\n`,
+            );
           }
           builder.setVertexMain(vertexMain);
           addControlsToBuilder(shaderBuilderState, builder);
@@ -260,6 +263,9 @@ void emitDefault() {
             builder.addVarying(`highp ${info.glslDataType}`, `vCustom${i}`);
             vertexMain += `vCustom${i} = readAttribute${i}(vertexIndex);\n`;
             builder.addFragmentCode(`#define ${info.name} vCustom${i}\n`);
+            builder.addFragmentCode(
+              `#define prop_${info.name}() vCustom${i}\n`,
+            );
           }
           builder.setVertexMain(vertexMain);
           addControlsToBuilder(shaderBuilderState, builder);

--- a/src/ui/segmentation_display_options_tab.ts
+++ b/src/ui/segmentation_display_options_tab.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import { buildShaderPropertyList } from "#src/layer/annotation/index.js";
 import type { SegmentationUserLayer } from "#src/layer/segmentation/index.js";
 import { SKELETON_RENDERING_SHADER_CONTROL_TOOL_ID } from "#src/layer/segmentation/json_keys.js";
 import { LAYER_CONTROLS } from "#src/layer/segmentation/layer_controls.js";
@@ -74,6 +75,18 @@ export class DisplayOptionsTab extends Tab {
         layer.hasSkeletonsLayer,
         (hasSkeletonsLayer, parent, refCounted) => {
           if (!hasSkeletonsLayer) return;
+          const skeletonLayer = layer.getSkeletonLayer()!;
+          if (skeletonLayer.vertexAttributes.length > 1) {
+            buildShaderPropertyList(
+              skeletonLayer.vertexAttributes.slice(1).map((x) => {
+                return {
+                  type: x.glslDataType,
+                  identifier: x.name,
+                };
+              }),
+              parent,
+            );
+          }
           const codeWidget = refCounted.registerDisposer(
             makeSkeletonShaderCodeWidget(this.layer),
           );


### PR DESCRIPTION
Also made the properties available in the shader via `prop_{identifier}()` to match annotation layer behavior

<img width="395" height="166" alt="Screenshot 2025-07-30 at 1 56 56 PM" src="https://github.com/user-attachments/assets/87369c56-dbb9-45df-bdda-c0a4c272f4dc" />
