### PR TITLE
fix: remove query parameters when suggesting layer name

### DIFF
--- a/src/datasource/index.ts
+++ b/src/datasource/index.ts
@@ -35,6 +35,7 @@ import {
   extractQueryAndFragment,
   finalPipelineUrlComponent,
   parsePipelineUrlComponent,
+  parseUrlSuffix,
   splitPipelineUrl,
 } from "#src/kvstore/url.js";
 import type { MeshSource, MultiscaleMeshSource } from "#src/mesh/frontend.js";
@@ -607,7 +608,9 @@ export class DataSourceRegistry extends RefCounted {
     for (let i = parts.length - 1; i >= 0; --i) {
       let { suffix } = parts[i];
       if (!suffix) continue;
-      suffix = suffix.replace(/^\/+/, "").replace(/\/+$/, "");
+      const { authorityAndPath } = parseUrlSuffix(suffix);
+      if (!authorityAndPath) continue;
+      suffix = authorityAndPath.replace(/^\/+/, "").replace(/\/+$/, "");
       if (!suffix) continue;
       return suggestLayerNameBasedOnSeparator(suffix);
     }

--- a/tests/datasource/suggest_name.spec.ts
+++ b/tests/datasource/suggest_name.spec.ts
@@ -25,6 +25,8 @@ test.for([
   ["http://localhost/path/to/array", "array"],
   ["http://localhost/path/to/group/|zarr3:path/to/array/", "array"],
   ["brainmaps://foo:bar:baz", "baz"],
+  ["http://localhost/path/to/array/?a=b", "array"],
+  ["http://localhost/path/to/array?a=b", "array"],
 ])("%s -> %s", async ([url, expectedName]) => {
   const registry = await datasourceProviderFixture();
   expect(registry.suggestLayerName(url)).toEqual(expectedName);


### PR DESCRIPTION
Previously, the query parameters would be the suggested layer name