### PR TITLE
feat(segmentation_user_layer): add ability to color segmentation based on segment properties

### DIFF
--- a/src/layer/segmentation/json_keys.ts
+++ b/src/layer/segmentation/json_keys.ts
@@ -12,6 +12,7 @@ export const SEGMENTS_JSON_KEY = "segments";
 export const EQUIVALENCES_JSON_KEY = "equivalences";
 export const COLOR_SEED_JSON_KEY = "colorSeed";
 export const SEGMENT_STATED_COLORS_JSON_KEY = "segmentColors";
+export const SEGMENT_PROPERTY_COLORS_JSON_KEY = "segmentPropertyColors";
 export const MESH_RENDER_SCALE_JSON_KEY = "meshRenderScale";
 export const CROSS_SECTION_RENDER_SCALE_JSON_KEY = "crossSectionRenderScale";
 export const SKELETON_RENDERING_JSON_KEY = "skeletonRendering";

--- a/src/uint64_map.ts
+++ b/src/uint64_map.ts
@@ -90,8 +90,10 @@ export class Uint64Map
     return this.hashTable.size;
   }
 
-  assignFrom(other: Uint64Map) {
-    this.clear();
+  assignFrom(other: Uint64Map, clear = true) {
+    if (clear) {
+      this.clear();
+    }
     for (const [key, value] of other) {
       this.set(key, value);
     }

--- a/src/util/json.ts
+++ b/src/util/json.ts
@@ -682,28 +682,31 @@ export function verify3dDimensions(obj: any) {
   return parseFixedLengthArray(vec3.create(), obj, verifyPositiveInt);
 }
 
-export function verifyStringArray(a: any) {
+export function verifyArray(a: any) {
   if (!Array.isArray(a)) {
     throw new Error(`Expected array, received: ${JSON.stringify(a)}.`);
   }
-  for (const x of a) {
+  return a;
+}
+
+export function verifyStringArray(a: any) {
+  const arr = verifyArray(a);
+  for (const x of arr) {
     if (typeof x !== "string") {
       throw new Error(`Expected string, received: ${JSON.stringify(x)}.`);
     }
   }
-  return <string[]>a;
+  return <string[]>arr;
 }
 
 export function verifyIntegerArray(a: unknown) {
-  if (!Array.isArray(a)) {
-    throw new Error(`Expected array, received: ${JSON.stringify(a)}.`);
-  }
-  for (const x of a) {
+  const arr = verifyArray(a);
+  for (const x of arr) {
     if (!Number.isInteger(x)) {
       throw new Error(`Expected integer, received: ${JSON.stringify(x)}.`);
     }
   }
-  return <number[]>a;
+  return <number[]>arr;
 }
 
 export function verifyBoolean(x: any) {


### PR DESCRIPTION
We would like to add support for colormaps and alpha was mentioned though that would require some rendering logic changes since it would conflict with visible segments. One option would be to force alpha to 0 on all non-visible segments. I will push a deployment with a rudimentary UI for ease of testing later today.

Example:
```json
"segmentPropertyColors": [
  {
    "type": "tag",
    "active": true,
    "map": {
      "L3": "#FFFFFF"
    }
  },
  {
    "type": "numeric",
    "active": true,
    "property": "NSI",
    "options": {
      "min": 5000,
      "max": 7500,
      "minColor": "#FF0000",
      "maxColor": "#0000FF"
    }
  }
],
```


http://localhost:8080/#!%7B%22dimensions%22:%7B%22x%22:%5B8e-9%2C%22m%22%5D%2C%22y%22:%5B8e-9%2C%22m%22%5D%2C%22z%22:%5B3.3e-8%2C%22m%22%5D%7D%2C%22position%22:%5B336923.5%2C198344.5%2C3314.5%5D%2C%22crossSectionScale%22:31.976459773130287%2C%22projectionOrientation%22:%5B0.2733137607574463%2C-0.049999721348285675%2C-0.28637629747390747%2C0.9169450402259827%5D%2C%22projectionScale%22:149658.33236829395%2C%22layers%22:%5B%7B%22type%22:%22segmentation%22%2C%22source%22:%5B%7B%22url%22:%22gs://h01-release/data/20210601/c3/%7Cneuroglancer-precomputed:%22%2C%22subsources%22:%7B%22default%22:true%2C%22bounds%22:true%2C%22properties%22:true%2C%22mesh%22:true%7D%2C%22enableDefaultSubsources%22:false%7D%2C%22gs://lichtman-h01-49eee972005c8846803ef58fbd36e049/goog14r0s5c3/segment_properties/%7Cneuroglancer-precomputed:%22%5D%2C%22tab%22:%22segments%22%2C%22segments%22:%5B%223823768399%22%2C%22%21101153362960%22%2C%22%213154035698%22%2C%223720480838%22%2C%223808204067%22%2C%223896803064%22%2C%224669328082%22%2C%225293286102%22%2C%225890292881%22%2C%226385207860%22%2C%226445451958%22%2C%226677125078%22%2C%2232443424006%22%2C%2233374997143%22%2C%224200138429%22%2C%2242108919642%22%5D%2C%22segmentQuery%22:%22#L4%20NVx%3E=7806957120.53791%20NVx%3C=20235583190.66803%20NSI%3E=5024%20NSI%3C=7675%22%2C%22segmentColors%22:%7B%223154035698%22:%22#ffffff%22%7D%2C%22segmentPropertyColors%22:%5B%7B%22type%22:%22tag%22%2C%22active%22:true%2C%22map%22:%7B%22L3%22:%22#FFFFFF%22%7D%7D%2C%7B%22type%22:%22numeric%22%2C%22active%22:true%2C%22property%22:%22NSI%22%2C%22options%22:%7B%22min%22:5000%2C%22max%22:7500%2C%22minColor%22:%22#FF0000%22%2C%22maxColor%22:%22#0000FF%22%7D%7D%5D%2C%22name%22:%22c3%22%7D%5D%2C%22showSlices%22:false%2C%22selectedLayer%22:%7B%22size%22:392%2C%22visible%22:true%2C%22layer%22:%22c3%22%7D%2C%22layout%22:%223d%22%2C%22selection%22:%7B%22size%22:693%2C%22visible%22:false%7D%7D