### PR TITLE
fix: Update S3 prefix listing to work with ListObjectsV2 API 

### DIFF
--- a/src/kvstore/s3/list.ts
+++ b/src/kvstore/s3/list.ts
@@ -28,7 +28,7 @@ const EXPECTED_XML_NAMESPACE_URIS = [
 function isValidListObjectsResponse(documentElement: Element): boolean {
   return (
     EXPECTED_XML_NAMESPACE_URIS.includes(documentElement.namespaceURI!) &&
-    documentElement.tagName === "ListBucketResult"
+    documentElement.localName === "ListBucketResult"
   );
 }
 
@@ -76,35 +76,39 @@ export async function getS3BucketListing(
       );
     }
     const namespaceURI = documentElement.namespaceURI!;
-    const namespaceResolver: XPathNSResolver = () => namespaceURI;
-    const commonPrefixNodes = doc.evaluate(
-      "//CommonPrefixes/Prefix",
-      doc,
-      namespaceResolver,
-      XPathResult.UNORDERED_NODE_SNAPSHOT_TYPE,
-      null,
-    );
     const directories: string[] = [];
-    for (let i = 0, n = commonPrefixNodes.snapshotLength; i < n; ++i) {
-      let name = commonPrefixNodes.snapshotItem(i)!.textContent;
-      if (name === null) continue;
-      name = decodeURIComponent(name);
-      // Exclude delimiter from end of `name`.
-      directories.push(name.substring(0, name.length - delimiter.length));
+    const commonPrefixes = documentElement.getElementsByTagNameNS(
+      namespaceURI,
+      "CommonPrefixes",
+    );
+    for (let i = 0; i < commonPrefixes.length; ++i) {
+      const commonPrefix = commonPrefixes.item(i)!;
+      const prefixNodes = commonPrefix.getElementsByTagNameNS(
+        namespaceURI,
+        "Prefix",
+      );
+      for (let j = 0; j < prefixNodes.length; ++j) {
+        let name = prefixNodes.item(j)!.textContent;
+        if (name === null) continue;
+        name = decodeURIComponent(name);
+        // Exclude delimiter from end of `name`.
+        directories.push(name.substring(0, name.length - delimiter.length));
+      }
     }
 
     const entries: ListEntry[] = [];
-    const contents = doc.evaluate(
-      "//Contents/Key",
-      doc,
-      namespaceResolver,
-      XPathResult.UNORDERED_NODE_SNAPSHOT_TYPE,
-      null,
+    const contentNodes = documentElement.getElementsByTagNameNS(
+      namespaceURI,
+      "Contents",
     );
-    for (let i = 0, n = contents.snapshotLength; i < n; ++i) {
-      const name = contents.snapshotItem(i)!.textContent;
-      if (name === null) continue;
-      entries.push({ key: decodeURIComponent(name) });
+    for (let i = 0; i < contentNodes.length; ++i) {
+      const contentNode = contentNodes.item(i)!;
+      const keyNodes = contentNode.getElementsByTagNameNS(namespaceURI, "Key");
+      for (let j = 0; j < keyNodes.length; ++j) {
+        const name = keyNodes.item(j)!.textContent;
+        if (name === null) continue;
+        entries.push({ key: decodeURIComponent(name) });
+      }
     }
     return { directories, entries };
   } catch (e) {

--- a/tests/kvstore/s3.browser_test.ts
+++ b/tests/kvstore/s3.browser_test.ts
@@ -1,0 +1,67 @@
+/**
+ * @license
+ * Copyright 2026 Google Inc.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, test } from "vitest";
+import { getS3BucketListing } from "#src/kvstore/s3/list.js";
+
+describe("s3 xml parsing (browser)", () => {
+  test("parses default-namespace ListBucketResult prefixes and keys", async () => {
+    const listBucketResultXml = `<?xml version="1.0" encoding="UTF-8"?>
+    <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+      <Name>example-public-dataset</Name>
+      <Prefix></Prefix>
+      <KeyCount>5</KeyCount>
+      <MaxKeys>1000</MaxKeys>
+      <Delimiter>/</Delimiter>
+      <EncodingType>url</EncodingType>
+      <IsTruncated>false</IsTruncated>
+      <Contents>
+        <Key>catalog.csv</Key>
+        <LastModified>2026-01-15T10:00:00.000Z</LastModified>
+        <ETag>&quot;11111111111111111111111111111111-10&quot;</ETag>
+        <Size>102400</Size>
+        <StorageClass>INTELLIGENT_TIERING</StorageClass>
+      </Contents>
+      <Contents>
+        <Key>readme.txt</Key>
+        <LastModified>2026-02-20T08:30:00.000Z</LastModified>
+        <ETag>&quot;22222222222222222222222222222222&quot;</ETag>
+        <ChecksumAlgorithm>CRC64NVME</ChecksumAlgorithm>
+        <ChecksumType>FULL_OBJECT</ChecksumType>
+        <Size>256</Size>
+        <StorageClass>STANDARD</StorageClass>
+      </Contents>
+      <CommonPrefixes><Prefix>dataset-alpha/</Prefix></CommonPrefixes>
+      <CommonPrefixes><Prefix>dataset-beta/</Prefix></CommonPrefixes>
+      <CommonPrefixes><Prefix>archive-2026/</Prefix></CommonPrefixes>
+    </ListBucketResult>`;
+
+    const response = await getS3BucketListing(
+      "https://example.com/example-public-dataset/",
+      "",
+      async () =>
+        new Response(listBucketResultXml, {
+          headers: { "content-type": "application/xml; charset=UTF-8" },
+        }),
+      {},
+    );
+
+    expect(response).toEqual({
+      directories: ["dataset-alpha", "dataset-beta", "archive-2026"],
+      entries: [{ key: "catalog.csv" }, { key: "readme.txt" }],
+    });
+  });
+});


### PR DESCRIPTION
Got a fix here for the s3 autocomplete. If this has been fixed or addressed in another PR or issue, please disregard. Thanks for your review!

**Summary of issue** 
I noticed for the past couple months that S3 URIs have not been completing in the source input box in Chrome/Safari/Firefox. Should be reproducible in any [mainline Neuroglancer distribution]((https://neuroglancer.bossdb.io/)). (Try `s3://bossdb-open-data/`) 

Google cloud bucket URIs were autocompleting. I assumed it was an issue with the listing operation itself but the XML response looked correct to me (properly showing all prefixes delimited by a `/`), so I think I tracked the issue with the XML parser in the S3 listing script here. 

**What Changed**

- File changed: src/kvstore/s3/list.ts
- Updated root element validation to use documentElement.localName instead of tagName.
- Replaced XPath-based extraction with namespace-aware DOM traversal via getElementsByTagNameNS for:
    - CommonPrefixes > Prefix (directories)
    - Contents > Key (entries)

Technically we might not need `Keys` or individual objects. 
**Impact**
S3-backed datasource URL autocomplete now surfaces prefixes/files as expected for namespace-qualified ListObjectsV2 XML responses.

**Testing**
- Ran: `npm test -- tests/kvstore/s3.spec.ts`
    - Passed
- Manually tested S3 and GCP URIs for autocomplete on Chrome/Firefox/Safari

This change was implemented with assistance from Codex (AI coding assistant). CLA has been signed.