### PR TITLE
docs(README): update multiresolution-mesh-creator to mesh-n-bone

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ There is a Google Group/mailing list for discussion related to Neuroglancer:
   as a useful example for converting other datasets.
 - [BigArrays.jl](https://github.com/seung-lab/BigArrays.jl) - Julia interface of neuroglancer precomputed data format.
 - [cloudvolume](https://github.com/seung-lab/cloud-volume) - Python interface of neuroglancer precomputed data format.
-- [multiresolution-mesh-creator](https://github.com/janelia-cosem/multiresolution-mesh-creator) - Python tool for creating [multi-resolution meshes](https://github.com/google/neuroglancer/blob/master/src/datasource/precomputed/meshes.md#multi-resolution-mesh-format) from single resolution or multiscale meshes.
+- [mesh-n-bone](https://github.com/janelia-cellmap/mesh-n-bone) - Python tool for creating [multi-resolution meshes](https://github.com/google/neuroglancer/blob/master/src/datasource/precomputed/meshes.md#multi-resolution-mesh-format) from segmentation volumes or meshes.
 - [Igneous](https://github.com/seung-lab/igneous) - Python pipeline for scalable meshing, skeletonizing, downsampling, and management of large 3d images focusing on Neuroglancer Precomputed format.
 
 # Contributing


### PR DESCRIPTION
## Summary
- Replace reference to `janelia-cosem/multiresolution-mesh-creator` with `janelia-cellmap/mesh-n-bone` in the Related Projects section of the README
- Updates the repo URL and description to reflect the renamed and updated tool

## Details
The `multiresolution-mesh-creator` tool has been renamed to `mesh-n-bone` and moved to the `janelia-cellmap` GitHub organization. The description is also updated to better reflect its current capabilities (creating multi-resolution meshes from segmentation volumes or meshes).