### PR TITLE
fix(vitest): add "mac" vitest project with increased hookTimeout value

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -66,7 +66,7 @@ jobs:
         run: npm test
         if: ${{ runner.os != 'macOS' }}
       - name: Run JavaScript tests (excluding WebGL)
-        run: npm test -- --project node
+        run: npm test -- --project mac
         if: ${{ runner.os == 'macOS' }}
       - name: Run JavaScript benchmarks
         run: npm run benchmark

--- a/vitest.workspace.ts
+++ b/vitest.workspace.ts
@@ -65,17 +65,24 @@ const KVSTORE_TESTS_WITH_CUSTOM_CONDITIONS = [
   { name: "icechunk", conditions: ["neuroglancer/kvstore/s3:enabled"] },
 ];
 
+const defaultProject = mergeConfig(defaultNodeProject(), {
+  test: {
+    name: "node",
+    include: ["src/**/*.spec.ts", "tests/**/*.spec.ts"],
+    exclude: KVSTORE_TESTS_WITH_CUSTOM_CONDITIONS.map(
+      ({ name }) => `tests/kvstore/${name}.spec.ts`,
+    ),
+    benchmark: {
+      include: ["src/**/*.benchmark.ts"],
+    },
+  },
+});
+
 export default defineWorkspace([
-  mergeConfig(defaultNodeProject(), {
+  mergeConfig(defaultProject, {
     test: {
-      name: "node",
-      include: ["src/**/*.spec.ts", "tests/**/*.spec.ts"],
-      exclude: KVSTORE_TESTS_WITH_CUSTOM_CONDITIONS.map(
-        ({ name }) => `tests/kvstore/${name}.spec.ts`,
-      ),
-      benchmark: {
-        include: ["src/**/*.benchmark.ts"],
-      },
+      name: "mac",
+      hookTimeout: 120000,
     },
   }),
   ...KVSTORE_TESTS_WITH_CUSTOM_CONDITIONS.map(({ name, conditions = [] }) =>


### PR DESCRIPTION
 ...to fix hook timeout issue when starting moto_server on mac.
 
~Even though the macos env is the only one that specifies the "node" vitest project, it appears it is the default as well.~
I added a "mac" project to restrict the hookTimeout increase.
 
 I tried using vitest cli argument --hook-timeout but could not get it to work. I was able to make it work by added the vitest CLI parser to the workspace file. I should open up an issue with vitest about that.