### PR TITLE
fix: add channels correctly for auto layers

### DIFF
--- a/src/layer/multi_channel_setup.ts
+++ b/src/layer/multi_channel_setup.ts
@@ -379,6 +379,7 @@ export function createImageLayerAsMultiChannel(
       "Input omera metadata is not set up correctly. Colors are either missing or all close to black, and all ranges are the same or missing. Using default values for display purposes.",
     );
   }
+  const newChannelLayers: ManagedUserLayer[] = [];
   for (let i = 0; i < totalLocalChannels; i++) {
     const channelMetadata = getLayerChannelMetadata(managedLayer, i);
     const { localPosition, chanName } = getAdjustedLocalPositionAndName(i);
@@ -405,6 +406,7 @@ export function createImageLayerAsMultiChannel(
         parentIndex !== -1 ? parentIndex + i : undefined,
       );
       addedLayer = newLayer;
+      newChannelLayers.push(newLayer);
     }
     setupLayerPostCreation(
       addedLayer,
@@ -415,8 +417,31 @@ export function createImageLayerAsMultiChannel(
       ignoreInputMetadata,
     );
   }
-  if (isTopLevelLayerListManager(managedLayer.manager)) {
-    managedLayer.manager.display.multiChannelSetupFinished.dispatch();
+  // Propagate new channel layers to all layer group subsets that contain the
+  // original managed layer.  The initial manager.add() above only adds to
+  // one manager (the layer's own manager and, if it is a subset, its owner).
+  // Other subsets referencing the original layer must be updated individually.
+  if (newChannelLayers.length > 0) {
+    const root = managedLayer.manager.root;
+    for (const subset of root.subsets) {
+      // Skip the subset that is the current manager (already handled above).
+      if (subset === managedLayer.manager) continue;
+      const subsetIndex =
+        subset.layerManager.managedLayers.indexOf(managedLayer);
+      if (subsetIndex === -1) continue;
+      for (let j = 0; j < newChannelLayers.length; j++) {
+        subset.layerManager.addManagedLayer(
+          newChannelLayers[j].addRef(),
+          subsetIndex + 1 + j,
+        );
+      }
+    }
+  }
+  // Use the root manager for the multiChannelSetupFinished signal since the
+  // layer's own manager may be a LayerSubsetSpecification without `display`.
+  const root = managedLayer.manager.root;
+  if (isTopLevelLayerListManager(root)) {
+    root.display.multiChannelSetupFinished.dispatch();
   }
   postCreationSetupFunctions.forEach((fn) => fn());
   reverseGlobalDimOrderIfNeeded(managedLayer);

--- a/src/layer/multi_channel_setup.ts
+++ b/src/layer/multi_channel_setup.ts
@@ -417,14 +417,13 @@ export function createImageLayerAsMultiChannel(
       ignoreInputMetadata,
     );
   }
-  // Propagate new channel layers to all layer group subsets that contain the
-  // original managed layer.  The initial manager.add() above only adds to
-  // one manager (the layer's own manager and, if it is a subset, its owner).
-  // Other subsets referencing the original layer must be updated individually.
+  // Propagate new channel layers to all layer group subsets that contain the original managed layer
+  // The initial manager.add() above only adds to the layer's own manager and its owner
+  // Update other subsets referencing the original layer
   if (newChannelLayers.length > 0) {
     const root = managedLayer.manager.root;
     for (const subset of root.subsets) {
-      // Skip the subset that is the current manager (already handled above).
+      // Skip the subset that is the current manager
       if (subset === managedLayer.manager) continue;
       const subsetIndex =
         subset.layerManager.managedLayers.indexOf(managedLayer);
@@ -437,8 +436,6 @@ export function createImageLayerAsMultiChannel(
       }
     }
   }
