### PR TITLE
doc: Add gallery page to documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,28 +11,15 @@ Refer to the documentation website at https://neuroglancer-docs.web.app for more
 
 This is not an official Google product.
 
-# Examples
+# Getting started
 
 A live demo is hosted at <https://neuroglancer-demo.appspot.com>. (The prior link opens the viewer without any preloaded dataset.) Use the viewer links below to open the viewer preloaded with an example dataset.
 
 The four-pane view consists of 3 orthogonal cross-sectional views as well as a 3-D view (with independent orientation) that displays 3-D models (if available) for the selected objects. All four views maintain the same center position. The orientation of the 3 cross-sectional views can also be adjusted, although they maintain a fixed orientation relative to each other. (Try holding the shift key and either dragging with the left mouse button or pressing an arrow key.)
 
-- [FlyEM Hemibrain](https://www.janelia.org/project-team/flyem/hemibrain) (8x8x8 cubic nanometer resolution). <a href="https://hemibrain-dot-neuroglancer-demo.appspot.com/#!gs://neuroglancer-janelia-flyem-hemibrain/v1.0/neuroglancer_demo_states/base.json" target="_blank">Open viewer</a>
+# Examples
 
-- [FAFB-FFN1 Full Adult Fly Brain Automated Segmentation](https://fafb-ffn1.storage.googleapis.com/landing.html) (4x4x40 cubic nanometer resolution). <a href="https://neuroglancer-demo.appspot.com/fafb.html#!gs://fafb-ffn1/main_ng.json" target="_blank">Open viewer</a>
-
-- Kasthuri et al., 2014. Mouse somatosensory cortex (6x6x30 cubic nanometer resolution). <a href="https://neuroglancer-demo.appspot.com/#!{'layers':{'original-image':{'type':'image'_'source':'precomputed://gs://neuroglancer-public-data/kasthuri2011/image'_'visible':false}_'corrected-image':{'type':'image'_'source':'precomputed://gs://neuroglancer-public-data/kasthuri2011/image_color_corrected'}_'ground_truth':{'type':'segmentation'_'source':'precomputed://gs://neuroglancer-public-data/kasthuri2011/ground_truth'_'selectedAlpha':0.63_'notSelectedAlpha':0.14_'segments':['3208'_'4901'_'13'_'4965'_'4651'_'2282'_'3189'_'3758'_'15'_'4027'_'3228'_'444'_'3207'_'3224'_'3710']}}_'navigation':{'pose':{'position':{'voxelSize':[6_6_30]_'voxelCoordinates':[5523.99072265625_8538.9384765625_1198.0423583984375]}}_'zoomFactor':22.573112129999547}_'perspectiveOrientation':[-0.004047565162181854_-0.9566211104393005_-0.2268827110528946_-0.1827099621295929]_'perspectiveZoom':340.35867907175077}" target="_blank">Open viewer.</a>
-
-  This dataset was copied from <https://neurodata.io/data/kasthuri15/> and is made available under the [Open Data Common Attribution License](http://opendatacommons.org/licenses/by/1.0/). Paper: <a href="http://dx.doi.org/10.1016/j.cell.2015.06.054" target="_blank">Kasthuri, Narayanan, et al. "Saturated reconstruction of a volume of neocortex." Cell 162.3 (2015): 648-661.</a>
-
-- Janelia FlyEM FIB-25. 7-column Drosophila medulla (8x8x8 cubic nanometer resolution). <a href="https://neuroglancer-demo.appspot.com/#!{'layers':{'image':{'type':'image'_'source':'precomputed://gs://neuroglancer-public-data/flyem_fib-25/image'}_'ground-truth':{'type':'segmentation'_'source':'precomputed://gs://neuroglancer-public-data/flyem_fib-25/ground_truth'_'segments':['21894'_'22060'_'158571'_'24436'_'2515']}}_'navigation':{'pose':{'position':{'voxelSize':[8_8_8]_'voxelCoordinates':[2914.500732421875_3088.243408203125_4045]}}_'zoomFactor':30.09748283999932}_'perspectiveOrientation':[0.3143535554409027_0.8142156600952148_0.4843369424343109_-0.06040262430906296]_'perspectiveZoom':443.63404517712684_'showSlices':false}" target="_blank">Open viewer.</a>
-
-  This dataset was copied from <https://www.janelia.org/project-team/flyem/data-and-software-release>, and is made available under the [Open Data Common Attribution License](http://opendatacommons.org/licenses/by/1.0/). Paper: <a href="http://dx.doi.org/10.1073/pnas.1509820112" target="_blank">Takemura, Shin-ya et al. "Synaptic Circuits and Their Variations within Different Columns in the Visual System of Drosophila." Proceedings of the National Academy of Sciences of the United States of America 112.44 (2015): 13711-13716.</a>
-
-- Example of viewing 2D microscopy (coronal section of rat brain at 325 nanometer resolution). <a href="https://neuroglancer-demo.appspot.com/#!%7B%22dimensions%22:%7B%22x%22:%5B1e-9%2C%22m%22%5D%2C%22y%22:%5B1e-9%2C%22m%22%5D%7D%2C%22position%22:%5B10387071%2C5347131%5D%2C%22crossSectionScale%22:263.74955563693914%2C%22projectionScale%22:65536%2C%22layers%22:%5B%7B%22type%22:%22image%22%2C%22source%22:%7B%22url%22:%22deepzoom://https://data-proxy.ebrains.eu/api/v1/buckets/localizoom/14122_mPPC_BDA_s186.tif/14122_mPPC_BDA_s186.dzi%22%2C%22transform%22:%7B%22outputDimensions%22:%7B%22x%22:%5B1e-9%2C%22m%22%5D%2C%22y%22:%5B1e-9%2C%22m%22%5D%2C%22c%5E%22:%5B1%2C%22%22%5D%7D%2C%22inputDimensions%22:%7B%22x%22:%5B3.25e-7%2C%22m%22%5D%2C%22y%22:%5B3.25e-7%2C%22m%22%5D%2C%22c%5E%22:%5B1%2C%22%22%5D%7D%7D%7D%2C%22tab%22:%22rendering%22%2C%22shader%22:%22void%20main%28%29%7BemitRGB%28vec3%28toNormalized%28getDataValue%280%29%29%2CtoNormalized%28getDataValue%281%29%29%2CtoNormalized%28getDataValue%282%29%29%29%29%3B%7D%22%2C%22channelDimensions%22:%7B%22c%5E%22:%5B1%2C%22%22%5D%7D%2C%22name%22:%2214122_mPPC_BDA_s186.dzi%22%7D%5D%2C%22selectedLayer%22:%7B%22layer%22:%2214122_mPPC_BDA_s186.dzi%22%7D%2C%22layout%22:%22xy%22%7D"
-  target="_blank">Open viewer.</a> (Use <kbd>Ctrl</kbd>+<kbd>MouseWheel</kbd> to zoom out)
-
-  This image is part of: Olsen et al., 2020. Anterogradely labeled axonal projections from the posterior parietal cortex in rat [Data set]. EBRAINS. <https://doi.org/10.25493/FKM4-ZCC>
+See the [Neuroglancer Gallery](https://neuroglancer-docs.web.app/gallery/index.html) for example data visualized in Neuroglancer.
 
 # Supported data sources
 

--- a/docs/gallery/index.rst
+++ b/docs/gallery/index.rst
@@ -1,0 +1,119 @@
+.. _gallery:
+
+.. role:: raw-html(raw)
+   :format: html
+
+A selection of public datasets pre-loaded in Neuroglancer.
+Interact with each embedded viewer directly, or click **Open in new tab**.
+
+----
+
+FlyEM Hemibrain
+---------------
+
+:raw-html:`<a href="https://www.janelia.org/project-team/flyem/hemibrain" target="_blank">FlyEM Hemibrain</a>` with 8x8x8 cubic nanometer resolution.
+
+.. raw:: html
+
+   <iframe
+     src="https://hemibrain-dot-neuroglancer-demo.appspot.com/#!gs://neuroglancer-janelia-flyem-hemibrain/v1.0/neuroglancer_demo_states/base.json"
+     width="100%"
+     height="500"
+     style="border: 1px solid #ccc; border-radius: 4px;"
+     allow="fullscreen"
+     loading="lazy"
+   ></iframe>
+
+   <a href="https://hemibrain-dot-neuroglancer-demo.appspot.com/#!gs://neuroglancer-janelia-flyem-hemibrain/v1.0/neuroglancer_demo_states/base.json" style="display: inline-block; margin-top: 0.5em; margin-bottom: 1.5em; padding: 0.4em 1em; border: 1px solid currentColor; border-radius: 4px; text-decoration: none; font-size: 0.8em;" target="_blank">Open in new tab ↗</a>
+
+----
+
+FAFB-FFN1 Full Adult Fly Brain Automated Segmentation
+-----------------------------------------------------
+
+:raw-html:`<a href="https://fafb-ffn1.storage.googleapis.com/landing.html" target="_blank">FAFB-FFN1 Full Adult Fly Brain Automated Segmentation</a>` with 4x4x40 cubic nanometer resolution.
+
+.. raw:: html
+
+   <iframe
+     src="https://neuroglancer-demo.appspot.com/fafb.html#!gs://fafb-ffn1/main_ng.json"
+     width="100%"
+     height="500"
+     style="border: 1px solid #ccc; border-radius: 4px;"
+     allow="fullscreen"
+     loading="lazy"
+   ></iframe>
+
+   <a href="https://neuroglancer-demo.appspot.com/fafb.html#!gs://fafb-ffn1/main_ng.json" style="display: inline-block; margin-top: 0.5em; margin-bottom: 1.5em; padding: 0.4em 1em; border: 1px solid currentColor; border-radius: 4px; text-decoration: none; font-size: 0.8em;" target="_blank">Open in new tab ↗</a>
+
+----
+
+Kasthuri et al., 2014 — Mouse Somatosensory Cortex
+--------------------------------------------------
+
+Kasthuri et al., 2014. Mouse somatosensory cortex with 6x6x30 cubic nanometer resolution.
+
+This dataset was copied from :raw-html:`<a href="https://neurodata.io/data/kasthuri15/" target="_blank">https://neurodata.io/data/kasthuri15/</a>` and is made available under the
+:raw-html:`<a href="http://opendatacommons.org/licenses/by/1.0/" target="_blank">Open Data Common Attribution License</a>`.
+Paper: :raw-html:`<a href="http://dx.doi.org/10.1016/j.cell.2015.06.054" target="_blank">Kasthuri, Narayanan, et al. Saturated reconstruction of a volume of neocortex. Cell 162.3 (2015): 648-661.</a>`
+
+.. raw:: html
+
+   <iframe
+     src="https://neuroglancer-demo.appspot.com/#!{'layers':{'original-image':{'type':'image'_'source':'precomputed://gs://neuroglancer-public-data/kasthuri2011/image'_'visible':false}_'corrected-image':{'type':'image'_'source':'precomputed://gs://neuroglancer-public-data/kasthuri2011/image_color_corrected'}_'ground_truth':{'type':'segmentation'_'source':'precomputed://gs://neuroglancer-public-data/kasthuri2011/ground_truth'_'selectedAlpha':0.63_'notSelectedAlpha':0.14_'segments':['3208'_'4901'_'13'_'4965'_'4651'_'2282'_'3189'_'3758'_'15'_'4027'_'3228'_'444'_'3207'_'3224'_'3710']}}_'navigation':{'pose':{'position':{'voxelSize':[6_6_30]_'voxelCoordinates':[5523.99072265625_8538.9384765625_1198.0423583984375]}}_'zoomFactor':22.573112129999547}_'perspectiveOrientation':[-0.004047565162181854_-0.9566211104393005_-0.2268827110528946_-0.1827099621295929]_'perspectiveZoom':340.35867907175077}"
+     width="100%"
+     height="500"
+     style="border: 1px solid #ccc; border-radius: 4px;"
+     allow="fullscreen"
+     loading="lazy"
+   ></iframe>
+
+   <a href="https://neuroglancer-demo.appspot.com/#!{'layers':{'original-image':{'type':'image'_'source':'precomputed://gs://neuroglancer-public-data/kasthuri2011/image'_'visible':false}_'corrected-image':{'type':'image'_'source':'precomputed://gs://neuroglancer-public-data/kasthuri2011/image_color_corrected'}_'ground_truth':{'type':'segmentation'_'source':'precomputed://gs://neuroglancer-public-data/kasthuri2011/ground_truth'_'selectedAlpha':0.63_'notSelectedAlpha':0.14_'segments':['3208'_'4901'_'13'_'4965'_'4651'_'2282'_'3189'_'3758'_'15'_'4027'_'3228'_'444'_'3207'_'3224'_'3710']}}_'navigation':{'pose':{'position':{'voxelSize':[6_6_30]_'voxelCoordinates':[5523.99072265625_8538.9384765625_1198.0423583984375]}}_'zoomFactor':22.573112129999547}_'perspectiveOrientation':[-0.004047565162181854_-0.9566211104393005_-0.2268827110528946_-0.1827099621295929]_'perspectiveZoom':340.35867907175077}" style="display: inline-block; margin-top: 0.5em; margin-bottom: 1.5em; padding: 0.4em 1em; border: 1px solid currentColor; border-radius: 4px; text-decoration: none; font-size: 0.8em;" target="_blank">Open in new tab ↗</a>
+
+----
+
+Janelia FlyEM FIB-25
+--------------------
+
+Seven-column Drosophila medulla with 8x8x8 cubic nanometer resolution.
+
+This dataset was copied from :raw-html:`<a href="https://www.janelia.org/project-team/flyem/data-and-software-release" target="_blank">https://www.janelia.org/project-team/flyem/data-and-software-release</a>` and is made available under the
+:raw-html:`<a href="http://opendatacommons.org/licenses/by/1.0/" target="_blank">Open Data Common Attribution License</a>`.
+Paper: :raw-html:`<a href="http://dx.doi.org/10.1073/pnas.1509820112" target="_blank">Takemura, Shin-ya et al. Synaptic Circuits and Their Variations within Different Columns in the Visual System of Drosophila. Proceedings of the National Academy of Sciences of the United States of America 112.44 (2015): 13711-13716.</a>`
+
+.. raw:: html
+
+   <iframe
+     src="https://neuroglancer-demo.appspot.com/#!{'layers':{'image':{'type':'image'_'source':'precomputed://gs://neuroglancer-public-data/flyem_fib-25/image'}_'ground-truth':{'type':'segmentation'_'source':'precomputed://gs://neuroglancer-public-data/flyem_fib-25/ground_truth'_'segments':['21894'_'22060'_'158571'_'24436'_'2515']}}_'navigation':{'pose':{'position':{'voxelSize':[8_8_8]_'voxelCoordinates':[2914.500732421875_3088.243408203125_4045]}}_'zoomFactor':30.09748283999932}_'perspectiveOrientation':[0.3143535554409027_0.8142156600952148_0.4843369424343109_-0.06040262430906296]_'perspectiveZoom':443.63404517712684_'showSlices':false}"
+     width="100%"
+     height="500"
+     style="border: 1px solid #ccc; border-radius: 4px;"
+     allow="fullscreen"
+     loading="lazy"
+   ></iframe>
+
+   <a href="https://neuroglancer-demo.appspot.com/#!{'layers':{'image':{'type':'image'_'source':'precomputed://gs://neuroglancer-public-data/flyem_fib-25/image'}_'ground-truth':{'type':'segmentation'_'source':'precomputed://gs://neuroglancer-public-data/flyem_fib-25/ground_truth'_'segments':['21894'_'22060'_'158571'_'24436'_'2515']}}_'navigation':{'pose':{'position':{'voxelSize':[8_8_8]_'voxelCoordinates':[2914.500732421875_3088.243408203125_4045]}}_'zoomFactor':30.09748283999932}_'perspectiveOrientation':[0.3143535554409027_0.8142156600952148_0.4843369424343109_-0.06040262430906296]_'perspectiveZoom':443.63404517712684_'showSlices':false}" style="display: inline-block; margin-top: 0.5em; margin-bottom: 1.5em; padding: 0.4em 1em; border: 1px solid currentColor; border-radius: 4px; text-decoration: none; font-size: 0.8em;" target="_blank">Open in new tab ↗</a>
+
+----
+
+Example of viewing 2D microscopy
+--------------------------------
+
+Coronal section of a rat brain at 325 nanometer resolution.
+
+This image is part of: Olsen et al., 2020. Anterogradely labeled axonal projections from the posterior parietal cortex in rat [:raw-html:`<a href="https://doi.org/10.25493/FKM4-ZCC" target="_blank">EBRAINS Dataset</a>`].
+
+Use :kbd:`Ctrl` + :kbd:`MouseWheel` to zoom out.
+
+.. raw:: html
+
+   <iframe
+     src="https://neuroglancer-demo.appspot.com/#!%7B%22dimensions%22:%7B%22x%22:%5B1e-9%2C%22m%22%5D%2C%22y%22:%5B1e-9%2C%22m%22%5D%7D%2C%22position%22:%5B10387071%2C5347131%5D%2C%22crossSectionScale%22:263.74955563693914%2C%22projectionScale%22:65536%2C%22layers%22:%5B%7B%22type%22:%22image%22%2C%22source%22:%7B%22url%22:%22deepzoom://https://data-proxy.ebrains.eu/api/v1/buckets/localizoom/14122_mPPC_BDA_s186.tif/14122_mPPC_BDA_s186.dzi%22%2C%22transform%22:%7B%22outputDimensions%22:%7B%22x%22:%5B1e-9%2C%22m%22%5D%2C%22y%22:%5B1e-9%2C%22m%22%5D%2C%22c%5E%22:%5B1%2C%22%22%5D%7D%2C%22inputDimensions%22:%7B%22x%22:%5B3.25e-7%2C%22m%22%5D%2C%22y%22:%5B3.25e-7%2C%22m%22%5D%2C%22c%5E%22:%5B1%2C%22%22%5D%7D%7D%7D%2C%22tab%22:%22rendering%22%2C%22shader%22:%22void%20main%28%29%7BemitRGB%28vec3%28toNormalized%28getDataValue%280%29%29%2CtoNormalized%28getDataValue%281%29%29%2CtoNormalized%28getDataValue%282%29%29%29%29%3B%7D%22%2C%22channelDimensions%22:%7B%22c%5E%22:%5B1%2C%22%22%5D%7D%2C%22name%22:%2214122_mPPC_BDA_s186.dzi%22%7D%5D%2C%22selectedLayer%22:%7B%22layer%22:%2214122_mPPC_BDA_s186.dzi%22%7D%2C%22layout%22:%22xy%22%7D"
+     width="100%"
+     height="500"
+     style="border: 1px solid #ccc; border-radius: 4px;"
+     allow="fullscreen"
+     loading="lazy"
+   ></iframe>
+
+   <a href="https://neuroglancer-demo.appspot.com/#!%7B%22dimensions%22:%7B%22x%22:%5B1e-9%2C%22m%22%5D%2C%22y%22:%5B1e-9%2C%22m%22%5D%7D%2C%22position%22:%5B10387071%2C5347131%5D%2C%22crossSectionScale%22:263.74955563693914%2C%22projectionScale%22:65536%2C%22layers%22:%5B%7B%22type%22:%22image%22%2C%22source%22:%7B%22url%22:%22deepzoom://https://data-proxy.ebrains.eu/api/v1/buckets/localizoom/14122_mPPC_BDA_s186.tif/14122_mPPC_BDA_s186.dzi%22%2C%22transform%22:%7B%22outputDimensions%22:%7B%22x%22:%5B1e-9%2C%22m%22%5D%2C%22y%22:%5B1e-9%2C%22m%22%5D%2C%22c%5E%22:%5B1%2C%22%22%5D%7D%2C%22inputDimensions%22:%7B%22x%22:%5B3.25e-7%2C%22m%22%5D%2C%22y%22:%5B3.25e-7%2C%22m%22%5D%2C%22c%5E%22:%5B1%2C%22%22%5D%7D%7D%7D%2C%22tab%22:%22rendering%22%2C%22shader%22:%22void%20main%28%29%7BemitRGB%28vec3%28toNormalized%28getDataValue%280%29%29%2CtoNormalized%28getDataValue%281%29%29%2CtoNormalized%28getDataValue%282%29%29%29%29%3B%7D%22%2C%22channelDimensions%22:%7B%22c%5E%22:%5B1%2C%22%22%5D%7D%2C%22name%22:%2214122_mPPC_BDA_s186.dzi%22%7D%5D%2C%22selectedLayer%22:%7B%22layer%22:%2214122_mPPC_BDA_s186.dzi%22%7D%2C%22layout%22:%22xy%22%7D" style="display: inline-block; margin-top: 0.5em; margin-bottom: 1.5em; padding: 0.4em 1em; border: 1px solid currentColor; border-radius: 4px; text-decoration: none; font-size: 0.8em;" target="_blank">Open in new tab ↗</a>

--- a/docs/gallery/index.rst
+++ b/docs/gallery/index.rst
@@ -1,3 +1,5 @@
+:hide-toc:
+
 .. _gallery:
 
 .. role:: raw-html(raw)

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -35,6 +35,12 @@ Neuroglancer
 
 .. toctree::
    :hidden:
+   :caption: Gallery
+
+   gallery/index
+
+.. toctree::
+   :hidden:
    :caption: Governance
 
    governance/governance


### PR DESCRIPTION
## Context

I think it would be helpful to have a dedicated page to showcase Neuroglancer scenes with example data.  So here I propose moving the `Examples` from the readme to such a page in the documentation. Hopefully others using Neuroglancer will add their data/scenes to this page in the future.

## Changes

- [x] Move examples from readme to `Gallery` page in documentation
- [x] Embed each Neuroglancer viewer as an iframe and lazy load each iframe
- [x] Test locally

cc @satra @ayendiki