### PR TITLE
feat: define `DATA_VALUE_TYPE` and `DATA_VALUE_TYPE_IS_*` for shaders

### DIFF
--- a/build_tools/vitest/polyfill-browser-globals-in-node.ts
+++ b/build_tools/vitest/polyfill-browser-globals-in-node.ts
@@ -14,3 +14,17 @@ for (const name of [
     value: jsdom.window[name],
   });
 }
+
+// Minimally mock WebGL2RenderingContext
+// Required for shader_lib.spec.ts tests
+if (typeof globalThis.WebGL2RenderingContext === "undefined") {
+  (globalThis as any).WebGL2RenderingContext = {
+    UNSIGNED_BYTE: 0x1401,
+    BYTE: 0x1400,
+    UNSIGNED_SHORT: 0x1403,
+    SHORT: 0x1402,
+    FLOAT: 0x1406,
+    INT: 0x1404,
+    UNSIGNED_INT: 0x1405,
+  };
+}

--- a/src/sliceview/image_layer_rendering.md
+++ b/src/sliceview/image_layer_rendering.md
@@ -222,15 +222,6 @@ DATA_VALUE_TYPE value = getDataValue();
   // Do something for other data types
 #endif
 ```
-The full list of data types are:
-- `float`, `vec2`, `vec3`, `vec4`
-- `uint64_t`
-- `uint32_t`
-- `uint16_t`, `uint16x2_t`
-- `uint8_t`, `uint8x2_t`, `uint8x3_t`, `uint8x4_t`
-- `int32_t`
-- `int16_t`, `int16x2_t`
-- `int8_t`, `int8x2_t`, `int8x3_t`, `int8x4_t`
 
 Note that only `float` is a builtin GLSL type. The remaining types are defined as simple structs in order to avoid ambiguity regarding the nature of the value:
 
@@ -248,6 +239,8 @@ struct uint64_t {
   highp uvec2 value;
 };
 ```
+
+Similar structures exist for signed integer types.
 
 To obtain the raw value as a float, call the `toRaw` function:
 

--- a/src/sliceview/image_layer_rendering.md
+++ b/src/sliceview/image_layer_rendering.md
@@ -210,14 +210,27 @@ may still be specified.
 The `getDataValue` function returns the nearest value without interpolation, while the
 `getInterpolatedDataValue` function uses trilinear interpolation.
 
-The `DATA_VALUE_TYPE` macro constant holds the return type of `getDataValue` and `getInterpolatedDataValue`. This can be used for type-generic programming. For example:
+The `DATA_VALUE_TYPE` macro constant holds the return type of `getDataValue` and `getInterpolatedDataValue`.
+For each supported data type, a corresponding `DATA_VALUE_TYPE_IS_*` constant (all uppercase) is defined with a value of `1` if it matches the current data type, and `0` otherwise.
+These macro constants allow for type-generic programming. For example:
 
 ```glsl
 DATA_VALUE_TYPE value = getDataValue();
-#if DATA_VALUE_TYPE == float
+#if DATA_VALUE_TYPE_IS_FLOAT
   // Do something specific for float data
+#else
+  // Do something for other data types
 #endif
 ```
+The full list of data types are:
+- `float`, `vec2`, `vec3`, `vec4`
+- `uint64_t`
+- `uint32_t`
+- `uint16_t`, `uint16x2_t`
+- `uint8_t`, `uint8x2_t`, `uint8x3_t`, `uint8x4_t`
+- `int32_t`
+- `int16_t`, `int16x2_t`
+- `int8_t`, `int8x2_t`, `int8x3_t`, `int8x4_t`
 
 Note that only `float` is a builtin GLSL type. The remaining types are defined as simple structs in order to avoid ambiguity regarding the nature of the value:
 

--- a/src/sliceview/image_layer_rendering.md
+++ b/src/sliceview/image_layer_rendering.md
@@ -210,6 +210,15 @@ may still be specified.
 The `getDataValue` function returns the nearest value without interpolation, while the
 `getInterpolatedDataValue` function uses trilinear interpolation.
 
