### PR TITLE
feat: ctrl+right click always pins the new selection instead of toggling the pinned state

### DIFF
--- a/src/layer/index.ts
+++ b/src/layer/index.ts
@@ -1432,10 +1432,8 @@ export class TrackableDataSelectionState
   select() {
     const { pin } = this;
     this.location.visible = true;
-    pin.value = !pin.value;
-    if (pin.value) {
-      this.capture();
-    }
+    pin.value = true;
+    this.capture();
   }
   capture(canRetain = false) {
     const newValue = capturePersistentViewerSelectionState(


### PR DESCRIPTION
See https://github.com/google/neuroglancer/issues/814 I think this enables the intended behaviour there if I'm understanding correctly. I've also been a little confused in the past when trying to pin a new segment but actually just unpinning my current segment. It does mean you have to manually unpin now from what I can tell though. Anyway open to thoughts from @unidesigner @jbms 