### PR TITLE
feat: Increase progress bars  height

### DIFF
--- a/src/ui/layer_bar.css
+++ b/src/ui/layer_bar.css
@@ -112,7 +112,7 @@
 .neuroglancer-layer-item-prefetch-progress {
   position: absolute;
   left: 0px;
-  height: 2px;
+  height: 4px;
   background-color: #666;
 }
 


### PR DESCRIPTION
Based on [April's fool version of neuroglancer](https://ng-ux-dot-neuroglancer-dot-seung-lab.ue.r.appspot.com/#!%7B%22dimensions%22:%7B%22x%22:%5B8e-9%2C%22m%22%5D%2C%22y%22:%5B8e-9%2C%22m%22%5D%2C%22z%22:%5B4e-8%2C%22m%22%5D%7D%2C%22position%22:%5B120320.5%2C103936.5%2C21360.5%5D%2C%22crossSectionScale%22:1%2C%22projectionScale%22:262144%2C%22layers%22:%5B%7B%22type%22:%22image%22%2C%22source%22:%22https://bossdb-open-data.s3.amazonaws.com/iarpa_microns/minnie/minnie65/em/%7Cneuroglancer-precomputed:%22%2C%22tab%22:%22source%22%2C%22name%22:%22em%22%7D%2C%7B%22type%22:%22segmentation%22%2C%22source%22:%22gs://iarpa_microns/minnie/minnie65/seg_m1300/%7Cneuroglancer-precomputed:%22%2C%22tab%22:%22rendering%22%2C%22segments%22:%5B%22%21864691135483184309%22%2C%22%21864691135448213310%22%5D%2C%22name%22:%22seg%22%7D%5D%2C%22selectedLayer%22:%7B%22size%22:456%2C%22visible%22:true%2C%22layer%22:%22seg%22%7D%2C%22layout%22:%22xy%22%7D) from @chrisj we believe that a taller progress bar makes layer-fetching progress easier for users to understand.