+The `DATA_VALUE_TYPE` macro constant holds the return type of `getDataValue` and `getInterpolatedDataValue`. This can be used for type-generic programming. For example:
+
+```glsl
+DATA_VALUE_TYPE value = getDataValue();
+#if DATA_VALUE_TYPE == float
+  // Do something specific for float data
+#endif
+```
+
 Note that only `float` is a builtin GLSL type. The remaining types are defined as simple structs in order to avoid ambiguity regarding the nature of the value:
 
 ```glsl

--- a/src/sliceview/volume/frontend.ts
+++ b/src/sliceview/volume/frontend.ts
@@ -109,6 +109,9 @@ export function defineChunkDataShaderAccess(
   }
 
   builder.addFragmentCode(glsl_mixLinear);
+  builder.addFragmentCode(`
+#define SHADER_TYPE ${getShaderType(dataType)}
+`);
   const dataAccessCode = `
 ${getShaderType(dataType)} getDataValue(${dataAccessChannelParams}) {
   highp ivec3 p = ivec3(max(vec3(0.0, 0.0, 0.0), min(floor(${getPositionWithinChunkExpr}), uChunkDataSize - 1.0)));

--- a/src/sliceview/volume/frontend.ts
+++ b/src/sliceview/volume/frontend.ts
@@ -110,7 +110,7 @@ export function defineChunkDataShaderAccess(
 
   builder.addFragmentCode(glsl_mixLinear);
   builder.addFragmentCode(`
-#define SHADER_TYPE ${getShaderType(dataType)}
+#define DATA_VALUE_TYPE ${getShaderType(dataType)}
 `);
   const dataAccessCode = `
 ${getShaderType(dataType)} getDataValue(${dataAccessChannelParams}) {

--- a/src/sliceview/volume/frontend.ts
+++ b/src/sliceview/volume/frontend.ts
@@ -34,7 +34,11 @@ import type {
 import type { Disposable } from "#src/util/disposable.js";
 import type { GL } from "#src/webgl/context.js";
 import type { ShaderBuilder, ShaderProgram } from "#src/webgl/shader.js";
-import { getShaderType, glsl_mixLinear } from "#src/webgl/shader_lib.js";
+import {
+  getShaderType,
+  getShaderTypeDefines,
+  glsl_mixLinear,
+} from "#src/webgl/shader_lib.js";
 
 export type VolumeChunkKey = string;
 
@@ -109,9 +113,7 @@ export function defineChunkDataShaderAccess(
   }
 
   builder.addFragmentCode(glsl_mixLinear);
-  builder.addFragmentCode(`
-#define DATA_VALUE_TYPE ${getShaderType(dataType)}
-`);
+  builder.addFragmentCode(getShaderTypeDefines(dataType));
   const dataAccessCode = `
 ${getShaderType(dataType)} getDataValue(${dataAccessChannelParams}) {
   highp ivec3 p = ivec3(max(vec3(0.0, 0.0, 0.0), min(floor(${getPositionWithinChunkExpr}), uChunkDataSize - 1.0)));

--- a/src/webgl/shader_lib.spec.ts
+++ b/src/webgl/shader_lib.spec.ts
@@ -25,94 +25,31 @@ function expectExactlyOneTypeSet(result: string) {
 
 describe("getShaderTypeDefines", () => {
   it("includes all possible shader types as defines", () => {
-    const result = getShaderTypeDefines(DataType.FLOAT32, 1);
-    expect(result.split("\n").length).toEqual(20); // 1 for DATA_VALUE_TYPE and 19 for DATA_VALUE_TYPE_IS_*
+    const result = getShaderTypeDefines(DataType.FLOAT32);
+    expect(result.split("\n").length).toEqual(1+8); // 1 for DATA_VALUE_TYPE and 8 for DATA_VALUE_TYPE_IS_*
 
     // Check that all float types are included
     expect(result).toContain("DATA_VALUE_TYPE_IS_FLOAT");
-    expect(result).toContain("DATA_VALUE_TYPE_IS_VEC2");
-    expect(result).toContain("DATA_VALUE_TYPE_IS_VEC3");
-    expect(result).toContain("DATA_VALUE_TYPE_IS_VEC4");
-
-    // Check that uint8 types are included
     expect(result).toContain("DATA_VALUE_TYPE_IS_UINT8_T");
-    expect(result).toContain("DATA_VALUE_TYPE_IS_UINT8X2_T");
-    expect(result).toContain("DATA_VALUE_TYPE_IS_UINT8X3_T");
-    expect(result).toContain("DATA_VALUE_TYPE_IS_UINT8X4_T");
-
-    // Check that int8 types are included
     expect(result).toContain("DATA_VALUE_TYPE_IS_INT8_T");
-    expect(result).toContain("DATA_VALUE_TYPE_IS_INT8X2_T");
-    expect(result).toContain("DATA_VALUE_TYPE_IS_INT8X3_T");
-    expect(result).toContain("DATA_VALUE_TYPE_IS_INT8X4_T");
-
-    // Check that uint16 types are included
-    expect(result).toContain("DATA_VALUE_TYPE_IS_UINT16_T");
-    expect(result).toContain("DATA_VALUE_TYPE_IS_UINT16X2_T");
-
-    // Check that int16 types are included
+    expect(result).toContain("DATA_VALUE_TYPE_IS_UINT16_T")
     expect(result).toContain("DATA_VALUE_TYPE_IS_INT16_T");
-    expect(result).toContain("DATA_VALUE_TYPE_IS_INT16X2_T");
-
-    // Check that uint32, int32, uint64 types are included
     expect(result).toContain("DATA_VALUE_TYPE_IS_UINT32_T");
     expect(result).toContain("DATA_VALUE_TYPE_IS_INT32_T");
     expect(result).toContain("DATA_VALUE_TYPE_IS_UINT64_T");
   });
 
-  it("generates correct defines for FLOAT32 with 1 component", () => {
-    const result = getShaderTypeDefines(DataType.FLOAT32, 1);
-    expect(result).toContain("#define DATA_VALUE_TYPE float");
-    expect(result).toContain("#define DATA_VALUE_TYPE_IS_FLOAT 1");
-    expectExactlyOneTypeSet(result);
-  });
-
-  it("generates correct defines for FLOAT32 with 4 components", () => {
-    const result = getShaderTypeDefines(DataType.FLOAT32, 4);
-    expect(result).toContain("#define DATA_VALUE_TYPE vec4");
-    expect(result).toContain("#define DATA_VALUE_TYPE_IS_VEC4 1");
-    expectExactlyOneTypeSet(result);
-  });
-
-  it("generates correct defines for UINT8 with 1 component", () => {
-    const result = getShaderTypeDefines(DataType.UINT8, 1);
-    expect(result).toContain("#define DATA_VALUE_TYPE uint8_t");
-    expect(result).toContain("#define DATA_VALUE_TYPE_IS_UINT8_T 1");
-    expectExactlyOneTypeSet(result);
-  });
-
-  it("generates correct defines for UINT8 with 4 components", () => {
-    const result = getShaderTypeDefines(DataType.UINT8, 4);
-    expect(result).toContain("#define DATA_VALUE_TYPE uint8x4_t");
-    expect(result).toContain("#define DATA_VALUE_TYPE_IS_UINT8X4_T 1");
-    expectExactlyOneTypeSet(result);
-  });
-
-  it("generates correct defines for INT16 with 2 components", () => {
-    const result = getShaderTypeDefines(DataType.INT16, 2);
-    expect(result).toContain("#define DATA_VALUE_TYPE int16x2_t");
-    expect(result).toContain("#define DATA_VALUE_TYPE_IS_INT16X2_T 1");
-    expectExactlyOneTypeSet(result);
-  });
-
-  it("generates correct defines for UINT32 with 1 component", () => {
-    const result = getShaderTypeDefines(DataType.UINT32, 1);
-    expect(result).toContain("#define DATA_VALUE_TYPE uint32_t");
-    expect(result).toContain("#define DATA_VALUE_TYPE_IS_UINT32_T 1");
-    expectExactlyOneTypeSet(result);
-  });
-
-  it("generates correct defines for UINT64 with 1 component", () => {
-    const result = getShaderTypeDefines(DataType.UINT64, 1);
-    expect(result).toContain("#define DATA_VALUE_TYPE uint64_t");
-    expect(result).toContain("#define DATA_VALUE_TYPE_IS_UINT64_T 1");
-    expectExactlyOneTypeSet(result);
-  });
-
-  it("defaults to numComponents=1 when not specified", () => {
+  it("generates correct defines for FLOAT32", () => {
     const result = getShaderTypeDefines(DataType.FLOAT32);
     expect(result).toContain("#define DATA_VALUE_TYPE float");
     expect(result).toContain("#define DATA_VALUE_TYPE_IS_FLOAT 1");
+    expectExactlyOneTypeSet(result);
+  });
+
+  it("generates correct defines for UINT8", () => {
+    const result = getShaderTypeDefines(DataType.UINT8);
+    expect(result).toContain("#define DATA_VALUE_TYPE uint8_t");
+    expect(result).toContain("#define DATA_VALUE_TYPE_IS_UINT8_T 1");
     expectExactlyOneTypeSet(result);
   });
 });

--- a/src/webgl/shader_lib.spec.ts
+++ b/src/webgl/shader_lib.spec.ts
@@ -1,0 +1,118 @@
+/**
+ * @license
+ * Copyright 2025 Google Inc.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, it, expect } from "vitest";
+import { DataType } from "#src/util/data_type.js";
+import { getShaderTypeDefines } from "#src/webgl/shader_lib.js";
+
+function expectExactlyOneTypeSet(result: string) {
+  const ones = (result.match(/DATA_VALUE_TYPE_IS_\w+ 1/g) || []).length;
+  expect(ones).toBe(1);
+}
+
+describe("getShaderTypeDefines", () => {
+  it("includes all possible shader types as defines", () => {
+    const result = getShaderTypeDefines(DataType.FLOAT32, 1);
+    expect(result.split("\n").length).toEqual(20); // 1 for DATA_VALUE_TYPE and 19 for DATA_VALUE_TYPE_IS_*
+
+    // Check that all float types are included
+    expect(result).toContain("DATA_VALUE_TYPE_IS_FLOAT");
+    expect(result).toContain("DATA_VALUE_TYPE_IS_VEC2");
+    expect(result).toContain("DATA_VALUE_TYPE_IS_VEC3");
+    expect(result).toContain("DATA_VALUE_TYPE_IS_VEC4");
+
+    // Check that uint8 types are included
+    expect(result).toContain("DATA_VALUE_TYPE_IS_UINT8_T");
+    expect(result).toContain("DATA_VALUE_TYPE_IS_UINT8X2_T");
+    expect(result).toContain("DATA_VALUE_TYPE_IS_UINT8X3_T");
+    expect(result).toContain("DATA_VALUE_TYPE_IS_UINT8X4_T");
+
+    // Check that int8 types are included
+    expect(result).toContain("DATA_VALUE_TYPE_IS_INT8_T");
+    expect(result).toContain("DATA_VALUE_TYPE_IS_INT8X2_T");
+    expect(result).toContain("DATA_VALUE_TYPE_IS_INT8X3_T");
+    expect(result).toContain("DATA_VALUE_TYPE_IS_INT8X4_T");
+
+    // Check that uint16 types are included
+    expect(result).toContain("DATA_VALUE_TYPE_IS_UINT16_T");
+    expect(result).toContain("DATA_VALUE_TYPE_IS_UINT16X2_T");
+
+    // Check that int16 types are included
+    expect(result).toContain("DATA_VALUE_TYPE_IS_INT16_T");
+    expect(result).toContain("DATA_VALUE_TYPE_IS_INT16X2_T");
+
+    // Check that uint32, int32, uint64 types are included
+    expect(result).toContain("DATA_VALUE_TYPE_IS_UINT32_T");
+    expect(result).toContain("DATA_VALUE_TYPE_IS_INT32_T");
+    expect(result).toContain("DATA_VALUE_TYPE_IS_UINT64_T");
+  });
+
+  it("generates correct defines for FLOAT32 with 1 component", () => {
+    const result = getShaderTypeDefines(DataType.FLOAT32, 1);
+    expect(result).toContain("#define DATA_VALUE_TYPE float");
+    expect(result).toContain("#define DATA_VALUE_TYPE_IS_FLOAT 1");
+    expectExactlyOneTypeSet(result);
+  });
+
+  it("generates correct defines for FLOAT32 with 4 components", () => {
+    const result = getShaderTypeDefines(DataType.FLOAT32, 4);
+    expect(result).toContain("#define DATA_VALUE_TYPE vec4");
+    expect(result).toContain("#define DATA_VALUE_TYPE_IS_VEC4 1");
+    expectExactlyOneTypeSet(result);
+  });
+
+  it("generates correct defines for UINT8 with 1 component", () => {
+    const result = getShaderTypeDefines(DataType.UINT8, 1);
+    expect(result).toContain("#define DATA_VALUE_TYPE uint8_t");
+    expect(result).toContain("#define DATA_VALUE_TYPE_IS_UINT8_T 1");
+    expectExactlyOneTypeSet(result);
+  });
+
+  it("generates correct defines for UINT8 with 4 components", () => {
+    const result = getShaderTypeDefines(DataType.UINT8, 4);
+    expect(result).toContain("#define DATA_VALUE_TYPE uint8x4_t");
+    expect(result).toContain("#define DATA_VALUE_TYPE_IS_UINT8X4_T 1");
+    expectExactlyOneTypeSet(result);
+  });
+
+  it("generates correct defines for INT16 with 2 components", () => {
+    const result = getShaderTypeDefines(DataType.INT16, 2);
+    expect(result).toContain("#define DATA_VALUE_TYPE int16x2_t");
+    expect(result).toContain("#define DATA_VALUE_TYPE_IS_INT16X2_T 1");
+    expectExactlyOneTypeSet(result);
+  });
+
+  it("generates correct defines for UINT32 with 1 component", () => {
+    const result = getShaderTypeDefines(DataType.UINT32, 1);
+    expect(result).toContain("#define DATA_VALUE_TYPE uint32_t");
+    expect(result).toContain("#define DATA_VALUE_TYPE_IS_UINT32_T 1");
+    expectExactlyOneTypeSet(result);
+  });
+
+  it("generates correct defines for UINT64 with 1 component", () => {
+    const result = getShaderTypeDefines(DataType.UINT64, 1);
+    expect(result).toContain("#define DATA_VALUE_TYPE uint64_t");
+    expect(result).toContain("#define DATA_VALUE_TYPE_IS_UINT64_T 1");
+    expectExactlyOneTypeSet(result);
+  });
+
+  it("defaults to numComponents=1 when not specified", () => {
+    const result = getShaderTypeDefines(DataType.FLOAT32);
+    expect(result).toContain("#define DATA_VALUE_TYPE float");
+    expect(result).toContain("#define DATA_VALUE_TYPE_IS_FLOAT 1");
+    expectExactlyOneTypeSet(result);
+  });
+});

--- a/src/webgl/shader_lib.ts
+++ b/src/webgl/shader_lib.ts
@@ -498,6 +498,32 @@ export function getShaderType(dataType: DataType, numComponents = 1) {
   );
 }
 
+export function getShaderTypeDefines(dataType: DataType, numComponents = 1) {
+  const shaderType = getShaderType(dataType, numComponents);
+  const allShaderTypes = new Set<string>();
+
+  // Generate all possible shader types
+  for (const dt of [DataType.UINT8, DataType.INT8, DataType.UINT16, DataType.INT16,
+  DataType.UINT32, DataType.INT32, DataType.UINT64, DataType.FLOAT32]) {
+    for (let nc = 1; nc <= 4; nc++) {
+      try {
+        allShaderTypes.add(getShaderType(dt, nc));
+      } catch {
+        // Ignore invalid combinations
+      }
+    }
+  }
+
+  const defines: string[] = [`#define DATA_VALUE_TYPE ${shaderType}`];
+
+  for (const type of allShaderTypes) {
+    const upperType = type.toUpperCase();
+    defines.push(`#define DATA_VALUE_TYPE_IS_${upperType} ${type === shaderType ? 1 : 0}`);
+  }
+
+  return defines.join('\n');
+}
+
 export const dataTypeShaderDefinition: Record<DataType, ShaderCodePart> = {
   [DataType.UINT8]: glsl_uint8,
   [DataType.INT8]: glsl_int8,

--- a/src/webgl/shader_lib.ts
+++ b/src/webgl/shader_lib.ts
@@ -19,11 +19,10 @@ import {
   DATA_TYPE_SIGNED,
   DataType,
 } from "#src/util/data_type.js";
-import {
-  getShader,
-  type AttributeIndex,
-  type ShaderBuilder,
-  type ShaderCodePart,
+import type {
+  AttributeIndex,
+  ShaderBuilder,
+  ShaderCodePart,
 } from "#src/webgl/shader.js";
 
 export const glsl_mixLinear = `

--- a/src/webgl/shader_lib.ts
+++ b/src/webgl/shader_lib.ts
@@ -19,10 +19,11 @@ import {
   DATA_TYPE_SIGNED,
   DataType,
 } from "#src/util/data_type.js";
-import type {
-  AttributeIndex,
-  ShaderBuilder,
-  ShaderCodePart,
+import {
+  getShader,
+  type AttributeIndex,
+  type ShaderBuilder,
+  type ShaderCodePart,
 } from "#src/webgl/shader.js";
 
 export const glsl_mixLinear = `
@@ -498,27 +499,15 @@ export function getShaderType(dataType: DataType, numComponents = 1) {
   );
 }
 
-export function getShaderTypeDefines(dataType: DataType, numComponents = 1) {
-  const shaderType = getShaderType(dataType, numComponents);
-  const allShaderTypes = new Set<string>();
-
-  // Generate all possible shader types
-  for (const dt of [DataType.UINT8, DataType.INT8, DataType.UINT16, DataType.INT16,
-  DataType.UINT32, DataType.INT32, DataType.UINT64, DataType.FLOAT32]) {
-    for (let nc = 1; nc <= 4; nc++) {
-      try {
-        allShaderTypes.add(getShaderType(dt, nc));
-      } catch {
-        // Ignore invalid combinations
-      }
-    }
-  }
+export function getShaderTypeDefines(dataType: DataType) {
+  const shaderType = getShaderType(dataType);
 
   const defines: string[] = [`#define DATA_VALUE_TYPE ${shaderType}`];
 
-  for (const type of allShaderTypes) {
-    const upperType = type.toUpperCase();
-    defines.push(`#define DATA_VALUE_TYPE_IS_${upperType} ${type === shaderType ? 1 : 0}`);
+  for (const type of [DataType.UINT8, DataType.INT8, DataType.UINT16, DataType.INT16,
+  DataType.UINT32, DataType.INT32, DataType.UINT64, DataType.FLOAT32]) {
+    const upperType = getShaderType(type).toUpperCase();
+    defines.push(`#define DATA_VALUE_TYPE_IS_${upperType} ${dataType === type ? 1 : 0}`);
   }
 
   return defines.join('\n');


### PR DESCRIPTION
This is handy for writing generic user shaders that use `getDataValue()` etc