### PR TITLE
fix(status): limit mousedown focus suppression to credential prompts

### DIFF
--- a/src/credentials_provider/interactive_credentials_provider.ts
+++ b/src/credentials_provider/interactive_credentials_provider.ts
@@ -28,6 +28,7 @@ export function getCredentialsWithStatus<Token>(
 ): Promise<Token> {
   const { requestDescription = "login" } = options;
   const status = new StatusMessage(/*delay=*/ true);
+  status.setPreventFocusChangeOnMouseDown(true);
   let abortController: AbortController | undefined;
   return new Promise<Token>((resolve, reject) => {
     const disposeAbortCallback = scopedAbortCallback(signal, (reason) => {

--- a/src/status.ts
+++ b/src/status.ts
@@ -28,17 +28,9 @@ export const DEFAULT_STATUS_DELAY = 200;
 
 export type Delay = boolean | number;
 
-function setupStatusContainer(container: HTMLElement) {
-  container.addEventListener("mousedown", (event) => {
-    // Prevent focus changes due to clicking on status message.
-    event.preventDefault();
-  });
-}
-
 function getStatusContainer() {
   if (statusContainer === undefined) {
     statusContainer = document.createElement("ul");
-    setupStatusContainer(statusContainer);
     statusContainer.id = "neuroglancer-status-container";
     const el: HTMLElement | null = document.getElementById(
       "neuroglancer-container",
@@ -55,7 +47,6 @@ function getStatusContainer() {
 function getModalStatusContainer() {
   if (modalStatusContainer === undefined) {
     modalStatusContainer = document.createElement("ul");
-    setupStatusContainer(modalStatusContainer);
     modalStatusContainer.id = "neuroglancer-status-container-modal";
     const el: HTMLElement | null = document.getElementById(
       "neuroglancer-container",
@@ -79,9 +70,17 @@ export class StatusMessage {
   private modalElementWrapper: HTMLElement | undefined;
   private timer: number | null;
   private visibility = true;
+  private preventFocusChangeOnMouseDown = false;
+  private handleMouseDown = (event: MouseEvent) => {
+    if (this.preventFocusChangeOnMouseDown) {
+      // Prevent focus changes due to clicking on status message.
+      event.preventDefault();
+    }
+  };
   constructor(delay: Delay = false, modal = false) {
     const element = document.createElement("li");
     this.element = element;
+    element.addEventListener("mousedown", this.handleMouseDown);
     if (delay === true) {
       delay = DEFAULT_STATUS_DELAY;
     }
@@ -122,10 +121,14 @@ export class StatusMessage {
       this.setVisible(true);
     }
   }
+  setPreventFocusChangeOnMouseDown(value: boolean) {
+    this.preventFocusChangeOnMouseDown = value;
+  }
   setModal(value: boolean) {
     if (value) {
       if (this.modalElementWrapper === undefined) {
         const modalElementWrapper = document.createElement("div");
+        modalElementWrapper.addEventListener("mousedown", this.handleMouseDown);
         const dismissModalElement = makeCloseButton({
           title: "Dismiss",
           onClick: () => {


### PR DESCRIPTION
This prior fix: https://github.com/google/neuroglancer/commit/9a20ef0e6cf791b9068c653348fb3a8ed0017b3a

prevents users from being able to click on select input elements that are in status messages. In the below link, if you press shift+a, the blending tool will become active and the select element won't respond to a click. I altered the prior fix to only preventDefault on mousedown for the interactive credentials provider status message.

https://neuroglancer-demo.appspot.com/#!%7B%22dimensions%22:%7B%22x%22:%5B8e-9%2C%22m%22%5D%2C%22y%22:%5B8e-9%2C%22m%22%5D%2C%22z%22:%5B8e-9%2C%22m%22%5D%7D%2C%22position%22:%5B17213.5%2C19862.5%2C20697.5%5D%2C%22crossSectionScale%22:1%2C%22projectionScale%22:65536%2C%22layers%22:%5B%7B%22type%22:%22image%22%2C%22source%22:%22gs://neuroglancer-janelia-flyem-hemibrain/emdata/clahe_yz/jpeg/%7Cneuroglancer-precomputed:%22%2C%22toolBindings%22:%7B%22A%22:%22blend%22%7D%2C%22tab%22:%22rendering%22%2C%22name%22:%22jpeg%22%7D%5D%2C%22selectedLayer%22:%7B%22visible%22:true%2C%22layer%22:%22jpeg%22%7D%2C%22layout%22:%22xy%22%7D