### PR TITLE
feat(panels): allow a debug visualisation for offscreen textures

### DIFF
--- a/src/display_context.ts
+++ b/src/display_context.ts
@@ -276,6 +276,37 @@ export abstract class RenderedPanel extends RefCounted {
     gl.scissor(canvasRelativeClippedLeft, glBottom, width, height);
   }
 
+  setSubdividedGLClippedViewport(cellIndex: number, totalCells: number) {
+    const {
+      gl,
+      canvasRelativeClippedTop,
+      canvasRelativeClippedLeft,
+      renderViewport: { width, height },
+    } = this;
+
+    const numCols = Math.ceil(Math.sqrt(totalCells));
+    const numRows = Math.ceil(totalCells / numCols);
+
+    const col = cellIndex % numCols;
+    const row = Math.floor(cellIndex / numCols);
+
+    const cellWidth = width / numCols;
+    const cellHeight = height / numRows;
+
+    const left = canvasRelativeClippedLeft + col * cellWidth;
+    const top = canvasRelativeClippedTop + row * cellHeight;
+    const bottom = top + cellHeight;
+
+    const glLeft = Math.floor(left);
+    const glBottom = Math.floor(this.context.canvas.height - bottom);
+    const glWidth = Math.ceil(cellWidth);
+    const glHeight = Math.ceil(cellHeight);
+
+    gl.enable(WebGL2RenderingContext.SCISSOR_TEST);
+    gl.viewport(glLeft, glBottom, glWidth, glHeight);
+    gl.scissor(glLeft, glBottom, glWidth, glHeight);
+  }
+
   // Sets the viewport to the logical viewport, using the scissor test to constrain drawing to the
   // clipped viewport.  Drawing does not need to take `visible{Left,Top,Width,Height}Fraction` into
   // account.

--- a/src/perspective_view/panel.ts
+++ b/src/perspective_view/panel.ts
@@ -84,7 +84,7 @@ import type { RPC } from "#src/worker_rpc.js";
 import { SharedObject } from "#src/worker_rpc.js";
 
 // Turn on to see each of the offscreen textures
-// render order is from bottom left to top right
+// render order is from top left to bottom right
 // picking will not work as expected in a subdivision
 // of the full panel, pretend you are picking from the full panel
 const DEBUG_OFFSCREEN_TEXTURES = false;

--- a/src/perspective_view/panel.ts
+++ b/src/perspective_view/panel.ts
@@ -83,6 +83,12 @@ import { MultipleScaleBarTextures } from "#src/widget/scale_bar.js";
 import type { RPC } from "#src/worker_rpc.js";
 import { SharedObject } from "#src/worker_rpc.js";
 
+// Turn on to see each of the offscreen textures
+// render order is from bottom left to top right
+// picking will not work as expected in a subdivision
+// of the full panel, pretend you are picking from the full panel
+const DEBUG_OFFSCREEN_TEXTURES = false;
+
 export interface PerspectiveViewerState extends RenderedDataViewerState {
   wireFrame: WatchableValueInterface<boolean>;
   enableAdaptiveDownsampling: WatchableValueInterface<boolean>;
@@ -1419,11 +1425,22 @@ export class PerspectivePanel extends RenderedDataPanel {
     }
     this.offscreenFramebuffer.unbind();
 
-    // Draw the texture over the whole viewport.
-    this.setGLClippedViewport();
-    this.offscreenCopyHelper.draw(
-      this.offscreenFramebuffer.colorBuffers[OffscreenTextures.COLOR].texture,
-    );
+    if (DEBUG_OFFSCREEN_TEXTURES) {
+      const numTextures = OffscreenTextures.NUM_TEXTURES;
+      for (let i = 0; i < numTextures; i++) {
+        const texture = this.offscreenFramebuffer.colorBuffers[i].texture;
+        if (texture) {
+          this.setSubdividedGLClippedViewport(i, numTextures);
+          this.offscreenCopyHelper.draw(texture);
+        }
+      }
+    } else {
+      // Draw the texture over the whole viewport.
+      this.setGLClippedViewport();
+      this.offscreenCopyHelper.draw(
+        this.offscreenFramebuffer.colorBuffers[OffscreenTextures.COLOR].texture,
+      );
+    }
     return true;
   }
 

--- a/src/perspective_view/panel.ts
+++ b/src/perspective_view/panel.ts
@@ -1434,13 +1434,13 @@ export class PerspectivePanel extends RenderedDataPanel {
           this.offscreenCopyHelper.draw(texture);
         }
       }
-    } else {
-      // Draw the texture over the whole viewport.
-      this.setGLClippedViewport();
-      this.offscreenCopyHelper.draw(
-        this.offscreenFramebuffer.colorBuffers[OffscreenTextures.COLOR].texture,
-      );
+      return true;
     }
+    // Draw the texture over the whole viewport.
+    this.setGLClippedViewport();
+    this.offscreenCopyHelper.draw(
+      this.offscreenFramebuffer.colorBuffers[OffscreenTextures.COLOR].texture,
+    );
     return true;
   }
 

