### PR TITLE
fix: load omero metadata for NGFF 0.5 data

### DIFF
--- a/src/datasource/zarr/ome.ts
+++ b/src/datasource/zarr/ome.ts
@@ -729,7 +729,7 @@ export function parseOmeMetadata(
 ): OmeMetadata | undefined {
   const ome = attrs.ome;
   const multiscales = ome == undefined ? attrs.multiscales : ome.multiscales; // >0.4
-  const omero = attrs.omero;
+  const omero = ome == undefined ? attrs.omero : ome.omero; // >0.4
 
   if (!Array.isArray(multiscales)) return undefined;
   const errors: string[] = [];

--- a/src/datasource/zarr/ome.ts
+++ b/src/datasource/zarr/ome.ts
@@ -727,9 +727,9 @@ export function parseOmeMetadata(
   attrs: any,
   zarrVersion: number,
 ): OmeMetadata | undefined {
-  const ome = attrs.ome;
-  const multiscales = ome == undefined ? attrs.multiscales : ome.multiscales; // >0.4
-  const omero = ome == undefined ? attrs.omero : ome.omero; // >0.4
+  const { ome } = attrs;
+  const metadata = ome ?? attrs; // 0.5+ nests under `ome`; 0.4 keeps fields at root
+  const { multiscales, omero } = metadata;
 
   if (!Array.isArray(multiscales)) return undefined;
   const errors: string[] = [];
@@ -743,7 +743,7 @@ export function parseOmeMetadata(
       return undefined;
     }
 
-    const version = ome == undefined ? multiscale.version : ome.version; // >0.4
+    const version = ome?.version ?? multiscale.version; // 0.5+ moved version onto `ome`
 
     if (version === undefined) return undefined;
     if (!SUPPORTED_OME_MULTISCALE_VERSIONS.has(version)) {


### PR DESCRIPTION
This PR fixes #959 which prevents [transitional OMERO metadata](https://ngff.openmicroscopy.org/specifications/0.5/index.html#omero-metadata-transitional) from being correctly loaded for NGFF 0.5. 

Previously `parseOmeMetadata` read `multiscales` from either `attrs.ome.multiscales` (v0.5+) or `attrs.multiscales` (≤v0.4), but always read `omero` from `attrs.omero`. As a result, channel rendering metadata (colors, windows, labels) was silently dropped for OME-Zarr 0.5 datasets.

This PR mirrors the existing `multiscales` pattern for `omero`.

@StephanPreibisch @mkitti 
