### PR TITLE
fix(tool_palette): display LayerTool description in tool palettes

### DIFF
--- a/src/ui/tool.ts
+++ b/src/ui/tool.ts
@@ -105,7 +105,9 @@ export abstract class Tool<Context extends object = object> extends RefCounted {
   abstract activate(activation: ToolActivation<this>): void;
   renderInPalette(context: RefCounted): HTMLElement | undefined {
     context;
-    return undefined;
+    const content = document.createElement("div");
+    content.textContent = this.description;
+    return content;
   }
 
   abstract toJSON(): any;


### PR DESCRIPTION
Before:
<img width="117" height="115" alt="Screenshot 2025-11-10 at 10 11 51 AM" src="https://github.com/user-attachments/assets/c4876b2d-a918-4439-bce4-af13721fdee0" />

After:
<img width="121" height="111" alt="Screenshot 2025-11-10 at 10 12 06 AM" src="https://github.com/user-attachments/assets/032191ba-49b5-486d-bf4d-7d91affaf77c" />