--- a/src/sliceview/panel.ts
+++ b/src/sliceview/panel.ts
@@ -448,13 +448,13 @@ export class SliceViewPanel extends RenderedDataPanel {
           this.offscreenCopyHelper.draw(texture);
         }
       }
-    } else {
-      // Draw the texture over the whole viewport.
-      this.setGLClippedViewport();
-      this.offscreenCopyHelper.draw(
-        this.offscreenFramebuffer.colorBuffers[OffscreenTextures.COLOR].texture,
-      );
+      return true;
     }
+    // Draw the texture over the whole viewport
+    this.setGLClippedViewport();
+    this.offscreenCopyHelper.draw(
+      this.offscreenFramebuffer.colorBuffers[OffscreenTextures.COLOR].texture,
+    );
     return true;
   }
 

--- a/src/sliceview/panel.ts
+++ b/src/sliceview/panel.ts
@@ -60,7 +60,7 @@ import type { TrackableScaleBarOptions } from "#src/widget/scale_bar.js";
 import { MultipleScaleBarTextures } from "#src/widget/scale_bar.js";
 
 // Turn on to see each of the offscreen textures
-// render order is from bottom left to top right
+// render order is from top left to bottom right
 // picking will not work as expected in a subdivision
 // of the full panel, pretend you are picking from the full panel
 const DEBUG_OFFSCREEN_TEXTURES = false;

--- a/src/sliceview/panel.ts
+++ b/src/sliceview/panel.ts
@@ -59,6 +59,12 @@ import type { ShaderBuilder } from "#src/webgl/shader.js";
 import type { TrackableScaleBarOptions } from "#src/widget/scale_bar.js";
 import { MultipleScaleBarTextures } from "#src/widget/scale_bar.js";
 
+// Turn on to see each of the offscreen textures
+// render order is from bottom left to top right
+// picking will not work as expected in a subdivision
+// of the full panel, pretend you are picking from the full panel
+const DEBUG_OFFSCREEN_TEXTURES = false;
+
 export interface SliceViewerState extends RenderedDataViewerState {
   showScaleBar: TrackableBoolean;
   wireFrame: TrackableBoolean;
@@ -431,14 +437,24 @@ export class SliceViewPanel extends RenderedDataPanel {
         gl.disable(WebGL2RenderingContext.BLEND);
       }
     }
-
     this.offscreenFramebuffer.unbind();
 
-    // Draw the texture over the whole viewport.
-    this.setGLClippedViewport();
-    this.offscreenCopyHelper.draw(
-      this.offscreenFramebuffer.colorBuffers[OffscreenTextures.COLOR].texture,
-    );
+    if (DEBUG_OFFSCREEN_TEXTURES) {
+      const numTextures = OffscreenTextures.NUM_TEXTURES;
+      for (let i = 0; i < numTextures; i++) {
+        const texture = this.offscreenFramebuffer.colorBuffers[i].texture;
+        if (texture) {
+          this.setSubdividedGLClippedViewport(i, numTextures);
+          this.offscreenCopyHelper.draw(texture);
+        }
+      }
+    } else {
+      // Draw the texture over the whole viewport.
+      this.setGLClippedViewport();
+      this.offscreenCopyHelper.draw(
+        this.offscreenFramebuffer.colorBuffers[OffscreenTextures.COLOR].texture,
+      );
+    }
     return true;
   }
 

--- a/src/sliceview/panel.ts
+++ b/src/sliceview/panel.ts
@@ -450,7 +450,7 @@ export class SliceViewPanel extends RenderedDataPanel {
       }
       return true;
     }
-    // Draw the texture over the whole viewport
+    // Draw the texture over the whole viewport.
     this.setGLClippedViewport();
     this.offscreenCopyHelper.draw(
       this.offscreenFramebuffer.colorBuffers[OffscreenTextures.COLOR].texture,


### PR DESCRIPTION
I've recently been debugging through some picking and depth buffer interactions, and I thought sharing the debug vis for the offscreen buffers could be helpful for future use. This adds a constant to both the slice view and projection panels that can be independently turned on. It's designed to extend pretty readily, since for example https://github.com/google/neuroglancer/pull/993 adds a new offscreen buffer for normals.  As an example of this vis (top left Color, top right Z, bottom left Pick, bottom right empty):

<img width="1254" height="890" alt="image" src="https://github.com/user-attachments/assets/c5540822-22e9-4281-94c9-ed6446c439cc" />
<img width="1313" height="890" alt="image" src="https://github.com/user-attachments/assets/e4575cef-d8dd-41e5-939c-29d1ccf64ae0" />

This could be further improved to show the debugs for each panel better by having a custom shader for each, but that's not likely worth it for the debug vis. If you need to see one panel better you can modify the default shader which is in `defineCopyFragmentShader` of `offscreen.ts`. To try it, it has to be built locally since the debug flags are false by default.