### PR TITLE
updating framerate adjustment parameters

### DIFF
--- a/src/perspective_view/panel.ts
+++ b/src/perspective_view/panel.ts
@@ -297,7 +297,7 @@ export class PerspectivePanel extends RenderedDataPanel {
   private frameRateCalculator = new DownsamplingBasedOnFrameRateCalculator(
     6 /* numberOfStoredFrameDeltas */,
     8 /* maxDownsamplingFactor */,
-    8 /* desiredFrameTimingMs */,
+    33 /* desiredFrameTimingMs */,
     60 /* downsamplingPersistenceDurationInFrames */,
   );
   private isContinuousCameraMotionInProgress = false;

--- a/src/util/framerate.spec.ts
+++ b/src/util/framerate.spec.ts
@@ -68,7 +68,7 @@ describe("FrameRateCounter", () => {
     const frameRateCounter = new DownsamplingBasedOnFrameRateCalculator(
       9,
       8,
-      100,
+      33,
       15,
     );
 


### PR DESCRIPTION
I have noticed that the framerate downsampling has felt overly aggressive, and so i looked into whether there was a way to make it less aggressive and maintain reasonable performance.  

I added some logging statements to see what it was doing, and noticed that the actual target the code was going for was a mean of 8ms which is 125 Hz, which I think is way too aggressive.  The combination of MEAN, where an outlier number can drive things up significantly, and the overly high refresh rate was causing regular downsampling of 4 and 8 on my mac.  However, changing this to a 33 ms target (roughly a 30Hz refresh rate) means with a reasonable amount of data loaded I don't have any downsampling happening and it still feels quite snappy to me.  

I've left the logging in for now (but turned off) in order to help facilitate investigation across some use cases, but i'd advocate for changing this to give users a better experience while rotating volume rendering. 