### PR TITLE
fix(skeleton): read/expose the correct custom attribute associated with each vertex

### DIFF
--- a/src/skeleton/frontend.ts
+++ b/src/skeleton/frontend.ts
@@ -172,7 +172,7 @@ highp vec3 vertexA = readAttribute0(aVertexIndex.x);
 highp vec3 vertexB = readAttribute0(aVertexIndex.y);
 emitLine(uProjection, vertexA, vertexB, uLineWidth);
 highp uint lineEndpointIndex = getLineEndpointIndex();
-highp uint vertexIndex = aVertexIndex.x * lineEndpointIndex + aVertexIndex.y * (1u - lineEndpointIndex);
+highp uint vertexIndex = aVertexIndex.x * (1u - lineEndpointIndex) + aVertexIndex.y * lineEndpointIndex;
 `;
 
           builder.addFragmentCode(`


### PR DESCRIPTION
Previously, the shader read the attribute for the opposing vertex of each line segment.

I noticed with https://github.com/google/neuroglancer/pull/820 that the lines were getting drawn with inverse of the expected width change. It seems pretty clear to me now that this is the correct calculation.

getLineEndpointIndex returns 0 for vertexA (aVertexIndex.x) and 1 for vertexB (aVertexIndex.y) so to use vertexA we need 1 - getLineEndpointIndex and getLineEndpointIndex for vertexB.