### PR TITLE
Feedback requested - url rate limit function

### DIFF
--- a/src/main_python.ts
+++ b/src/main_python.ts
@@ -147,12 +147,7 @@ configState.add("volumeRequests", volumeHandler.requestState);
 let sharedState: Trackable | undefined = viewer.state;
 
 if (window.location.hash) {
-  const hashBinding = viewer.registerDisposer(
-    new UrlHashBinding(
-      viewer.state,
-      viewer.dataSourceProvider.sharedKvStoreContext,
-    ),
-  );
+  const hashBinding = viewer.registerDisposer(new UrlHashBinding(viewer));
   hashBinding.updateFromUrlHash();
   sharedState = undefined;
 }

--- a/src/ui/default_viewer_setup.ts
+++ b/src/ui/default_viewer_setup.ts
@@ -35,16 +35,12 @@ export function setupDefaultViewer(options?: Partial<MinimalViewerOptions>) {
   setDefaultInputEventBindings(viewer.inputEventBindings);
 
   const hashBinding = viewer.registerDisposer(
-    new UrlHashBinding(
-      viewer.state,
-      viewer.dataSourceProvider.sharedKvStoreContext,
-      {
-        defaultFragment:
-          typeof NEUROGLANCER_DEFAULT_STATE_FRAGMENT !== "undefined"
-            ? NEUROGLANCER_DEFAULT_STATE_FRAGMENT
-            : undefined,
-      },
-    ),
+    new UrlHashBinding(viewer, {
+      defaultFragment:
+        typeof NEUROGLANCER_DEFAULT_STATE_FRAGMENT !== "undefined"
+          ? NEUROGLANCER_DEFAULT_STATE_FRAGMENT
+          : undefined,
+    }),
   );
   viewer.registerDisposer(
     hashBinding.parseError.changed.add(() => {

--- a/src/ui/url_hash_binding.ts
+++ b/src/ui/url_hash_binding.ts
@@ -14,18 +14,17 @@
  * limitations under the License.
  */
 
-import { debounce } from "lodash-es";
-import type { SharedKvStoreContext } from "#src/kvstore/frontend.js";
 import { StatusMessage } from "#src/status.js";
 import { WatchableValue } from "#src/trackable_value.js";
+import { dynamicDebounce } from "#src/util/debounce.js";
 import { RefCounted } from "#src/util/disposable.js";
 import {
   bigintToStringJsonReplacer,
   urlSafeParse,
   verifyObject,
 } from "#src/util/json.js";
-import type { Trackable } from "#src/util/trackable.js";
 import { getCachedJson } from "#src/util/trackable.js";
+import type { Viewer } from "#src/viewer.js";
 
 /**
  * @file Implements a binding between a Trackable value and the URL hash state.
@@ -68,25 +67,97 @@ export class UrlHashBinding extends RefCounted {
 
   private defaultFragment: string;
 
+  get root() {
+    return this.viewer.state;
+  }
+
+  get sharedKvStoreContext() {
+    return this.viewer.dataSourceProvider.sharedKvStoreContext;
+  }
+
+  urlHashRateLimit = new WatchableValue(200);
+
   constructor(
-    public root: Trackable,
-    public sharedKvStoreContext: SharedKvStoreContext,
+    public viewer: Viewer,
+    // public root: Trackable,
+    // public sharedKvStoreContext: SharedKvStoreContext,
     options: UrlHashBindingOptions = {},
   ) {
     super();
-    const { updateDelayMilliseconds = 200, defaultFragment = "{}" } = options;
+    const { defaultFragment = "{}" } = options;
     this.registerEventListener(window, "hashchange", () =>
       this.updateFromUrlHash(),
     );
-    const throttledSetUrlHash = debounce(
-      () => this.setUrlHash(),
-      updateDelayMilliseconds,
-      { maxWait: updateDelayMilliseconds * 2 },
+    const throttledSetUrlHash = this.registerDisposer(
+      dynamicDebounce(
+        () => this.setUrlHash(),
+        this.urlHashRateLimit,
+        (wait) => ({ maxWait: wait }),
+      ),
     );
-    this.registerDisposer(root.changed.add(throttledSetUrlHash));
-    this.registerDisposer(() => throttledSetUrlHash.cancel());
+    this.registerDisposer(this.root.changed.add(throttledSetUrlHash));
+    // try to update the url before the user might attempt to be copying it
+    window.addEventListener("blur", () => {
+      throttledSetUrlHash.flush();
+    });
+    // mouseleave works better (occurs earlier) than blur
+    document.addEventListener("mouseleave", () => {
+      throttledSetUrlHash.flush();
+    });
+    // update url for the select url shortcut (ctrl+l/cmd+l)
+    // select url triggers the blur event, but for chrome, it occurs too late for the url to be updated
+    // alo testing out ctrl+s/cmd+s to update url
+    window.addEventListener("keydown", (event) => {
+      if (event.key === "l") {
+        throttledSetUrlHash.flush();
+      }
+      if ((event.ctrlKey || event.metaKey) && event.key === "s") {
+        event.preventDefault();
+        throttledSetUrlHash.flush();
+      }
+    });
     this.defaultFragment = defaultFragment;
+    this.viewer.urlHashRateLimit.changed.add(this.updateRateLimit);
+
+    this.registerDisposer(
+      this.viewer.saveStateSession.changed.add(() => {
+        throttledSetUrlHash.flush();
+      }),
+    );
+
+    window.addEventListener("beforeunload", () => {
+      if (!this.viewer.saveStateSession.value) return;
+      const cacheState = getCachedJson(this.root);
+      const stateString = JSON.stringify(
+        cacheState.value,
+        bigintToStringJsonReplacer,
+      );
+      window.sessionStorage.setItem("state", stateString);
+    });
   }
+
+  updateRateLimit = () => {
+    const debugEl =
+      document.body.querySelector("#debug-url-rate") ??
+      document.body.appendChild(document.createElement("div"));
+    debugEl.id = "debug-url-rate";
+
+    const userFunc = this.viewer.urlHashRateLimit.value;
+    const safeFunc = /^[xelogmaxin ,*/+\-\d()]*$/;
+    if (safeFunc.test(userFunc)) {
+      const translatedFunc = userFunc
+        .replaceAll("log", "Math.log")
+        .replaceAll("min", "Math.min")
+        .replaceAll("max", "Math.max")
+        .replaceAll("e", "Math.E");
+      this.urlHashRateLimit.value = eval(
+        `'use strict';(x) => ${translatedFunc}`,
+      )(this.prevStateString?.length ?? 0);
+      debugEl.textContent = `URL rate: ${(this.urlHashRateLimit.value / 1000).toFixed(1)} s (state size (x)=${this.prevStateString?.length ?? 0}, f=${this.viewer.urlHashRateLimit.value})`;
+    } else {
+      debugEl.textContent = `URL rate: INVALID FUNCTION (${userFunc})`;
+    }
+  };
 
   /**
    * Sets the URL hash to match the current state.
@@ -101,6 +172,8 @@ export class UrlHashBinding extends RefCounted {
       );
       if (stateString !== this.prevStateString) {
         this.prevStateString = stateString;
+        this.updateRateLimit();
+        StatusMessage.showTemporaryMessage(`URL updated! (debug)`);
         if (decodeURIComponent(stateString) === "{}") {
           history.replaceState(null, "", "#");
         } else {
@@ -115,6 +188,8 @@ export class UrlHashBinding extends RefCounted {
    * on the URL hash, then this should be called immediately after construction.
    */
   updateFromUrlHash() {
+    const sessionStateString = window.sessionStorage.getItem("state");
+    window.sessionStorage.removeItem("state");
     try {
       let s = location.href.replace(/^[^#]+/, "");
       if (s === "" || s === "#" || s === "#!") {
@@ -137,6 +212,12 @@ export class UrlHashBinding extends RefCounted {
             errorPrefix: "Error loading state:",
           },
         );
+      } else if (sessionStateString) {
+        const json = JSON.parse(sessionStateString);
+        this.prevStateString = encodeFragment(json);
+        verifyObject(json);
+        this.root.reset();
+        this.root.restoreState(json);
       } else if (s.startsWith("#!+")) {
         s = s.slice(3);
         // Firefox always %-encodes the URL even if it is not typed that way.

--- a/src/ui/viewer_settings.css
+++ b/src/ui/viewer_settings.css
@@ -68,3 +68,15 @@
 .neuroglancer-settings-limit-widget > input {
   width: 11ch;
 }
+
+#debug-url-rate {
+  position: fixed;
+  bottom: 0;
+  right: 0;
+  background-color: rgba(0, 0, 0, 0.5);
+  color: white;
+  font-size: 12pt;
+  padding: 2px;
+  z-index: 1000;
+  font-family: monospace;
+}

--- a/src/ui/viewer_settings.ts
+++ b/src/ui/viewer_settings.ts
@@ -102,6 +102,19 @@ export class ViewerSettingsPanel extends SidePanel {
       "Concurrent chunk requests",
       viewer.chunkQueueManager.capacities.download.itemLimit,
     );
+    // addLimitWidget("Url update rate limit function", viewer.urlHashRateLimit);
+    {
+      const label = document.createElement("div");
+      label.textContent = "Url update rate limit function";
+      label.classList.add("neuroglancer-settings-limit-widget");
+      scroll.appendChild(label);
+      const titleWidget = this.registerDisposer(
+        new TextInputWidget(viewer.urlHashRateLimit),
+      );
+      titleWidget.element.placeholder = "Url update rate limit function";
+      titleWidget.element.classList.add("neuroglancer-settings-title");
+      scroll.appendChild(titleWidget.element);
+    }
 
     const addCheckbox = (
       label: string,
@@ -115,6 +128,7 @@ export class ViewerSettingsPanel extends SidePanel {
       labelElement.appendChild(checkbox.element);
       scroll.appendChild(labelElement);
     };
+    addCheckbox("Save state before refresh", viewer.saveStateSession);
     addCheckbox("Show axis lines", viewer.showAxisLines);
     addCheckbox("Show scale bar", viewer.showScaleBar);
     addCheckbox("Show cross sections in 3-d", viewer.showPerspectiveSliceViews);

--- a/src/util/debounce.ts
+++ b/src/util/debounce.ts
@@ -1,0 +1,50 @@
+/**
+ * @license
+ * Copyright 2025 Google Inc.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { DebouncedFunc, DebounceSettings } from "lodash-es";
+import { debounce } from "lodash-es";
+import type { WatchableValue } from "#src/trackable_value.js";
+
+export function dynamicDebounce<T extends (...args: any) => any>(
+  func: T,
+  wait: WatchableValue<number>,
+  options?: (wait: number) => DebounceSettings,
+) {
+  let debouncedFunc: DebouncedFunc<T> | undefined = undefined;
+  const updateDebounce = () => {
+    debouncedFunc?.flush(); // or cancel
+    debouncedFunc = debounce(func, wait.value, options?.(wait.value));
+  };
+  const unregister = wait.changed.add(updateDebounce);
+  updateDebounce();
+  return Object.assign(
+    (...args: Parameters<T>) => {
+      return debouncedFunc!(...args);
+    },
+    {
+      cancel: () => {
+        debouncedFunc?.cancel();
+      },
+      dispose: () => {
+        debouncedFunc?.cancel();
+        unregister();
+      },
+      flush: () => {
+        debouncedFunc?.flush();
+      },
+    },
+  );
+}

--- a/src/viewer.ts
+++ b/src/viewer.ts
@@ -259,6 +259,8 @@ class TrackableViewerState extends CompoundTrackable {
     this.add("projectionScale", viewer.projectionScale);
     this.add("projectionDepth", viewer.projectionDepthRange);
     this.add("layers", viewer.layerSpecification);
+    this.add("urlHashRateLimit", viewer.urlHashRateLimit);
+    this.add("saveStateSession", viewer.saveStateSession);
     this.add("showAxisLines", viewer.showAxisLines);
     this.add("wireFrame", viewer.wireFrame);
     this.add("enableAdaptiveDownsampling", viewer.enableAdaptiveDownsampling);
@@ -433,6 +435,8 @@ export class Viewer extends RefCounted implements ViewerState {
   selectedLayer = this.registerDisposer(
     new SelectedLayerState(this.layerManager.addRef()),
   );
+  urlHashRateLimit = new TrackableValue<string>("x", verifyString);
+  saveStateSession = new TrackableBoolean(false, false);
   showAxisLines = new TrackableBoolean(true, true);
   wireFrame = new TrackableBoolean(false, false);
   enableAdaptiveDownsampling = new TrackableBoolean(true, true);


### PR DESCRIPTION
deployment - https://neuroglancer--pr975-g10oyxt3.web.app

This branch is set up to get user feedback on a proposed rate limiting function based on the size of the state (based on string length)

The value returned is in ms so using the default rate limit function `f(x) = x`, a string 1000 characters long will update at most once per second (less if there is no state change).

Currently the implementation only the following update interval when the state size changes. If the user changes the rate limit function, it issues an immediate state update and then immediately the new rate limit. This could be changed so that state changes could extend or decrease the current active interval.

In addition to the rate limit function, Neuroglancer will also update the state when you move your mouse to click in the address bar or if you press the default keybind to select the url (ctrl+L / cmd+L). The point of this is to update the url whenever you try to copy it from the address bar. Unfortunately those were the only reliable ways to trigger an update in time. If a user changes the keybind for selecting the url, this code won't react to that.

The rate limit function can be changed in the user settings. This is only there for gathering feedback.
<img width="305" height="170" alt="Screenshot 2026-05-01 at 2 09 05 PM" src="https://github.com/user-attachments/assets/7215be4b-5ce6-418a-83a5-813d27a518dc" />

Below that is an additional option "Save state before refresh" This is disabled by default, it ensures the state is saved before performing a refresh. Both this and the attempt to update before manually copying the url from the address bar are designed to be useful for very large states where the update rate needs to be high to prevent issues with the chrome browser.

In order to analyze performance of the rate limit function, there is a status bar message at the bottom that will appear every time a url is updated
<img width="302" height="145" alt="Screenshot 2026-05-01 at 2 18 40 PM" src="https://github.com/user-attachments/assets/69aa84d5-beb3-4e13-be8c-20521464e32f" />

There is also a debug message in the bottom right containing information about the current rate limit value in seconds, size of the state, and the rate limit function:
```
URL rate: 0.2 s (state size (x)=221, f=x)
```

