### PR TITLE
making showLayerPanel toggleable in the layerPanel

### DIFF
--- a/src/layer_groups_layout.ts
+++ b/src/layer_groups_layout.ts
@@ -446,7 +446,7 @@ export class SingletonLayerGroupViewer
           ...getCommonViewerState(viewer),
         },
         {
-          showLayerPanel: viewer.uiControlVisibility.showLayerPanel,
+          showLayerPanel: viewer.effectiveShowLayerPanel,
           showViewerMenu: false,
           showLayerHoverValues: viewer.uiControlVisibility.showLayerHoverValues,
         },
@@ -763,7 +763,7 @@ function makeComponent(container: LayoutComponentContainer, spec: any) {
           ...getCommonViewerState(viewer),
         },
         {
-          showLayerPanel: viewer.uiControlVisibility.showLayerPanel,
+          showLayerPanel: viewer.effectiveShowLayerPanel,
           showViewerMenu: true,
           showLayerHoverValues: viewer.uiControlVisibility.showLayerHoverValues,
           showAllPlotBounds: viewer.uiConfiguration.showAllDimensionPlotBounds,

--- a/src/ui/layer_list_panel.ts
+++ b/src/ui/layer_list_panel.ts
@@ -359,7 +359,7 @@ export class LayerListPanel extends SidePanel {
       toggleButton.element.style.order = "50"; // Position before close button (order: 100)
       titleBar.appendChild(toggleButton.element);
       this.registerDisposer(toggleButton);
-      
+
       // Watch for showLayerPanel configuration changes and hide/show button accordingly
       this.registerDisposer(
         this.showLayerPanel.changed.add(() => {

--- a/src/ui/layer_list_panel.ts
+++ b/src/ui/layer_list_panel.ts
@@ -24,6 +24,7 @@ import type {
   TopLevelLayerListSpecification,
 } from "#src/layer/index.js";
 import { deleteLayer } from "#src/layer/index.js";
+import type { TrackableBoolean } from "#src/trackable_boolean.js";
 import { TrackableBooleanCheckbox } from "#src/trackable_boolean.js";
 import type { DropLayers } from "#src/ui/layer_drag_and_drop.js";
 import {
@@ -338,7 +339,7 @@ export class LayerListPanel extends SidePanel {
     sidePanelManager: SidePanelManager,
     public manager: TopLevelLayerListSpecification,
     public state: LayerListPanelState,
-    public showLayerPanel?: import("#src/trackable_boolean.js").TrackableBoolean,
+    public showLayerPanel?: TrackableBoolean,
   ) {
     super(sidePanelManager, state.location);
     const { itemContainer, layerDropZone } = this;

--- a/src/ui/layer_list_panel.ts
+++ b/src/ui/layer_list_panel.ts
@@ -363,18 +363,9 @@ export class LayerListPanel extends SidePanel {
       // Watch for showLayerPanel configuration changes and hide/show button accordingly
       this.registerDisposer(
         this.showLayerPanel.changed.add(() => {
-          if (this.showLayerPanel!.value) {
-            // Configuration enabled - show button
-            if (!toggleButton.element.parentElement) {
-              titleBar.appendChild(toggleButton.element);
-            }
-          } else {
-            // Configuration disabled - hide button
-            if (toggleButton.element.parentElement) {
-              toggleButton.element.remove();
-            }
-          }
-        }),
+          toggleButton.element.style.display = this.showLayerPanel!.value
+            ? ""
+            : "none";
       );
     }
     itemContainer.classList.add("neuroglancer-layer-list-panel-items");

--- a/src/ui/layer_list_panel.ts
+++ b/src/ui/layer_list_panel.ts
@@ -339,6 +339,7 @@ export class LayerListPanel extends SidePanel {
     sidePanelManager: SidePanelManager,
     public manager: TopLevelLayerListSpecification,
     public state: LayerListPanelState,
+    public hideLayerPanel: TrackableBoolean,
     public showLayerPanel?: TrackableBoolean,
   ) {
     super(sidePanelManager, state.location);
@@ -347,8 +348,9 @@ export class LayerListPanel extends SidePanel {
     this.titleElement = titleElement!;
 
     // Add layer panel toggle button to title bar
-    if (this.showLayerPanel) {
-      const toggleButton = new CheckboxIcon(this.showLayerPanel, {
+    // Only show toggle button when showLayerPanel configuration is enabled
+    if (this.showLayerPanel?.value) {
+      const toggleButton = new CheckboxIcon(this.hideLayerPanel, {
         svg: svg_eye,
         backgroundScheme: "dark",
         enableTitle: "Hide layer panel",
@@ -357,6 +359,23 @@ export class LayerListPanel extends SidePanel {
       toggleButton.element.style.order = "50"; // Position before close button (order: 100)
       titleBar.appendChild(toggleButton.element);
       this.registerDisposer(toggleButton);
+      
+      // Watch for showLayerPanel configuration changes and hide/show button accordingly
+      this.registerDisposer(
+        this.showLayerPanel.changed.add(() => {
+          if (this.showLayerPanel!.value) {
+            // Configuration enabled - show button
+            if (!toggleButton.element.parentElement) {
+              titleBar.appendChild(toggleButton.element);
+            }
+          } else {
+            // Configuration disabled - hide button
+            if (toggleButton.element.parentElement) {
+              toggleButton.element.remove();
+            }
+          }
+        }),
+      );
     }
     itemContainer.classList.add("neuroglancer-layer-list-panel-items");
     this.addBody(itemContainer);

--- a/src/ui/layer_list_panel.ts
+++ b/src/ui/layer_list_panel.ts
@@ -344,18 +344,15 @@ export class LayerListPanel extends SidePanel {
     const { itemContainer, layerDropZone } = this;
     const { titleElement, titleBar } = this.addTitleBar({ title: "" });
     this.titleElement = titleElement!;
-    
+
     // Add layer panel toggle button to title bar
     if (this.showLayerPanel) {
-      const toggleButton = new CheckboxIcon(
-        this.showLayerPanel,
-        {
-          svg: svg_eye,
-          backgroundScheme: "dark",
-          enableTitle: "Hide layer panel",
-          disableTitle: "Show layer panel",
-        },
-      );
+      const toggleButton = new CheckboxIcon(this.showLayerPanel, {
+        svg: svg_eye,
+        backgroundScheme: "dark",
+        enableTitle: "Hide layer panel",
+        disableTitle: "Show layer panel",
+      });
       toggleButton.element.style.order = "50"; // Position before close button (order: 100)
       titleBar.appendChild(toggleButton.element);
       this.registerDisposer(toggleButton);

--- a/src/ui/layer_list_panel.ts
+++ b/src/ui/layer_list_panel.ts
@@ -366,6 +366,7 @@ export class LayerListPanel extends SidePanel {
           toggleButton.element.style.display = this.showLayerPanel!.value
             ? ""
             : "none";
+        }),
       );
     }
     itemContainer.classList.add("neuroglancer-layer-list-panel-items");

--- a/src/ui/layer_list_panel.ts
+++ b/src/ui/layer_list_panel.ts
@@ -338,11 +338,28 @@ export class LayerListPanel extends SidePanel {
     sidePanelManager: SidePanelManager,
     public manager: TopLevelLayerListSpecification,
     public state: LayerListPanelState,
+    public showLayerPanel?: import("#src/trackable_boolean.js").TrackableBoolean,
   ) {
     super(sidePanelManager, state.location);
     const { itemContainer, layerDropZone } = this;
-    const { titleElement } = this.addTitleBar({ title: "" });
+    const { titleElement, titleBar } = this.addTitleBar({ title: "" });
     this.titleElement = titleElement!;
+    
+    // Add layer panel toggle button to title bar
+    if (this.showLayerPanel) {
+      const toggleButton = new CheckboxIcon(
+        this.showLayerPanel,
+        {
+          svg: svg_eye,
+          backgroundScheme: "dark",
+          enableTitle: "Hide layer panel",
+          disableTitle: "Show layer panel",
+        },
+      );
+      toggleButton.element.style.order = "50"; // Position before close button (order: 100)
+      titleBar.appendChild(toggleButton.element);
+      this.registerDisposer(toggleButton);
+    }
     itemContainer.classList.add("neuroglancer-layer-list-panel-items");
     this.addBody(itemContainer);
     layerDropZone.style.flex = "1";

--- a/src/ui/layer_list_panel.ts
+++ b/src/ui/layer_list_panel.ts
@@ -24,7 +24,6 @@ import type {
   TopLevelLayerListSpecification,
 } from "#src/layer/index.js";
 import { deleteLayer } from "#src/layer/index.js";
-import type { TrackableBoolean } from "#src/trackable_boolean.js";
 import { TrackableBooleanCheckbox } from "#src/trackable_boolean.js";
 import type { WatchableValueInterface } from "#src/trackable_value.js";
 import type { DropLayers } from "#src/ui/layer_drag_and_drop.js";
@@ -341,7 +340,7 @@ export class LayerListPanel extends SidePanel {
     public manager: TopLevelLayerListSpecification,
     public state: LayerListPanelState,
     public layerPanelVisibility: WatchableValueInterface<boolean>,
-    public showLayerPanel?: TrackableBoolean,
+    public showLayerPanel?: WatchableValueInterface<boolean>,
   ) {
     super(sidePanelManager, state.location);
     const { itemContainer, layerDropZone } = this;

--- a/src/ui/layer_list_panel.ts
+++ b/src/ui/layer_list_panel.ts
@@ -26,6 +26,7 @@ import type {
 import { deleteLayer } from "#src/layer/index.js";
 import type { TrackableBoolean } from "#src/trackable_boolean.js";
 import { TrackableBooleanCheckbox } from "#src/trackable_boolean.js";
+import type { WatchableValueInterface } from "#src/trackable_value.js";
 import type { DropLayers } from "#src/ui/layer_drag_and_drop.js";
 import {
   registerLayerBarDragLeaveHandler,
@@ -339,7 +340,7 @@ export class LayerListPanel extends SidePanel {
     sidePanelManager: SidePanelManager,
     public manager: TopLevelLayerListSpecification,
     public state: LayerListPanelState,
-    public hideLayerPanel: TrackableBoolean,
+    public layerPanelVisibility: WatchableValueInterface<boolean>,
     public showLayerPanel?: TrackableBoolean,
   ) {
     super(sidePanelManager, state.location);
@@ -347,27 +348,25 @@ export class LayerListPanel extends SidePanel {
     const { titleElement, titleBar } = this.addTitleBar({ title: "" });
     this.titleElement = titleElement!;
 
-    // Add layer panel toggle button to title bar
-    // Only show toggle button when showLayerPanel configuration is enabled
-    if (this.showLayerPanel?.value) {
-      const toggleButton = new CheckboxIcon(this.hideLayerPanel, {
+    // Add layer panel toggle button to title bar.
+    if (showLayerPanel !== undefined) {
+      const toggleButton = new CheckboxIcon(this.layerPanelVisibility, {
         svg: svg_eye,
         backgroundScheme: "dark",
-        enableTitle: "Hide layer panel",
-        disableTitle: "Show layer panel",
+        enableTitle: "Show layer panel",
+        disableTitle: "Hide layer panel",
       });
       toggleButton.element.style.order = "50"; // Position before close button (order: 100)
       titleBar.appendChild(toggleButton.element);
       this.registerDisposer(toggleButton);
 
-      // Watch for showLayerPanel configuration changes and hide/show button accordingly
-      this.registerDisposer(
-        this.showLayerPanel.changed.add(() => {
-          toggleButton.element.style.display = this.showLayerPanel!.value
-            ? ""
-            : "none";
-        }),
-      );
+      // The toggle is only meaningful while the configuration permits the
+      // panel, so track the configuration rather than sampling it once.
+      const updateToggleVisibility = () => {
+        toggleButton.element.style.display = showLayerPanel.value ? "" : "none";
+      };
+      this.registerDisposer(showLayerPanel.changed.add(updateToggleVisibility));
+      updateToggleVisibility();
     }
     itemContainer.classList.add("neuroglancer-layer-list-panel-items");
     this.addBody(itemContainer);

--- a/src/viewer.ts
+++ b/src/viewer.ts
@@ -581,7 +581,7 @@ export class Viewer extends RefCounted implements ViewerState {
 
     this.dataSourceProvider = dataSourceProvider;
     this.uiConfiguration = uiConfiguration;
-    
+
     // Create effective showLayerPanel state that combines configuration and user preference
     this.effectiveShowLayerPanel = this.registerDisposer(
       makeDerivedWatchableValue(
@@ -591,9 +591,8 @@ export class Viewer extends RefCounted implements ViewerState {
         },
         this.uiConfiguration.showLayerPanel,
         this.hideLayerPanelState,
-      )
+      ),
     );
-    
 
     this.registerDisposer(
       observeWatchable((value) => {

--- a/src/viewer.ts
+++ b/src/viewer.ts
@@ -304,6 +304,7 @@ class TrackableViewerState extends CompoundTrackable {
     this.add("selectedStateServer", viewer.selectedStateServer);
     this.add("toolBindings", viewer.toolBinder);
     this.add("toolPalettes", viewer.toolPalettes);
+    this.add("hideLayerPanel", viewer.hideLayerPanelState);
 
     // Add UI configuration to state for persistence
     for (const key of VIEWER_UI_CONFIG_OPTIONS) {
@@ -459,6 +460,7 @@ export class Viewer extends RefCounted implements ViewerState {
   partialViewport = new TrackableWindowedViewport();
   statisticsDisplayState = new StatisticsDisplayState();
   helpPanelState = new HelpPanelState();
+  hideLayerPanelState = new TrackableBoolean(false, false);
   settingsPanelState = new ViewerSettingsPanelState();
   layerSelectedValues = this.registerDisposer(
     new LayerSelectedValues(this.layerManager, this.mouseState),

--- a/src/viewer.ts
+++ b/src/viewer.ts
@@ -307,9 +307,9 @@ class TrackableViewerState extends CompoundTrackable {
     this.add("hideLayerPanel", viewer.hideLayerPanelState);
 
     // Add UI configuration to state for persistence
-    for (const key of VIEWER_UI_CONFIG_OPTIONS) {
-      this.add(key, viewer.uiConfiguration[key]);
-    }
+    // for (const key of VIEWER_UI_CONFIG_OPTIONS) {
+    //   this.add(key, viewer.uiConfiguration[key]);
+    // }
   }
 
   restoreState(obj: any) {
@@ -499,6 +499,7 @@ export class Viewer extends RefCounted implements ViewerState {
   dataSourceProvider: Borrowed<DataSourceRegistry>;
 
   uiConfiguration: ViewerUIConfiguration;
+  effectiveShowLayerPanel: WatchableValueInterface<boolean>;
 
   private makeUiControlVisibilityState(
     key: (typeof VIEWER_UI_CONTROL_CONFIG_OPTIONS)[number],
@@ -580,6 +581,19 @@ export class Viewer extends RefCounted implements ViewerState {
 
     this.dataSourceProvider = dataSourceProvider;
     this.uiConfiguration = uiConfiguration;
+    
+    // Create effective showLayerPanel state that combines configuration and user preference
+    this.effectiveShowLayerPanel = this.registerDisposer(
+      makeDerivedWatchableValue(
+        (configEnabled: boolean, hideState: boolean) => {
+          // Layer panel is shown when config allows it AND hide state is false
+          return configEnabled && !hideState;
+        },
+        this.uiConfiguration.showLayerPanel,
+        this.hideLayerPanelState,
+      )
+    );
+    
 
     this.registerDisposer(
       observeWatchable((value) => {
@@ -993,6 +1007,7 @@ export class Viewer extends RefCounted implements ViewerState {
             this.sidePanelManager,
             this.layerSpecification,
             this.layerListPanelState,
+            this.hideLayerPanelState,
             this.uiConfiguration.showLayerPanel,
           ),
       }),

--- a/src/viewer.ts
+++ b/src/viewer.ts
@@ -304,6 +304,11 @@ class TrackableViewerState extends CompoundTrackable {
     this.add("selectedStateServer", viewer.selectedStateServer);
     this.add("toolBindings", viewer.toolBinder);
     this.add("toolPalettes", viewer.toolPalettes);
+    
+    // Add UI configuration to state for persistence
+    for (const key of VIEWER_UI_CONFIG_OPTIONS) {
+      this.add(key, viewer.uiConfiguration[key]);
+    }
   }
 
   restoreState(obj: any) {
@@ -986,6 +991,7 @@ export class Viewer extends RefCounted implements ViewerState {
             this.sidePanelManager,
             this.layerSpecification,
             this.layerListPanelState,
+            this.uiConfiguration.showLayerPanel,
           ),
       }),
     );

--- a/src/viewer.ts
+++ b/src/viewer.ts
@@ -304,7 +304,7 @@ class TrackableViewerState extends CompoundTrackable {
     this.add("selectedStateServer", viewer.selectedStateServer);
     this.add("toolBindings", viewer.toolBinder);
     this.add("toolPalettes", viewer.toolPalettes);
-    
+
     // Add UI configuration to state for persistence
     for (const key of VIEWER_UI_CONFIG_OPTIONS) {
       this.add(key, viewer.uiConfiguration[key]);

--- a/src/viewer.ts
+++ b/src/viewer.ts
@@ -122,6 +122,7 @@ import {
   verifyFinitePositiveFloat,
   verifyNonnegativeInt,
   verifyObject,
+  verifyOptionalBoolean,
   verifyOptionalObjectProperty,
   verifyString,
 } from "#src/util/json.js";
@@ -250,6 +251,40 @@ const defaultViewerOptions =
         resetStateWhenEmpty: true,
       };
 
+/**
+ * User overrides for the visibility of individual UI controls, persisted in the
+ * viewer state under the `uiControlVisibility` key.
+ *
+ * Each member is tri-state: `undefined` means "follow the embedder's
+ * `ViewerUIConfiguration` value", and `true`/`false` is an explicit user
+ * choice. The embedder's configuration still wins when it hides a control, so
+ * an override may hide a control the configuration permits but can never
+ * reveal one the configuration disallows.
+ *
+ * Additional `VIEWER_UI_CONTROL_CONFIG_OPTIONS` members belong here as they
+ * become user-toggleable, rather than as new top level state keys.
+ */
+class TrackableUiControlVisibility extends CompoundTrackable {
+  showLayerPanel = new TrackableValue<boolean | undefined>(
+    undefined,
+    verifyOptionalBoolean,
+  );
+
+  constructor() {
+    super();
+    this.add("showLayerPanel", this.showLayerPanel);
+  }
+
+  toJSON(): any {
+    const result = super.toJSON();
+    for (const key in result) {
+      if (result[key] !== undefined) return result;
+    }
+    // Omit the section rather than emitting an empty object in every state.
+    return undefined;
+  }
+}
+
 class TrackableViewerState extends CompoundTrackable {
   constructor(public viewer: Borrowed<Viewer>) {
     super();
@@ -306,12 +341,7 @@ class TrackableViewerState extends CompoundTrackable {
     this.add("selectedStateServer", viewer.selectedStateServer);
     this.add("toolBindings", viewer.toolBinder);
     this.add("toolPalettes", viewer.toolPalettes);
-    this.add("hideLayerPanel", viewer.hideLayerPanelState);
-
-    // Add UI configuration to state for persistence
-    // for (const key of VIEWER_UI_CONFIG_OPTIONS) {
-    //   this.add(key, viewer.uiConfiguration[key]);
-    // }
+    this.add("uiControlVisibility", viewer.uiControlVisibilityState);
   }
 
   restoreState(obj: any) {
@@ -462,7 +492,9 @@ export class Viewer extends RefCounted implements ViewerState {
   partialViewport = new TrackableWindowedViewport();
   statisticsDisplayState = new StatisticsDisplayState();
   helpPanelState = new HelpPanelState();
-  hideLayerPanelState = new TrackableBoolean(false, false);
+  uiControlVisibilityState = this.registerDisposer(
+    new TrackableUiControlVisibility(),
+  );
   settingsPanelState = new ViewerSettingsPanelState();
   layerSelectedValues = this.registerDisposer(
     new LayerSelectedValues(this.layerManager, this.mouseState),
@@ -501,7 +533,13 @@ export class Viewer extends RefCounted implements ViewerState {
   dataSourceProvider: Borrowed<DataSourceRegistry>;
 
   uiConfiguration: ViewerUIConfiguration;
+  /** Effective layer panel visibility: the configuration and the user override combined. */
   effectiveShowLayerPanel: WatchableValueInterface<boolean>;
+  /**
+   * Reads `effectiveShowLayerPanel` and writes the user override, for the
+   * toggle in the layer list panel.
+   */
+  layerPanelVisibility: WatchableValueInterface<boolean>;
 
   private makeUiControlVisibilityState(
     key: (typeof VIEWER_UI_CONTROL_CONFIG_OPTIONS)[number],
@@ -584,17 +622,27 @@ export class Viewer extends RefCounted implements ViewerState {
     this.dataSourceProvider = dataSourceProvider;
     this.uiConfiguration = uiConfiguration;
 
-    // Create effective showLayerPanel state that combines configuration and user preference
+    // The configuration is the embedder's policy and always wins when it hides
+    // the panel; the override is the user's choice within what it permits.
     this.effectiveShowLayerPanel = this.registerDisposer(
       makeDerivedWatchableValue(
-        (configEnabled: boolean, hideState: boolean) => {
-          // Layer panel is shown when config allows it AND hide state is false
-          return configEnabled && !hideState;
-        },
+        (configEnabled: boolean, override: boolean | undefined) =>
+          configEnabled && (override ?? true),
         this.uiConfiguration.showLayerPanel,
-        this.hideLayerPanelState,
+        this.uiControlVisibilityState.showLayerPanel,
       ),
     );
+    const { effectiveShowLayerPanel } = this;
+    const showLayerPanelOverride = this.uiControlVisibilityState.showLayerPanel;
+    this.layerPanelVisibility = {
+      get value() {
+        return effectiveShowLayerPanel.value;
+      },
+      set value(newValue: boolean) {
+        showLayerPanelOverride.value = newValue;
+      },
+      changed: effectiveShowLayerPanel.changed,
+    };
 
     this.registerDisposer(
       observeWatchable((value) => {
@@ -1008,7 +1056,7 @@ export class Viewer extends RefCounted implements ViewerState {
             this.sidePanelManager,
             this.layerSpecification,
             this.layerListPanelState,
-            this.hideLayerPanelState,
+            this.layerPanelVisibility,
             this.uiConfiguration.showLayerPanel,
           ),
       }),

--- a/src/viewer.ts
+++ b/src/viewer.ts
@@ -309,9 +309,9 @@ class TrackableViewerState extends CompoundTrackable {
     this.add("hideLayerPanel", viewer.hideLayerPanelState);
 
     // Add UI configuration to state for persistence
-    for (const key of VIEWER_UI_CONFIG_OPTIONS) {
-      this.add(key, viewer.uiConfiguration[key]);
-    }
+    // for (const key of VIEWER_UI_CONFIG_OPTIONS) {
+    //   this.add(key, viewer.uiConfiguration[key]);
+    // }
   }
 
   restoreState(obj: any) {
@@ -501,6 +501,7 @@ export class Viewer extends RefCounted implements ViewerState {
   dataSourceProvider: Borrowed<DataSourceRegistry>;
 
   uiConfiguration: ViewerUIConfiguration;
+  effectiveShowLayerPanel: WatchableValueInterface<boolean>;
 
   private makeUiControlVisibilityState(
     key: (typeof VIEWER_UI_CONTROL_CONFIG_OPTIONS)[number],
@@ -582,6 +583,19 @@ export class Viewer extends RefCounted implements ViewerState {
 
     this.dataSourceProvider = dataSourceProvider;
     this.uiConfiguration = uiConfiguration;
+    
+    // Create effective showLayerPanel state that combines configuration and user preference
+    this.effectiveShowLayerPanel = this.registerDisposer(
+      makeDerivedWatchableValue(
+        (configEnabled: boolean, hideState: boolean) => {
+          // Layer panel is shown when config allows it AND hide state is false
+          return configEnabled && !hideState;
+        },
+        this.uiConfiguration.showLayerPanel,
+        this.hideLayerPanelState,
+      )
+    );
+    
 
     this.registerDisposer(
       observeWatchable((value) => {
@@ -995,6 +1009,7 @@ export class Viewer extends RefCounted implements ViewerState {
             this.sidePanelManager,
             this.layerSpecification,
             this.layerListPanelState,
+            this.hideLayerPanelState,
             this.uiConfiguration.showLayerPanel,
           ),
       }),

--- a/src/viewer.ts
+++ b/src/viewer.ts
@@ -306,7 +306,7 @@ class TrackableViewerState extends CompoundTrackable {
     this.add("selectedStateServer", viewer.selectedStateServer);
     this.add("toolBindings", viewer.toolBinder);
     this.add("toolPalettes", viewer.toolPalettes);
-    
+
     // Add UI configuration to state for persistence
     for (const key of VIEWER_UI_CONFIG_OPTIONS) {
       this.add(key, viewer.uiConfiguration[key]);

--- a/src/viewer.ts
+++ b/src/viewer.ts
@@ -622,28 +622,6 @@ export class Viewer extends RefCounted implements ViewerState {
     this.dataSourceProvider = dataSourceProvider;
     this.uiConfiguration = uiConfiguration;
 
-    // The configuration is the embedder's policy and always wins when it hides
-    // the panel; the override is the user's choice within what it permits.
-    this.effectiveShowLayerPanel = this.registerDisposer(
-      makeDerivedWatchableValue(
-        (configEnabled: boolean, override: boolean | undefined) =>
-          configEnabled && (override ?? true),
-        this.uiConfiguration.showLayerPanel,
-        this.uiControlVisibilityState.showLayerPanel,
-      ),
-    );
-    const { effectiveShowLayerPanel } = this;
-    const showLayerPanelOverride = this.uiControlVisibilityState.showLayerPanel;
-    this.layerPanelVisibility = {
-      get value() {
-        return effectiveShowLayerPanel.value;
-      },
-      set value(newValue: boolean) {
-        showLayerPanelOverride.value = newValue;
-      },
-      changed: effectiveShowLayerPanel.changed,
-    };
-
     this.registerDisposer(
       observeWatchable((value) => {
         this.display.applyWindowedViewportToElement(element, value);
@@ -662,6 +640,31 @@ export class Viewer extends RefCounted implements ViewerState {
     for (const key of VIEWER_UI_CONTROL_CONFIG_OPTIONS) {
       this.uiControlVisibility[key] = this.makeUiControlVisibilityState(key);
     }
+
+    // Layer the user override on top of `uiControlVisibility.showLayerPanel`,
+    // not on `uiConfiguration.showLayerPanel`: the former also accounts for
+    // `showUIControls`, which `Viewer.screenshot` turns off to capture the data
+    // panels alone. The override may hide the panel within what the
+    // configuration permits, but can never reveal one it disallows.
+    this.effectiveShowLayerPanel = this.registerDisposer(
+      makeDerivedWatchableValue(
+        (configEnabled: boolean, override: boolean | undefined) =>
+          configEnabled && (override ?? true),
+        this.uiControlVisibility.showLayerPanel,
+        this.uiControlVisibilityState.showLayerPanel,
+      ),
+    );
+    const { effectiveShowLayerPanel } = this;
+    const showLayerPanelOverride = this.uiControlVisibilityState.showLayerPanel;
+    this.layerPanelVisibility = {
+      get value() {
+        return effectiveShowLayerPanel.value;
+      },
+      set value(newValue: boolean) {
+        showLayerPanelOverride.value = newValue;
+      },
+      changed: effectiveShowLayerPanel.changed,
+    };
     this.registerDisposer(
       this.uiConfiguration.showPanelBorders.changed.add(() => {
         this.updateShowBorders();
@@ -1057,7 +1060,7 @@ export class Viewer extends RefCounted implements ViewerState {
             this.layerSpecification,
             this.layerListPanelState,
             this.layerPanelVisibility,
-            this.uiConfiguration.showLayerPanel,
+            this.uiControlVisibility.showLayerPanel,
           ),
       }),
     );

--- a/src/viewer.ts
+++ b/src/viewer.ts
@@ -306,6 +306,11 @@ class TrackableViewerState extends CompoundTrackable {
     this.add("selectedStateServer", viewer.selectedStateServer);
     this.add("toolBindings", viewer.toolBinder);
     this.add("toolPalettes", viewer.toolPalettes);
+    
+    // Add UI configuration to state for persistence
+    for (const key of VIEWER_UI_CONFIG_OPTIONS) {
+      this.add(key, viewer.uiConfiguration[key]);
+    }
   }
 
   restoreState(obj: any) {
@@ -988,6 +993,7 @@ export class Viewer extends RefCounted implements ViewerState {
             this.sidePanelManager,
             this.layerSpecification,
             this.layerListPanelState,
+            this.uiConfiguration.showLayerPanel,
           ),
       }),
     );

--- a/src/viewer.ts
+++ b/src/viewer.ts
@@ -306,6 +306,7 @@ class TrackableViewerState extends CompoundTrackable {
     this.add("selectedStateServer", viewer.selectedStateServer);
     this.add("toolBindings", viewer.toolBinder);
     this.add("toolPalettes", viewer.toolPalettes);
+    this.add("hideLayerPanel", viewer.hideLayerPanelState);
 
     // Add UI configuration to state for persistence
     for (const key of VIEWER_UI_CONFIG_OPTIONS) {
@@ -461,6 +462,7 @@ export class Viewer extends RefCounted implements ViewerState {
   partialViewport = new TrackableWindowedViewport();
   statisticsDisplayState = new StatisticsDisplayState();
   helpPanelState = new HelpPanelState();
+  hideLayerPanelState = new TrackableBoolean(false, false);
   settingsPanelState = new ViewerSettingsPanelState();
   layerSelectedValues = this.registerDisposer(
     new LayerSelectedValues(this.layerManager, this.mouseState),

--- a/src/viewer.ts
+++ b/src/viewer.ts
@@ -583,7 +583,7 @@ export class Viewer extends RefCounted implements ViewerState {
 
     this.dataSourceProvider = dataSourceProvider;
     this.uiConfiguration = uiConfiguration;
-    
+
     // Create effective showLayerPanel state that combines configuration and user preference
     this.effectiveShowLayerPanel = this.registerDisposer(
       makeDerivedWatchableValue(
@@ -593,9 +593,8 @@ export class Viewer extends RefCounted implements ViewerState {
         },
         this.uiConfiguration.showLayerPanel,
         this.hideLayerPanelState,
-      )
+      ),
     );
-    
 
     this.registerDisposer(
       observeWatchable((value) => {


### PR DESCRIPTION
<img width="1076" height="277" alt="image" src="https://github.com/user-attachments/assets/beb8e879-8376-41ad-a418-9c62ac70737f" />
There were some options for layer panels that were not part of the state, and no way for UI users to set those options.  I have added a showLayerPanel visibility toggle to the layer list side panel, so that people can turn off the visibility of the layer list. 

This is particularly useful for those people who are trying to make simplified neuroglancer visualizations, and/or users who are working with large numbers of layers. 