### PR TITLE
feat: Adds copy view URL button to bypass browser URL truncation

### DIFF
--- a/python/neuroglancer/viewer_config_state.py
+++ b/python/neuroglancer/viewer_config_state.py
@@ -376,6 +376,9 @@ class ConfigState(JsonObjectWrapper):
     show_selection_panel_button = showSelectionPanelButton = wrapped_property(
         "showSelectionPanelButton", optional(bool, True)
     )
+    show_copy_url_button = showCopyUrlButton = wrapped_property(
+        "showCopyUrlButton", optional(bool, True)
+    )
     show_panel_borders = showPanelBorders = wrapped_property(
         "showPanelBorders", optional(bool, True)
     )

--- a/src/ui/url_hash_binding.ts
+++ b/src/ui/url_hash_binding.ts
@@ -41,6 +41,13 @@ function encodeFragment(fragment: string) {
   );
 }
 
+/**
+ * Encodes a state object as a URL fragment string.
+ */
+export function encodeStateAsFragment(state: any): string {
+  return encodeFragment(JSON.stringify(state, bigintToStringJsonReplacer));
+}
+
 export interface UrlHashBindingOptions {
   defaultFragment?: string;
   updateDelayMilliseconds?: number;
@@ -96,9 +103,7 @@ export class UrlHashBinding extends RefCounted {
     const { generation } = cacheState;
     if (generation !== this.prevStateGeneration) {
       this.prevStateGeneration = cacheState.generation;
-      const stateString = encodeFragment(
-        JSON.stringify(cacheState.value, bigintToStringJsonReplacer),
-      );
+      const stateString = encodeStateAsFragment(cacheState.value);
       if (stateString !== this.prevStateString) {
         this.prevStateString = stateString;
         if (decodeURIComponent(stateString) === "{}") {

--- a/src/viewer.ts
+++ b/src/viewer.ts
@@ -27,6 +27,7 @@ import {
   makeCoordinateSpace,
   TrackableCoordinateSpace,
 } from "#src/coordinate_transform.js";
+
 import { getDefaultCredentialsManager } from "#src/credentials_provider/default_manager.js";
 import type { CredentialsManager } from "#src/credentials_provider/index.js";
 import { SharedCredentialsManager } from "#src/credentials_provider/shared.js";
@@ -100,11 +101,13 @@ import {
   MultiToolPaletteManager,
   MultiToolPaletteState,
 } from "#src/ui/tool_palette.js";
+import { encodeStateAsFragment } from "#src/ui/url_hash_binding.js";
 import {
   ViewerSettingsPanel,
   ViewerSettingsPanelState,
 } from "#src/ui/viewer_settings.js";
 import { AutomaticallyFocusedElement } from "#src/util/automatic_focus.js";
+import { setClipboard } from "#src/util/clipboard.js";
 import { TrackableRGB } from "#src/util/color.js";
 import type { Borrowed, Owned } from "#src/util/disposable.js";
 import { RefCounted } from "#src/util/disposable.js";
@@ -136,6 +139,7 @@ import type {
 import { WatchableVisibilityPriority } from "#src/visibility_priority/frontend.js";
 import { AnnotationToolStatusWidget } from "#src/widget/annotation_tool_status.js";
 import { CheckboxIcon } from "#src/widget/checkbox_icon.js";
+import { makeCopyUrlButton } from "#src/widget/copy_button.js";
 import { makeIcon } from "#src/widget/icon.js";
 import {
   MousePositionWidget,
@@ -879,7 +883,18 @@ export class Viewer extends RefCounted implements ViewerState {
       );
       topRow.appendChild(button);
     }
-
+    {
+      const button = makeCopyUrlButton({
+        title: "Copy view URL to clipboard",
+        onClick: () => {
+          const stateString = encodeStateAsFragment(this.state.toJSON());
+          const url = new URL(window.location.href);
+          url.hash = "#!" + stateString;
+          setClipboard(url.href);
+        },
+      });
+      topRow.appendChild(button);
+    }
     {
       const { helpPanelState } = this;
       const button = this.registerDisposer(

--- a/src/viewer.ts
+++ b/src/viewer.ts
@@ -174,6 +174,7 @@ export const VIEWER_TOP_ROW_CONFIG_OPTIONS = [
   "showLayerSidePanelButton",
   "showLocation",
   "showAnnotationToolStatus",
+  "showCopyUrlButton",
 ] as const;
 
 export const VIEWER_UI_CONTROL_CONFIG_OPTIONS = [
@@ -893,6 +894,12 @@ export class Viewer extends RefCounted implements ViewerState {
           setClipboard(url.href);
         },
       });
+      this.registerDisposer(
+        new ElementVisibilityFromTrackableBoolean(
+          this.uiControlVisibility.showCopyUrlButton,
+          button,
+        ),
+      );
       topRow.appendChild(button);
     }
     {

--- a/src/viewer.ts
+++ b/src/viewer.ts
@@ -886,16 +886,14 @@ export class Viewer extends RefCounted implements ViewerState {
     }
     {
       const button = makeCopyUrlButton({
-        title: "Copy view URL to clipboard",
+        title: "Copy URL to clipboard",
         onClick: () => {
           const stateString = encodeStateAsFragment(this.state.toJSON());
           const url = new URL(window.location.href);
           url.hash = "#!" + stateString;
           const result = setClipboard(url.href);
           StatusMessage.showTemporaryMessage(
-            result
-              ? "URL copied to clipboard"
-              : "Failed to copy URL"
+            result ? "URL copied to clipboard" : "Failed to copy URL",
           );
         },
       });

--- a/src/viewer.ts
+++ b/src/viewer.ts
@@ -891,7 +891,12 @@ export class Viewer extends RefCounted implements ViewerState {
           const stateString = encodeStateAsFragment(this.state.toJSON());
           const url = new URL(window.location.href);
           url.hash = "#!" + stateString;
-          setClipboard(url.href);
+          const result = setClipboard(url.href);
+          StatusMessage.showTemporaryMessage(
+            result
+              ? "URL copied to clipboard"
+              : "Failed to copy URL"
+          );
         },
       });
       this.registerDisposer(

--- a/src/widget/copy_button.ts
+++ b/src/widget/copy_button.ts
@@ -14,10 +14,15 @@
  * limitations under the License.
  */
 
+import svg_clipboard from "ikonate/icons/clipboard.svg?raw";
 import svg_copy from "ikonate/icons/copy.svg?raw";
 import type { MakeIconOptions } from "#src/widget/icon.js";
 import { makeIcon } from "#src/widget/icon.js";
 
 export function makeCopyButton(options: MakeIconOptions = {}) {
   return makeIcon({ svg: svg_copy, ...options });
+}
+
+export function makeCopyUrlButton(options: MakeIconOptions = {}) {
+  return makeIcon({ svg: svg_clipboard, ...options });
 }


### PR DESCRIPTION
  ## Summary

  Adds a "Copy view URL to clipboard" button to the top bar that copies the complete URL including the full state fragment, bypassing browser truncation issues.

  ## Problem

  When neuroglancer state URLs become very long, browsers truncate them in the address bar. Copying the URL directly from the address bar results in an incomplete URL that cannot restore the full state when pasted into another browser

  ## Solution

  - Added a new button to the viewer top bar with a clipboard icon
  - The button programmatically constructs the complete URL from the current state and copies it to the clipboard

  ## Changes

  - `src/widget/copy_button.ts`: Added `makeCopyUrlButton()` function that uses the clipboard icon
  - `src/ui/url_hash_binding.ts`: Added `encodeStateAsFragment()` helper function and refactored existing code to use it
  - `src/viewer.ts`: Added the copy URL button to the top bar