-  // Use the root manager for the multiChannelSetupFinished signal since the
-  // layer's own manager may be a LayerSubsetSpecification without `display`.
   const root = managedLayer.manager.root;
   if (isTopLevelLayerListManager(root)) {
     root.display.multiChannelSetupFinished.dispatch();

--- a/src/layer/multi_channel_setup.ts
+++ b/src/layer/multi_channel_setup.ts
@@ -408,7 +408,7 @@ export function createImageLayerAsMultiChannel(
   // Propagate new channel layers to all layer group subsets that contain the original managed layer
   // The initial manager.add() above only adds to the layer's own manager and its owner
   // Update other subsets referencing the original layer
-  const { root } = managedLayer.manager.root;
+  const { root } = managedLayer.manager;
   if (newChannelLayers.length > 0) {
     for (const subset of root.subsets) {
       // Skip the subset that is the current manager

--- a/src/layer/multi_channel_setup.ts
+++ b/src/layer/multi_channel_setup.ts
@@ -20,7 +20,6 @@ import {
   permuteCoordinateSpace,
 } from "#src/coordinate_transform.js";
 import type { SingleChannelMetadata } from "#src/datasource/index.js";
-import type { DisplayContext } from "#src/display_context.js";
 import type { ImageUserLayer } from "#src/layer/image/index.js";
 import {
   type LayerListSpecification,
@@ -33,17 +32,6 @@ import type { Borrowed } from "#src/util/disposable.js";
 import type { vec3 } from "#src/util/geom.js";
 import { dataTypeIntervalEqual, defaultDataTypeRange } from "#src/util/lerp.js";
 import type { ShaderImageInvlerpControl } from "#src/webgl/shader_ui_controls.js";
-
-function isTopLevelLayerListManager(
-  x: LayerListSpecification,
-): x is LayerListSpecification & { display: DisplayContext } {
-  const display = (x as any).display as DisplayContext | undefined;
-
-  return (
-    !!display &&
-    typeof (display as any).multiChannelSetupFinished?.dispatch === "function"
-  );
-}
 
 function changeLayerName(managedLayer: ManagedUserLayer, newName: string) {
   newName = managedLayer.manager.root.layerManager.getUniqueLayerName(newName);
@@ -420,8 +408,8 @@ export function createImageLayerAsMultiChannel(
   // Propagate new channel layers to all layer group subsets that contain the original managed layer
   // The initial manager.add() above only adds to the layer's own manager and its owner
   // Update other subsets referencing the original layer
+  const { root } = managedLayer.manager.root;
   if (newChannelLayers.length > 0) {
-    const root = managedLayer.manager.root;
     for (const subset of root.subsets) {
       // Skip the subset that is the current manager
       if (subset === managedLayer.manager) continue;
@@ -436,10 +424,7 @@ export function createImageLayerAsMultiChannel(
       }
     }
   }
-  const root = managedLayer.manager.root;
-  if (isTopLevelLayerListManager(root)) {
-    root.display.multiChannelSetupFinished.dispatch();
-  }
+  root.display.multiChannelSetupFinished.dispatch();
   postCreationSetupFunctions.forEach((fn) => fn());
   reverseGlobalDimOrderIfNeeded(managedLayer);
 }


### PR DESCRIPTION
[Original Issue](https://github.com/google/neuroglancer/issues/931)

This PR aims to fix adding channels to all layer groups that reference a newly added layer. We do this by propagating all channel layers to all layers that contain the original layer.

JSON to test with:
```json
{
  "layers": [
    {
      "type": "auto",
      "source": "https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.4/idr0079A/idr0079_images.zarr/0",
      "name": "image"
    },
    {
      "type": "segmentation",
      "source": "https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.4/idr0079A/idr0079_images.zarr/0/labels/0",
      "name": "labels"
    }
  ],
  "layout": {
    "type": "row",
    "children": [
      {
        "type": "viewer",
        "layers": ["image"],
        "layout": "xy"
      },
      {
        "type": "viewer",
        "layers": ["labels"],
        "layout": "xy"
      }
    ]
  }
}
```