### PR TITLE
feat: volume rendering show value in layer bar

### DIFF
--- a/src/volume_rendering/volume_render_layer.ts
+++ b/src/volume_rendering/volume_render_layer.ts
@@ -17,14 +17,17 @@
 import { ChunkState } from "#src/chunk_manager/base.js";
 import { ChunkRenderLayerFrontend } from "#src/chunk_manager/frontend.js";
 import type { CoordinateSpace } from "#src/coordinate_transform.js";
-import type { VisibleLayerInfo } from "#src/layer/index.js";
+import type { PickState, VisibleLayerInfo } from "#src/layer/index.js";
 import type { PerspectivePanel } from "#src/perspective_view/panel.js";
 import type {
   PerspectiveViewReadyRenderContext,
   PerspectiveViewRenderContext,
 } from "#src/perspective_view/render_layer.js";
 import { PerspectiveViewRenderLayer } from "#src/perspective_view/render_layer.js";
-import type { RenderLayerTransformOrError } from "#src/render_coordinate_transform.js";
+import {
+  getChunkPositionFromCombinedGlobalLocalPositions,
+  type RenderLayerTransformOrError,
+} from "#src/render_coordinate_transform.js";
 import type { RenderScaleHistogram } from "#src/render_scale_statistics.js";
 import {
   numRenderScaleHistogramBins,
@@ -223,6 +226,8 @@ export class VolumeRenderingRenderLayer extends PerspectiveViewRenderLayer {
   private vertexIdHelper: VertexIdHelper;
   private dataHistogramSpecifications: HistogramSpecifications;
   private inverseModelViewProjection: mat4;
+  private tempChunkPosition: Float32Array;
+  private currentTransformedSources: TransformedVolumeSource[] | null = null;
 
   private shaderGetter: ParameterizedContextDependentShaderGetter<
     { emitter: ShaderModule; chunkFormat: ChunkFormat; wireFrame: boolean },
@@ -258,6 +263,7 @@ export class VolumeRenderingRenderLayer extends PerspectiveViewRenderLayer {
     super();
     this.gain = options.gain;
     this.multiscaleSource = options.multiscaleSource;
+    this.tempChunkPosition = new Float32Array(options.multiscaleSource.rank);
     this.transform = options.transform;
     this.inverseModelViewProjection = mat4.create();
     this.channelCoordinateSpace = options.channelCoordinateSpace;
@@ -660,6 +666,13 @@ outputValue = vec4(1.0, 1.0, 1.0, 1.0);
     );
     this.registerDisposer(this.mode.changed.add(this.redrawNeeded.dispatch));
     this.registerDisposer(
+      this.mode.changed.add(() => {
+        if (this.mode.value === VolumeRenderingModes.OFF) {
+          this.currentTransformedSources = null;
+        }
+      }),
+    );
+    this.registerDisposer(
       this.shaderControlState.fragmentMain.changed.add(
         this.redrawNeeded.dispatch,
       ),
@@ -740,9 +753,10 @@ outputValue = vec4(1.0, 1.0, 1.0, 1.0);
       VolumeRenderingAttachmentState
     >,
   ) {
-    if (!renderContext.emitColor) return;
     const allSources = attachment.state!.sources.value;
-    if (allSources.length === 0) return;
+    this.currentTransformedSources =
+      allSources.length === 0 ? null : allSources[0];
+    if (!renderContext.emitColor || allSources.length === 0) return;
     let curPhysicalSpacing = 0;
     let curOptimalSamples = 0;
     let curHistogramInformation: HistogramInformation = {
@@ -933,7 +947,6 @@ outputValue = vec4(1.0, 1.0, 1.0, 1.0);
         const { inverseModelViewProjection } = this;
         const clippingPlanes = tempVisibleVolumetricClippingPlanes;
         getFrustrumPlanes(clippingPlanes, modelViewProjection);
-        const inverseModelViewProjection = mat4.create();
         mat4.invert(inverseModelViewProjection, modelViewProjection);
         const { near, far, adjustedNear, adjustedFar } =
           getVolumeRenderingNearFarBounds(
@@ -1265,6 +1278,37 @@ outputValue = vec4(1.0, 1.0, 1.0, 1.0);
     if (needPickingPass || needToDrawHistogram) {
       restoreDrawingBuffersAndState();
     }
+  }
+  // The pick ID encodes no spatial data; return null so UserLayer.getValueAt
+  // falls through to getValueAt() which looks up the voxel value from the depth-derived position if in max or min mode.
+  transformPickedValue(pickState: PickState) {
+    if (pickState.pickedValue === 0n) {
+      return null;
+    }
+    return pickState.pickedValue;
+  }
+
+  getValueAt(globalPosition: Float32Array) {
+    const { currentTransformedSources, tempChunkPosition } = this;
+    if (currentTransformedSources === null) return null;
+    for (const { source, chunkTransform } of currentTransformedSources) {
+      if (
+        !getChunkPositionFromCombinedGlobalLocalPositions(
+          tempChunkPosition,
+          globalPosition,
+          this.localPosition.value,
+          chunkTransform.layerRank,
+          chunkTransform.combinedGlobalLocalToChunkTransform,
+        )
+      ) {
+        continue;
+      }
+      const result = source.getValueAt(tempChunkPosition, chunkTransform);
+      if (result != null) {
+        return result;
+      }
+    }
+    return null;
   }
 
   private bindDepthBufferTexture(

--- a/src/volume_rendering/volume_render_layer.ts
+++ b/src/volume_rendering/volume_render_layer.ts
@@ -222,6 +222,7 @@ export class VolumeRenderingRenderLayer extends PerspectiveViewRenderLayer {
   private modeOverride: TrackableVolumeRenderingModeValue;
   private vertexIdHelper: VertexIdHelper;
   private dataHistogramSpecifications: HistogramSpecifications;
+  private inverseModelViewProjection: mat4;
 
   private shaderGetter: ParameterizedContextDependentShaderGetter<
     { emitter: ShaderModule; chunkFormat: ChunkFormat; wireFrame: boolean },
@@ -258,6 +259,7 @@ export class VolumeRenderingRenderLayer extends PerspectiveViewRenderLayer {
     this.gain = options.gain;
     this.multiscaleSource = options.multiscaleSource;
     this.transform = options.transform;
+    this.inverseModelViewProjection = mat4.create();
     this.channelCoordinateSpace = options.channelCoordinateSpace;
     this.shaderControlState = options.shaderControlState;
     this.localPosition = options.localPosition;
@@ -367,7 +369,7 @@ void emitRGBA(vec4 rgba) {
             glsl_handleMaxProjectionUpdate = `
   float newIntensity = getIntensity();
   bool intensityChanged = newIntensity > savedIntensity;
-  savedIntensity = intensityChanged ? newIntensity : savedIntensity; 
+  savedIntensity = intensityChanged ? newIntensity : savedIntensity;
   savedDepth = intensityChanged ? depthAtRayPosition : savedDepth;
   outputColor = intensityChanged ? newColor : outputColor;
   emit(outputColor, savedDepth, savedIntensity, uPickId);
@@ -928,6 +930,7 @@ outputValue = vec4(1.0, 1.0, 1.0, 1.0);
           projectionParameters.viewProjectionMat,
           chunkLayout.transform,
         );
+        const { inverseModelViewProjection } = this;
         const clippingPlanes = tempVisibleVolumetricClippingPlanes;
         getFrustrumPlanes(clippingPlanes, modelViewProjection);
         const inverseModelViewProjection = mat4.create();

--- a/src/volume_rendering/volume_render_layer.ts
+++ b/src/volume_rendering/volume_render_layer.ts
@@ -1281,17 +1281,20 @@ outputValue = vec4(1.0, 1.0, 1.0, 1.0);
   }
   // The pick ID encodes no spatial data; return null so UserLayer.getValueAt
   // falls through to getValueAt() which looks up the voxel value from the depth-derived position if in max or min mode.
-  transformPickedValue(pickState: PickState) {
-    if (pickState.pickedValue === 0n) {
-      return null;
-    }
-    return pickState.pickedValue;
+  transformPickedValue(_pickState: PickState) {
+    return null;
   }
 
   getValueAt(globalPosition: Float32Array) {
     const { currentTransformedSources, tempChunkPosition } = this;
     if (currentTransformedSources === null) return null;
-    for (const { source, chunkTransform } of currentTransformedSources) {
+    const rank = tempChunkPosition.length;
+    for (const {
+      source,
+      chunkTransform,
+      lowerClipBound,
+      upperClipBound,
+    } of currentTransformedSources) {
       if (
         !getChunkPositionFromCombinedGlobalLocalPositions(
           tempChunkPosition,
@@ -1303,6 +1306,17 @@ outputValue = vec4(1.0, 1.0, 1.0, 1.0);
       ) {
         continue;
       }
+      let outOfBounds = false;
+      for (let i = 0; i < rank; ++i) {
+        if (
+          tempChunkPosition[i] < lowerClipBound[i] ||
+          tempChunkPosition[i] >= upperClipBound[i]
+        ) {
+          outOfBounds = true;
+          break;
+        }
+      }
+      if (outOfBounds) continue;
       const result = source.getValueAt(tempChunkPosition, chunkTransform);
       if (result != null) {
         return result;


### PR DESCRIPTION
There is currently a bit of an odd interaction with the value reported for image layers with volume rendering activated.
Because we can't really provide a single value for what is under the cursor for volume rendering ON (we can in max and min, since we have a single intensity), we instead always showed 0 as the value. However, because of how `captureSelectionState` works in the user layer, the following is happening fairly often in mixed scenes:
1. The user has a multi-panel setup, at least one panel is a slice view and at least one is a projection view.
2. The user hovers over a different object than the volume rendering in the scene as their picking result in the perspective panel. `captureSelectionState` is called on the image `UserLayer`. 
3. The `pickedRenderLayer` in `captureSelectionState` is therefore not the `VolumeRenderingRenderLayer`, and so it falls through the iterating through all `renderLayers` in the `UserLayer` to check if any return a valid result from `renderLayer.getValueAt`.
4. The `VolumeRenderingRenderLayer` has no `getValueAt` function, but the `ImageRenderLayer` does. The image `UserLayer` has both a `VolumeRenderingRenderLayer` and an `ImageRenderLayer` since this is a multi-panel setup. The `ImageRenderLayer` perform a lookup on the chunk value even though the `VolumeRenderingRenderLayer` has no `getValueAt` function.
6. This results in the user seeing the value in the volume from reprojecting the depth to world space when hovering non-volume rendering pick results, but does not see the value when hovering the volume rendering. This is in the layer bar. This feels odd and inconsistent.

The changes here aim to make the above system consistent. You always see a value in the layer value indicator by reprojecting the value from the depth buffer at the cursor back to world space. In the case of only having volume rendering, that means the value seen is the min/max intensity along a ray under the cursor. This is done by essentially forcing Step 3 in the above description to always happen, if the `pickedRenderLayer` is the `VolumeRenderingRenderLayer` then we use `transformPickedValue` on the `VolumeRenderingRenderLayer` to ignore the picked state value (would be 0n) and return null instead to force iterating through all the `renderLayers`.

[Screencast from 2026-05-22 12-31-08.webm](https://github.com/user-attachments/assets/33defbef-6754-4eb6-9386-3625ea329305)

I have this in draft at the moment because there is a bug with excluding the out of bounds information to avoid seeing "null" out of bounds (edit, I'm realising now the image render layer has no such protection, which means likely its not needed in the volume render layer either and the issue is from something else). The filtering works after a refresh but not before.

`UserLayer.captureSelectionState` for reference:
```
  getValueAt(position: Float32Array, pickState: PickState) {
    let result: any;
    const { renderLayers } = this;
    const { pickedRenderLayer } = pickState;
    if (
      pickedRenderLayer !== null &&
      renderLayers.indexOf(pickedRenderLayer) !== -1
    ) {
      result = pickedRenderLayer.transformPickedValue(pickState);
      result = this.transformPickedValue(result);
      if (result != null) return result;
    }
    for (const layer of renderLayers) {
      result = layer.getValueAt(position);
      if (result != null) {
        break;
      }
    }
    return this.transformPickedValue(result);
  }
  ```