### PR TITLE
feat: update invlerp and transferFunction heuristic for emitIntensity

### DIFF
--- a/src/webgl/lerp.ts
+++ b/src/webgl/lerp.ts
@@ -297,7 +297,7 @@ export function defineInvlerpShaderFunction(
 float ${name}(${shaderType} inputValue) {
   float v = computeInvlerp(inputValue, uLerpParams_${name});
   ${!clamp ? "" : "v = clamp(v, 0.0, 1.0);"}
-  defaultMaxProjectionIntensity = v;
+  defaultMaxProjectionIntensity = max(v, defaultMaxProjectionIntensity);
   return v;
 }
 `;

--- a/src/widget/transfer_function.ts
+++ b/src/widget/transfer_function.ts
@@ -1851,7 +1851,7 @@ vec4 ${name}_(float inputValue) {
 }
 vec4 ${name}(${shaderType} inputValue) {
   float v = computeInvlerp(inputValue, uLerpParams_${name});
-  defaultMaxProjectionIntensity = v;
+  defaultMaxProjectionIntensity = max(v, defaultMaxProjectionIntensity);
   return v < 0.0 ? vec4(0.0, 0.0, 0.0, 0.0) : ${name}_(clamp(v, 0.0, 1.0));
 }
 vec4 ${name}() {


### PR DESCRIPTION
Currently if you have more than one invlerp or transfer function UI control and use max projection volume rendering, if no `emitIntensity` is manually called in the user defined shader with neuroglancer, neuroglancer will use the value of the last called invlerp or transfer function to set the `intensity` used during max projection rendering.

While we can't always guess exactly what should be the `emitIntensity` with multiple invlerps it might be a more reasonable heuristic to take the max across all the invlerps / transferFunctions instead of the current behaviour. This would also need some tweaking for what to do when the mode is `min` instead of `max`.

Opening this to discuss that possibility. Will need to update some documentation about the rendering if this heuristic is used instead of the current one. cc @fcollman as this came up from an example

I guess the alternative is that maybe this wouldn't come up as a problem if we can adjust the blending across multiple channels  when each channel is it's own layer