### PR TITLE
 feat(skeleton): skeleton line width control and conversion from model units

### DIFF
--- a/src/annotation/line.ts
+++ b/src/annotation/line.ts
@@ -41,7 +41,10 @@ import {
   initializeLineShader,
 } from "#src/webgl/lines.js";
 import type { ShaderBuilder, ShaderProgram } from "#src/webgl/shader.js";
-import { defineVectorArrayVertexShaderInput } from "#src/webgl/shader_lib.js";
+import {
+  defineVectorArrayVertexShaderInput,
+  glsl_nanometersToPixels,
+} from "#src/webgl/shader_lib.js";
 import { defineVertexId, VertexIdHelper } from "#src/webgl/vertex_id.js";
 
 const FULL_OBJECT_PICK_OFFSET = 0;
@@ -89,6 +92,16 @@ class RenderHelper extends AnnotationRenderHelper {
       this.defineShader(builder);
       defineLineShader(builder);
       builder.addVarying(`highp float[${rank}]`, "vModelPosition");
+      builder.addVertexCode(glsl_nanometersToPixels);
+      builder.addVertexCode(`
+float nanometersToPixels(float value) {
+  vec2 lineOffset = getLineOffset();
+  highp vec3 vertexA = projectModelVectorToSubspace(getVertexPosition0());
+  highp vec3 vertexB = projectModelVectorToSubspace(getVertexPosition1());
+  highp vec3 vertex = mix(vertexA, vertexB, lineOffset.x);
+  return nanometersToPixels(value, vertex, uProjection, uModelView, 1.0 / uLineParams.x);
+}
+`);
       builder.addVertexCode(`
 float ng_LineWidth;
 `);
@@ -150,6 +163,15 @@ void setLineEndpointMarkerColor(vec4 startColor, vec4 endColor) {
 }
 void setLineEndpointMarkerBorderColor(vec4 startColor, vec4 endColor) {
   vBorderColor = mix(startColor, endColor, float(getEndpointIndex()));
+}
+`);
+      builder.addVertexCode(glsl_nanometersToPixels);
+      builder.addVertexCode(`
+float nanometersToPixels(float value) {
+  highp vec3 vertexA = projectModelVectorToSubspace(getVertexPosition0());
+  highp vec3 vertexB = projectModelVectorToSubspace(getVertexPosition1());
+  highp vec3 vertex = mix(vertexA, vertexB, float(getEndpointIndex()));
+  return nanometersToPixels(value, vertex, uProjection, uModelView, 1.0 / uCircleParams.x);
 }
 `);
       builder.setVertexMain(`

--- a/src/annotation/line.ts
+++ b/src/annotation/line.ts
@@ -43,7 +43,7 @@ import {
 import type { ShaderBuilder, ShaderProgram } from "#src/webgl/shader.js";
 import {
   defineVectorArrayVertexShaderInput,
-  glsl_nanometersToPixels,
+  glsl_modelToPixels,
 } from "#src/webgl/shader_lib.js";
 import { defineVertexId, VertexIdHelper } from "#src/webgl/vertex_id.js";
 
@@ -92,14 +92,14 @@ class RenderHelper extends AnnotationRenderHelper {
       this.defineShader(builder);
       defineLineShader(builder);
       builder.addVarying(`highp float[${rank}]`, "vModelPosition");
-      builder.addVertexCode(glsl_nanometersToPixels);
+      builder.addVertexCode(glsl_modelToPixels);
       builder.addVertexCode(`
-float nanometersToPixels(float value) {
+float modelToPixels(float value) {
   vec2 lineOffset = getLineOffset();
   highp vec3 vertexA = projectModelVectorToSubspace(getVertexPosition0());
   highp vec3 vertexB = projectModelVectorToSubspace(getVertexPosition1());
   highp vec3 vertex = mix(vertexA, vertexB, lineOffset.x);
-  return nanometersToPixels(value, vertex, uProjection, uModelView, 1.0 / uLineParams.x);
+  return value * modelToPixels(vertex, uProjection, uModelView, 1.0 / uLineParams.x);
 }
 `);
       builder.addVertexCode(`
@@ -165,13 +165,13 @@ void setLineEndpointMarkerBorderColor(vec4 startColor, vec4 endColor) {
   vBorderColor = mix(startColor, endColor, float(getEndpointIndex()));
 }
 `);
-      builder.addVertexCode(glsl_nanometersToPixels);
+      builder.addVertexCode(glsl_modelToPixels);
       builder.addVertexCode(`
-float nanometersToPixels(float value) {
+float modelToPixels(float value) {
   highp vec3 vertexA = projectModelVectorToSubspace(getVertexPosition0());
   highp vec3 vertexB = projectModelVectorToSubspace(getVertexPosition1());
   highp vec3 vertex = mix(vertexA, vertexB, float(getEndpointIndex()));
-  return nanometersToPixels(value, vertex, uProjection, uModelView, 1.0 / uCircleParams.x);
+  return value * modelToPixels(vertex, uProjection, uModelView, 1.0 / uCircleParams.x);
 }
 `);
       builder.setVertexMain(`

--- a/src/skeleton/frontend.ts
+++ b/src/skeleton/frontend.ts
@@ -75,7 +75,7 @@ import type {
   ShaderProgram,
   ShaderSamplerType,
 } from "#src/webgl/shader.js";
-import { glsl_nanometersToPixels } from "#src/webgl/shader_lib.js";
+import { glsl_modelToPixels } from "#src/webgl/shader_lib.js";
 import type { ShaderControlsBuilderState } from "#src/webgl/shader_ui_controls.js";
 import {
   addControlsToBuilder,
@@ -186,14 +186,14 @@ class RenderHelper extends RefCounted {
           builder.addUniform("highp float", "uNodeDiameter");
           builder.addVarying("vec4", "vColor");
           builder.addVertexCode(glsl_COLORMAPS);
-          builder.addVertexCode(glsl_nanometersToPixels);
+          builder.addVertexCode(glsl_modelToPixels);
           builder.addVertexCode(`
-float nanometersToPixels(float value) {
+float modelToPixels(float value) {
   vec2 lineOffset = getLineOffset();
   highp vec3 vertexA = readAttribute0(aVertexIndex.x);
   highp vec3 vertexB = readAttribute0(aVertexIndex.y);
   highp vec3 vertex = mix(vertexA, vertexB, lineOffset.x);
-  return nanometersToPixels(value, vertex, uProjection, uViewModel, 1.0 / uLineParams.x);
+  return value * modelToPixels(vertex, uProjection, uViewModel, 1.0 / uLineParams.x);
 }
 float ng_lineWidth;
 void setLineWidth(float width) {
@@ -274,12 +274,12 @@ emit(vec4(vColor.rgb, vColor.a * getLineAlpha() * ${this.getCrossSectionFadeFact
           builder.addUniform("highp float", "uLineWidth");
           builder.addVarying("vec4", "vColor");
           builder.addVertexCode(glsl_COLORMAPS);
-          builder.addVertexCode(glsl_nanometersToPixels);
+          builder.addVertexCode(glsl_modelToPixels);
           builder.addVertexCode(`
-float nanometersToPixels(float value) {
+float modelToPixels(float value) {
   highp uint vertexIndex = uint(gl_InstanceID);
   highp vec3 vertexPosition = readAttribute0(vertexIndex);
-  return nanometersToPixels(value, vertexPosition, uProjection, uViewModel, 1.0 / uCircleParams.x);
+  return value * modelToPixels(vertexPosition, uProjection, uViewModel, 1.0 / uCircleParams.x);
 }
 float ng_nodeDiameter;
 void setNodeDiameter(float size) {

--- a/src/skeleton/frontend.ts
+++ b/src/skeleton/frontend.ts
@@ -213,8 +213,7 @@ void emitDefault() {
 highp vec3 vertexA = readAttribute0(aVertexIndex.x);
 highp vec3 vertexB = readAttribute0(aVertexIndex.y);
 highp uint lineEndpointIndex = getLineEndpointIndex();
-highp uint vertexIndex = aVertexIndex.x * lineEndpointIndex + aVertexIndex.y * (1u - lineEndpointIndex);
-highp uint vertexIndex2 = aVertexIndex.y * lineEndpointIndex + aVertexIndex.x * (1u - lineEndpointIndex);
+highp uint vertexIndex = aVertexIndex.x * (1u - lineEndpointIndex) + aVertexIndex.y * lineEndpointIndex;
 setLineWidth(uLineWidth);
 `;
           const { vertexAttributes } = this;
@@ -222,7 +221,7 @@ setLineWidth(uLineWidth);
           for (let i = 1; i < numAttributes; ++i) {
             const info = vertexAttributes[i];
             builder.addVarying(`highp ${info.glslDataType}`, `vCustom${i}`);
-            vertexMain += `vCustom${i} = readAttribute${i}(vertexIndex2);\n`; // TODO, why is vertexIndex2 correct?
+            vertexMain += `vCustom${i} = readAttribute${i}(vertexIndex);\n`;
             builder.addVertexCode(`#define ${info.name} vCustom${i}\n`);
             builder.addVertexCode(
               `#define prop_${info.name}() vCustom${i}\n`,

--- a/src/skeleton/frontend.ts
+++ b/src/skeleton/frontend.ts
@@ -75,6 +75,7 @@ import type {
   ShaderProgram,
   ShaderSamplerType,
 } from "#src/webgl/shader.js";
+import { glsl_nanometersToPixels } from "#src/webgl/shader_lib.js";
 import type { ShaderControlsBuilderState } from "#src/webgl/shader_ui_controls.js";
 import {
   addControlsToBuilder,
@@ -94,7 +95,20 @@ import { defineVertexId, VertexIdHelper } from "#src/webgl/vertex_id.js";
 
 const tempMat2 = mat4.create();
 
-const DEFAULT_FRAGMENT_MAIN = `void main() {
+function defineNoOpEdgeSetters(builder: ShaderBuilder) {
+  builder.addVertexCode(`
+void setLineWidth(float width) {}
+`);
+}
+
+function defineNoOpNodeSetters(builder: ShaderBuilder) {
+  builder.addVertexCode(`
+void setNodeDiameter(float size) {}
+`);
+}
+
+const DEFAULT_VERTEX_MAIN = `
+void main() {
   emitDefault();
 }
 `;
@@ -126,6 +140,7 @@ class RenderHelper extends RefCounted {
     defineVertexId(builder);
     builder.addUniform("highp vec4", "uColor");
     builder.addUniform("highp mat4", "uProjection");
+    builder.addUniform("highp mat4", "uViewModel");
     builder.addUniform("highp uint", "uPickID");
   }
 
@@ -165,44 +180,68 @@ class RenderHelper extends RefCounted {
           this.defineCommonShader(builder);
           this.defineAttributeAccess(builder);
           defineLineShader(builder);
+          defineNoOpNodeSetters(builder);
           builder.addAttribute("highp uvec2", "aVertexIndex");
           builder.addUniform("highp float", "uLineWidth");
+          builder.addUniform("highp float", "uNodeDiameter");
+          builder.addVarying("vec4", "vColor");
+          builder.addVertexCode(glsl_COLORMAPS);
+          builder.addVertexCode(glsl_nanometersToPixels);
+          builder.addVertexCode(`
+float nanometersToPixels(float value) {
+  vec2 lineOffset = getLineOffset();
+  highp vec3 vertexA = readAttribute0(aVertexIndex.x);
+  highp vec3 vertexB = readAttribute0(aVertexIndex.y);
+  highp vec3 vertex = mix(vertexA, vertexB, lineOffset.x);
+  return nanometersToPixels(value, vertex, uProjection, uViewModel, 1.0 / uLineParams.x);
+}
+float ng_lineWidth;
+void setLineWidth(float width) {
+  ng_lineWidth = width;
+}
+void emitRGB(vec3 color) {
+  vColor = vec4(color.rgb, uColor.a);
+}
+void emitRGBA(vec4 color) {
+  vColor = color;
+}
+void emitDefault() {
+  emitRGBA(uColor);
+}
+`);
           let vertexMain = `
 highp vec3 vertexA = readAttribute0(aVertexIndex.x);
 highp vec3 vertexB = readAttribute0(aVertexIndex.y);
-emitLine(uProjection, vertexA, vertexB, uLineWidth);
 highp uint lineEndpointIndex = getLineEndpointIndex();
-highp uint vertexIndex = aVertexIndex.x * (1u - lineEndpointIndex) + aVertexIndex.y * lineEndpointIndex;
+highp uint vertexIndex = aVertexIndex.x * lineEndpointIndex + aVertexIndex.y * (1u - lineEndpointIndex);
+highp uint vertexIndex2 = aVertexIndex.y * lineEndpointIndex + aVertexIndex.x * (1u - lineEndpointIndex);
+setLineWidth(uLineWidth);
 `;
-
-          builder.addFragmentCode(`
-vec4 segmentColor() {
-  return uColor;
-}
-void emitRGB(vec3 color) {
-  emit(vec4(color * uColor.a, uColor.a * getLineAlpha() * ${this.getCrossSectionFadeFactor()}), uPickID);
-}
-void emitDefault() {
-  emit(vec4(uColor.rgb, uColor.a * getLineAlpha() * ${this.getCrossSectionFadeFactor()}), uPickID);
-}
-`);
-          builder.addFragmentCode(glsl_COLORMAPS);
           const { vertexAttributes } = this;
           const numAttributes = vertexAttributes.length;
           for (let i = 1; i < numAttributes; ++i) {
             const info = vertexAttributes[i];
             builder.addVarying(`highp ${info.glslDataType}`, `vCustom${i}`);
-            vertexMain += `vCustom${i} = readAttribute${i}(vertexIndex);\n`;
-            builder.addFragmentCode(`#define ${info.name} vCustom${i}\n`);
-            builder.addFragmentCode(
+            vertexMain += `vCustom${i} = readAttribute${i}(vertexIndex2);\n`; // TODO, why is vertexIndex2 correct?
+            builder.addVertexCode(`#define ${info.name} vCustom${i}\n`);
+            builder.addVertexCode(
               `#define prop_${info.name}() vCustom${i}\n`,
             );
-          }
+}
+          vertexMain += `
+userMain();
+emitLine(uProjection * uViewModel, vertexA, vertexB, ng_lineWidth);
+`;
           builder.setVertexMain(vertexMain);
           addControlsToBuilder(shaderBuilderState, builder);
-          builder.setFragmentMainFunction(
-            shaderCodeWithLineDirective(shaderBuilderState.parseResult.code),
+          builder.addVertexCode(
+            "\n#define main userMain\n" +
+              shaderCodeWithLineDirective(shaderBuilderState.parseResult.code) +
+              "\n#undef main\n",
           );
+          builder.setFragmentMain(`
+emit(vec4(vColor.rgb, vColor.a * getLineAlpha() * ${this.getCrossSectionFadeFactor()}), uPickID);
+`);
         },
       },
     );
@@ -233,45 +272,63 @@ void emitDefault() {
             builder,
             /*crossSectionFade=*/ this.targetIsSliceView,
           );
+          defineNoOpEdgeSetters(builder);
           builder.addUniform("highp float", "uNodeDiameter");
-          let vertexMain = `
-highp uint vertexIndex = uint(gl_InstanceID);
-highp vec3 vertexPosition = readAttribute0(vertexIndex);
-emitCircle(uProjection * vec4(vertexPosition, 1.0), uNodeDiameter, 0.0);
-`;
-
-          builder.addFragmentCode(`
-vec4 segmentColor() {
-  return uColor;
+          builder.addUniform("highp float", "uLineWidth");
+          builder.addVarying("vec4", "vColor");
+          builder.addVertexCode(glsl_COLORMAPS);
+          builder.addVertexCode(glsl_nanometersToPixels);
+          builder.addVertexCode(`
+float nanometersToPixels(float value) {
+  highp uint vertexIndex = uint(gl_InstanceID);
+  highp vec3 vertexPosition = readAttribute0(vertexIndex);
+  return nanometersToPixels(value, vertexPosition, uProjection, uViewModel, 1.0 / uCircleParams.x);
 }
-void emitRGBA(vec4 color) {
-  vec4 borderColor = color;
-  emit(getCircleColor(color, borderColor), uPickID);
+float ng_nodeDiameter;
+void setNodeDiameter(float size) {
+  ng_nodeDiameter = size;
 }
 void emitRGB(vec3 color) {
-  emitRGBA(vec4(color, 1.0));
+  vColor = vec4(color.rgb, uColor.a);
+}
+void emitRGBA(vec4 color) {
+  vColor = color;
 }
 void emitDefault() {
   emitRGBA(uColor);
 }
 `);
-          builder.addFragmentCode(glsl_COLORMAPS);
+          let vertexMain = `
+highp uint vertexIndex = uint(gl_InstanceID);
+highp vec3 vertexPosition = readAttribute0(vertexIndex);
+setNodeDiameter(uNodeDiameter);
+`;
           const { vertexAttributes } = this;
           const numAttributes = vertexAttributes.length;
           for (let i = 1; i < numAttributes; ++i) {
             const info = vertexAttributes[i];
             builder.addVarying(`highp ${info.glslDataType}`, `vCustom${i}`);
             vertexMain += `vCustom${i} = readAttribute${i}(vertexIndex);\n`;
-            builder.addFragmentCode(`#define ${info.name} vCustom${i}\n`);
-            builder.addFragmentCode(
+            builder.addVertexCode(`#define ${info.name} vCustom${i}\n`);
+            builder.addVertexCode(
               `#define prop_${info.name}() vCustom${i}\n`,
             );
           }
+          vertexMain += `
+userMain();
+emitCircle(uProjection * uViewModel * vec4(vertexPosition, 1.0), ng_nodeDiameter, 0.0);
+`;
           builder.setVertexMain(vertexMain);
           addControlsToBuilder(shaderBuilderState, builder);
-          builder.setFragmentMainFunction(
-            shaderCodeWithLineDirective(shaderBuilderState.parseResult.code),
+          builder.addVertexCode(
+            "\n#define main userMain\n" +
+              shaderCodeWithLineDirective(shaderBuilderState.parseResult.code) +
+              "\n#undef main\n",
           );
+          builder.setFragmentMain(`
+vec4 borderColor = vColor;
+emit(getCircleColor(vColor, borderColor), uPickID);
+`);
         },
       },
     );
@@ -318,9 +375,10 @@ void emitDefault() {
     renderContext: SliceViewPanelRenderContext | PerspectiveViewRenderContext,
     modelMatrix: mat4,
   ) {
-    const { viewProjectionMat } = renderContext.projectionParameters;
-    const mat = mat4.multiply(tempMat2, viewProjectionMat, modelMatrix);
-    gl.uniformMatrix4fv(shader.uniform("uProjection"), false, mat);
+    const { viewMatrix, projectionMat } = renderContext.projectionParameters;
+    const viewModelMat = mat4.multiply(tempMat2, viewMatrix, modelMatrix);
+    gl.uniformMatrix4fv(shader.uniform("uProjection"), false, projectionMat);
+    gl.uniformMatrix4fv(shader.uniform("uViewModel"), false, viewModelMat);
     this.vertexIdHelper.enable();
   }
 
@@ -427,7 +485,7 @@ export class SkeletonRenderingOptions implements Trackable {
     return this.compound.changed;
   }
 
-  shader = makeTrackableFragmentMain(DEFAULT_FRAGMENT_MAIN);
+  shader = makeTrackableFragmentMain(DEFAULT_VERTEX_MAIN);
   shaderControlState = new ShaderControlState(this.shader);
   params2d: ViewSpecificSkeletonRenderingOptions = {
     mode: new TrackableSkeletonRenderMode(SkeletonRenderMode.LINES_AND_POINTS),
@@ -477,7 +535,7 @@ export class SkeletonLayer extends RefCounted {
   private sharedObject: SegmentationLayerSharedObject;
   vertexAttributes: VertexAttributeRenderInfo[];
   fallbackShaderParameters = new WatchableValue(
-    getFallbackBuilderState(parseShaderUiControls(DEFAULT_FRAGMENT_MAIN)),
+    getFallbackBuilderState(parseShaderUiControls(DEFAULT_VERTEX_MAIN)),
   );
 
   get visibility() {

--- a/src/skeleton/frontend.ts
+++ b/src/skeleton/frontend.ts
@@ -223,10 +223,8 @@ setLineWidth(uLineWidth);
             builder.addVarying(`highp ${info.glslDataType}`, `vCustom${i}`);
             vertexMain += `vCustom${i} = readAttribute${i}(vertexIndex);\n`;
             builder.addVertexCode(`#define ${info.name} vCustom${i}\n`);
-            builder.addVertexCode(
-              `#define prop_${info.name}() vCustom${i}\n`,
-            );
-}
+            builder.addVertexCode(`#define prop_${info.name}() vCustom${i}\n`);
+          }
           vertexMain += `
 userMain();
 emitLine(uProjection * uViewModel, vertexA, vertexB, ng_lineWidth);
@@ -309,9 +307,7 @@ setNodeDiameter(uNodeDiameter);
             builder.addVarying(`highp ${info.glslDataType}`, `vCustom${i}`);
             vertexMain += `vCustom${i} = readAttribute${i}(vertexIndex);\n`;
             builder.addVertexCode(`#define ${info.name} vCustom${i}\n`);
-            builder.addVertexCode(
-              `#define prop_${info.name}() vCustom${i}\n`,
-            );
+            builder.addVertexCode(`#define prop_${info.name}() vCustom${i}\n`);
           }
           vertexMain += `
 userMain();

--- a/src/webgl/shader_lib.ts
+++ b/src/webgl/shader_lib.ts
@@ -465,6 +465,21 @@ highp int subtractSaturate(highp int x, highp uint y) {
 `,
 ];
 
+export const glsl_nanometersToPixels = `
+float nanometersToPixels(float nanometers, highp vec3 vertex, mat4 projection, mat4 viewModel, float projectionWidthPixels) {
+  float viewDistance = 1.0;
+  vec4 vertexViewOrigin = viewModel * vec4(vertex, 1.0);
+  vec4 vertexViewOffset = vertexViewOrigin + vec4(viewDistance, 0.0, 0.0, 0.0);
+  vec4 vertexClipOrigin = projection * vertexViewOrigin;
+  vec4 vertexClipOffset = projection * vertexViewOffset;
+  float projectionDistancePixels = abs(vertexClipOrigin.x - vertexClipOffset.x) * projectionWidthPixels;
+  float viewModalScale = length(viewModel[0].xyz);
+  float projectionScale = projectionDistancePixels / viewDistance;
+  float perspectiveScale = 1.0 / vertexClipOrigin.w;
+  return nanometers * viewModalScale * projectionScale * perspectiveScale;
+}
+`;
+
 export function getShaderType(dataType: DataType, numComponents = 1) {
   switch (dataType) {
     case DataType.FLOAT32:

--- a/src/webgl/shader_lib.ts
+++ b/src/webgl/shader_lib.ts
@@ -465,8 +465,8 @@ highp int subtractSaturate(highp int x, highp uint y) {
 `,
 ];
 
-export const glsl_nanometersToPixels = `
-float nanometersToPixels(float nanometers, highp vec3 vertex, mat4 projection, mat4 viewModel, float projectionWidthPixels) {
+export const glsl_modelToPixels = `
+float modelToPixels(highp vec3 vertex, mat4 projection, mat4 viewModel, float projectionWidthPixels) {
   float viewDistance = 1.0;
   vec4 vertexViewOrigin = viewModel * vec4(vertex, 1.0);
   vec4 vertexViewOffset = vertexViewOrigin + vec4(viewDistance, 0.0, 0.0, 0.0);
@@ -476,7 +476,7 @@ float nanometersToPixels(float nanometers, highp vec3 vertex, mat4 projection, m
   float viewModalScale = length(viewModel[0].xyz);
   float projectionScale = projectionDistancePixels / viewDistance;
   float perspectiveScale = 1.0 / vertexClipOrigin.w;
-  return nanometers * viewModalScale * projectionScale * perspectiveScale;
+  return viewModalScale * projectionScale * perspectiveScale;
 }
 `;
 


### PR DESCRIPTION
continuing from: https://github.com/google/neuroglancer/pull/820

Based on this section from the skeleton documentation:
> The special vertex attribute id of "radius" may be used to indicate the radius in "stored model" units; it should have a "data_type" of "float32" and "num_components" of 1.

I've renamed the shader function to "modelToPixels"

The documentation also indicates:
> If using a "radius" attribute, the scaling applied by "transform" should be uniform

So I think it is fine to keep the calculation of the scaling factor to be based on just a single dimension. What is lacking is the ability to use the display dimension scale. I think a 3d approach to rendering skeletons is the right choice if that matters.

I will look into finding a way to add good tests for this feature

I left in the line annotation code so we can see what adding annotation support would look like, but I will strip that out of this PR 