### PR TITLE
fix: zarr and OME-Zarr metadata loading with query parameters

### DIFF
--- a/src/datasource/zarr/frontend.ts
+++ b/src/datasource/zarr/frontend.ts
@@ -58,6 +58,7 @@ import { WithSharedKvStoreContext } from "#src/kvstore/chunk_source_frontend.js"
 import type { CompletionResult } from "#src/kvstore/context.js";
 import type { SharedKvStoreContext } from "#src/kvstore/frontend.js";
 import {
+  joinBaseUrlAndPath,
   kvstoreEnsureDirectoryPipelineUrl,
   parseUrlSuffix,
   pipelineUrlJoin,
@@ -388,13 +389,13 @@ async function getMetadata(
     const [zarray, zattrs] = await Promise.all([
       getJsonResource(
         sharedKvStoreContext,
-        `${url}.zarray`,
+        joinBaseUrlAndPath(url, ".zarray"),
         "zarr v2 array metadata",
         options,
       ),
       getJsonResource(
         sharedKvStoreContext,
-        `${url}.zattrs`,
+        joinBaseUrlAndPath(url, ".zattrs"),
         "zarr v2 attributes",
         options,
       ),
@@ -424,7 +425,7 @@ async function getMetadata(
   if (options.zarrVersion === 3) {
     const zarrJson = await getJsonResource(
       sharedKvStoreContext,
-      `${url}zarr.json`,
+      joinBaseUrlAndPath(url, "zarr.json"),
       "zarr v3 metadata",
       options,
     );

--- a/src/datasource/zarr/ome.ts
+++ b/src/datasource/zarr/ome.ts
@@ -20,6 +20,10 @@ import type {
   SingleChannelMetadata,
   ChannelMetadata,
 } from "#src/datasource/index.js";
+import {
+  joinBaseUrlAndPath,
+  kvstoreEnsureDirectoryPipelineUrl,
+} from "#src/kvstore/url.js";
 import { parseRGBColorSpecification } from "#src/util/color.js";
 import {
   parseArray,
@@ -269,7 +273,9 @@ function parseMultiscaleScale(
     "coordinateTransformations",
     (x) => parseOmeCoordinateTransforms(rank, x),
   );
-  const scaleUrl = `${url}${path}/`;
+  const scaleUrl = kvstoreEnsureDirectoryPipelineUrl(
+    joinBaseUrlAndPath(url, path),
+  );
   return { url: scaleUrl, transform };
 }
 


### PR DESCRIPTION
Fixes a source like `http://localhost/x.ome.zarr/?access_key=abcd|zarr3`, which would attempt to read `http://localhost/x.ome.zarr/?access_key=abcdzarr.json`