### PR TITLE
fix: prevent fork artifact deployment in workflow_run deploy jobs

### DIFF
--- a/.github/workflows/deploy_docs_preview.yml
+++ b/.github/workflows/deploy_docs_preview.yml
@@ -10,7 +10,11 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       statuses: write
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    # Only deploy previews built from the base repository, not from forks.
+    # Without this check, a fork PR's build artifact could be deployed using
+    # the FIREBASE_HOSTING_SERVICE_ACCOUNT_KEY secret (workflow_run runs in
+    # the base repo context even when triggered by a fork's build workflow).
+    if: ${{ github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.head_repository.full_name == github.repository }}
     steps:
       - name: "Create commit status"
         uses: actions/github-script@v7

--- a/.github/workflows/deploy_preview.yml
+++ b/.github/workflows/deploy_preview.yml
@@ -10,7 +10,11 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       statuses: write
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    # Only deploy previews built from the base repository, not from forks.
+    # Without this check, a fork PR's build artifact could be deployed using
+    # the FIREBASE_HOSTING_SERVICE_ACCOUNT_KEY secret (workflow_run runs in
+    # the base repo context even when triggered by a fork's build workflow).
+    if: ${{ github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.head_repository.full_name == github.repository }}
     steps:
       - name: "Create commit status"
         uses: actions/github-script@v7


### PR DESCRIPTION
## Summary

`deploy_preview.yml` and `deploy_docs_preview.yml` use `on: workflow_run` to deploy Firebase Hosting previews after a build completes. Because `workflow_run` always runs in the **base repository's context** (with access to `FIREBASE_HOSTING_SERVICE_ACCOUNT_KEY`), a build triggered by a fork PR's `pull_request` workflow will also trigger the deploy — meaning fork-contributed code is deployed to `neuroglancer-demo.web.app` using the production Firebase service account.

This PR adds a single-condition guard to both deploy jobs:

```yaml
if: ${{ github.event.workflow_run.conclusion == 'success' &&
        github.event.workflow_run.head_repository.full_name == github.repository }}
```

`head_repository.full_name` is `google/neuroglancer` for commits on the main repo and `<fork-owner>/neuroglancer` for fork PRs. The added condition means the deploy step is skipped for all fork-originated builds.

## Files changed

- `.github/workflows/deploy_preview.yml` — added `head_repository` guard to `deploy` job `if:` condition
- `.github/workflows/deploy_docs_preview.yml` — same fix

## Testing

Existing PR previews from collaborators (non-forks) continue to work — `head_repository.full_name == github.repository` is true for direct pushes and PRs from branches within `google/neuroglancer`.