### PR TITLE
fix(python): pin uv to 0.11.6 for job "python-build-package"

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -185,6 +185,7 @@ jobs:
       - uses: astral-sh/setup-uv@v7
         with:
           enable-cache: false
+          version: "0.11.6"
       - name: Get uv cache dir
         id: uv-cache
         run: |


### PR DESCRIPTION
Pinning until https://github.com/astral-sh/uv/issues/19080 is resolved and we should consider keeping it pinned with manual updates

~Testing a few things, this disables uv for windows, looking for the right fix.~

this action started failing with uv 0.11.7, downgrading to 0.11.6 fixed it

https://github.com/astral-sh/uv/releases/tag/0.11.7


```
2026-04-17T15:39:16.6896384Z ##[group]Building wheel...
2026-04-17T15:39:16.6896551Z 
2026-04-17T15:39:16.6899160Z + python -m build 'D:\a\neuroglancer\neuroglancer' --wheel '--outdir=C:\Users\runneradmin\AppData\Local\Temp\cibw-run-x7c6an0w\cp311-win_amd64\built_wheel' --installer=uv
2026-04-17T15:39:16.7561429Z Could not import runpy module
2026-04-17T15:39:16.7561944Z Traceback (most recent call last):
2026-04-17T15:39:16.7562498Z   File "<frozen importlib._bootstrap>", line 1176, in _find_and_load
2026-04-17T15:39:16.7563592Z   File "<frozen importlib._bootstrap>", line 1147, in _find_and_load_unlocked
2026-04-17T15:39:16.7564309Z   File "<frozen importlib._bootstrap>", line 690, in _load_unlocked
2026-04-17T15:39:16.7564951Z   File "<frozen importlib._bootstrap>", line 980, in exec_module
2026-04-17T15:39:16.7565443Z   File "<frozen runpy>", line 15, in <module>
2026-04-17T15:39:16.7565959Z   File "<frozen importlib._bootstrap>", line 1176, in _find_and_load
2026-04-17T15:39:16.7566841Z   File "<frozen importlib._bootstrap>", line 1147, in _find_and_load_unlocked
2026-04-17T15:39:16.7567477Z   File "<frozen importlib._bootstrap>", line 690, in _load_unlocked
2026-04-17T15:39:16.7568060Z   File "<frozen importlib._bootstrap>", line 980, in exec_module
2026-04-17T15:39:16.7568589Z   File "<frozen importlib.util>", line 18, in <module>
2026-04-17T15:39:16.7569316Z   File "D:\a\_temp\uv-python-dir\cpython-3.13-windows-x86_64-none\Lib\threading.py", line 35, in <module>
2026-04-17T15:39:16.7570048Z     _start_joinable_thread = _thread.start_joinable_thread
2026-04-17T15:39:16.7570497Z                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
2026-04-17T15:39:16.7571090Z AttributeError: module '_thread' has no attribute 'start_joinable_thread'
2026-04-17T15:39:16.8002635Z ##[endgroup]
2026-04-17T15:39:16.8003449Z                                                               [31m✕ [0m0.11s
2026-04-17T15:39:16.8008722Z ##[error]cibuildwheel: Command ['C:\\Users\\runneradmin\\AppData\\Local\\Temp\\cibw-run-x7c6an0w\\cp311-win_amd64\\build\\venv\\Scripts\\python.EXE', '-m', 'build', 'D:\\a\\neuroglancer\\neuroglancer', '--wheel', '--outdir=C:\\Users\\runneradmin\\AppData\\Local\\Temp\\cibw-run-x7c6an0w\\cp311-win_amd64\\built_wheel', '--installer=uv'] failed with code 1. 
2026-04-17T15:39:16.8010978Z 
2026-04-17T15:39:16.8419980Z nox > Command uv run --only-group cibuildwheel cibuildwheel --output-dir dist failed with exit code 1
2026-04-17T15:39:16.8420698Z nox > Session cibuildwheel failed.
```