### PR TITLE
annotation properties: int8 serializedBytes should be 1

### DIFF
--- a/src/annotation/index.ts
+++ b/src/annotation/index.ts
@@ -310,7 +310,7 @@ export const annotationPropertyTypeHandlers: {
   },
   int8: {
     serializedBytes() {
-      return 2;
+      return 1;
     },
     alignment() {
       return 1;


### PR DESCRIPTION
I have some precomputed annotations with a few `int8` properties that neuroglancer refuses to load.  In my javascript console I see the following error:

```
Error retrieving chunk [object Object]:0,0,0: Error: Expected 3968336 bytes, but received: 3401432 bytes
```

As far as I can tell, I think the number of bytes I wrote is correct; I don't understand the "expected" number in that message.

After a little digging, I think the issue stems from the [following line of code][1] in neuroglancer:

[1]: https://github.com/google/neuroglancer/blob/master/src/annotation/index.ts#L311-L314

```typescript
  int8: {
    serializedBytes() {
      return 2;
    },
```

Why does `serializedBytes()` return `2` for `int8`?

Assuming that's a bug, then here's a PR with the fix.
