### PR TITLE
chore(lint): remove uneeded assignment identified by lint warning

### DIFF
--- a/src/ui/annotation_schema_tab.ts
+++ b/src/ui/annotation_schema_tab.ts
@@ -139,7 +139,6 @@ class AnnotationUIProperty extends RefCounted {
     private parentView: AnnotationSchemaView,
   ) {
     super();
-    this.spec = spec;
     this.element.classList.add("neuroglancer-annotation-schema-row");
     this.makeUI();
   }


### PR DESCRIPTION
In the annotation schema tab a parameter property was being assigned, this is removed here

```
  ⚠ typescript-eslint(no-unnecessary-parameter-property-assignment): Assignment of parameter property is unnecessary
     ╭─[src/ui/annotation_schema_tab.ts:142:5]
 141 │     super();
 142 │     this.spec = spec;
     ·     ────────────────
 143 │     this.element.classList.add("neuroglancer-annotation-schema-row");
     ╰────
  help: Remove the unnecessary assignment
```