### PR TITLE
chore: rename frustrum to frustum

### DIFF
--- a/src/annotation/base.ts
+++ b/src/annotation/base.ts
@@ -23,7 +23,7 @@ import type {
 } from "#src/sliceview/base.js";
 import { forEachVisibleVolumetricChunk } from "#src/sliceview/base.js";
 import {
-  getViewFrustrumVolume,
+  getViewFrustumVolume,
   mat3,
   mat3FromMat4,
   prod3,
@@ -95,8 +95,8 @@ export function forEachVisibleAnnotationChunk<
     mat3.determinant(mat3FromMat4(tempMat3, viewMatrix)),
   );
   const canonicalToPhysicalScale = prod3(voxelPhysicalScales);
-  const viewFrustrumVolume =
-    (getViewFrustrumVolume(projectionMat) / viewDet) * canonicalToPhysicalScale;
+  const viewFrustumVolume =
+    (getViewFrustumVolume(projectionMat) / viewDet) * canonicalToPhysicalScale;
 
   if (transformedSources.length === 0) return;
   const baseSource = transformedSources[0];
@@ -107,7 +107,7 @@ export function forEachVisibleAnnotationChunk<
     sourceVolume *= upperClipDisplayBound[i] - lowerClipDisplayBound[i];
   }
 
-  const effectiveVolume = Math.min(sourceVolume, viewFrustrumVolume);
+  const effectiveVolume = Math.min(sourceVolume, viewFrustumVolume);
   const viewportArea = width * height;
   const targetNumAnnotations = viewportArea / renderScaleTarget ** 2;
   const physicalDensityTarget = targetNumAnnotations / effectiveVolume;

--- a/src/annotation/bounding_box.ts
+++ b/src/annotation/bounding_box.ts
@@ -35,7 +35,7 @@ import {
 } from "#src/sliceview/bounding_box_shader_helper.js";
 import type { SliceViewPanelRenderContext } from "#src/sliceview/renderlayer.js";
 import { tile2dArray } from "#src/util/array.js";
-import { getViewFrustrumWorldBounds, mat4 } from "#src/util/geom.js";
+import { getViewFrustumWorldBounds, mat4 } from "#src/util/geom.js";
 import { CORNERS_PER_BOX, EDGES_PER_BOX } from "#src/webgl/bounding_box.js";
 import { GLBuffer } from "#src/webgl/buffer.js";
 import {
@@ -226,7 +226,7 @@ abstract class RenderHelper extends AnnotationRenderHelper {
       tempInvModelViewProjectionMatrix,
       context.modelViewProjectionMatrix,
     );
-    getViewFrustrumWorldBounds(
+    getViewFrustumWorldBounds(
       tempInvModelViewProjectionMatrix,
       tempWorldBounds,
     );

--- a/src/mesh/backend.ts
+++ b/src/mesh/backend.ts
@@ -47,7 +47,7 @@ import {
 } from "#src/segmentation_display_state/base.js";
 import type { Endianness } from "#src/util/endian.js";
 import { convertEndian32 } from "#src/util/endian.js";
-import { getFrustrumPlanes, mat4, vec3 } from "#src/util/geom.js";
+import { getFrustumPlanes, mat4, vec3 } from "#src/util/geom.js";
 import {
   verifyObject,
   verifyObjectProperty,
@@ -715,7 +715,7 @@ export class MultiscaleMeshLayer extends withSegmentationLayerBackendState(
         projectionParameters.viewProjectionMat,
         modelViewProjectionMatrix,
       );
-      const clippingPlanes = getFrustrumPlanes(
+      const clippingPlanes = getFrustumPlanes(
         new Float32Array(24),
         modelViewProjectionMatrix,
       );

--- a/src/mesh/frontend.ts
+++ b/src/mesh/frontend.ts
@@ -58,7 +58,7 @@ import { makeCachedDerivedWatchableValue } from "#src/trackable_value.js";
 import type { Borrowed, RefCounted } from "#src/util/disposable.js";
 import type { vec4 } from "#src/util/geom.js";
 import {
-  getFrustrumPlanes,
+  getFrustumPlanes,
   mat3,
   mat3FromMat4,
   mat4,
@@ -860,7 +860,7 @@ export class MultiscaleMeshLayer extends PerspectiveViewRenderLayer<ThreeDimensi
       modelMatrix,
     );
 
-    const clippingPlanes = getFrustrumPlanes(
+    const clippingPlanes = getFrustumPlanes(
       new Float32Array(24),
       modelViewProjection,
     );
@@ -1020,7 +1020,7 @@ export class MultiscaleMeshLayer extends PerspectiveViewRenderLayer<ThreeDimensi
       modelMatrix,
     );
 
-    const clippingPlanes = getFrustrumPlanes(
+    const clippingPlanes = getFrustumPlanes(
       new Float32Array(24),
       modelViewProjection,
     );

--- a/src/mesh/multiscale.spec.ts
+++ b/src/mesh/multiscale.spec.ts
@@ -20,7 +20,7 @@ import {
   getDesiredMultiscaleMeshChunks,
   getMultiscaleChunksToDraw,
 } from "#src/mesh/multiscale.js";
-import { getFrustrumPlanes, mat4, vec3 } from "#src/util/geom.js";
+import { getFrustumPlanes, mat4, vec3 } from "#src/util/geom.js";
 
 interface MultiscaleChunkResult {
   lod: number;
@@ -40,7 +40,7 @@ function getDesiredChunkList(
   getDesiredMultiscaleMeshChunks(
     manifest,
     modelViewProjection,
-    getFrustrumPlanes(new Float32Array(24), modelViewProjection),
+    getFrustumPlanes(new Float32Array(24), modelViewProjection),
     detailCutoff,
     viewportWidth,
     viewportHeight,
@@ -71,7 +71,7 @@ function getDrawChunkList(
   getMultiscaleChunksToDraw(
     manifest,
     modelViewProjection,
-    getFrustrumPlanes(new Float32Array(24), modelViewProjection),
+    getFrustumPlanes(new Float32Array(24), modelViewProjection),
     detailCutoff,
     viewportWidth,
     viewportHeight,

--- a/src/mesh/multiscale.ts
+++ b/src/mesh/multiscale.ts
@@ -139,7 +139,7 @@ export function getDesiredMultiscaleMeshChunks(
   }
 
   /**
-   * Minimum value of w within clipping frustrum (under the assumption that the minimum value occurs
+   * Minimum value of w within clipping frustum (under the assumption that the minimum value occurs
    * on the near clipping plane).
    */
   const minWClip = getPointW(-nearD * nearA, -nearD * nearB, -nearD * nearC);

--- a/src/sliceview/base.ts
+++ b/src/sliceview/base.ts
@@ -28,8 +28,8 @@ import type {
 import { DATA_TYPE_BYTES, DataType } from "#src/util/data_type.js";
 import type { Disposable } from "#src/util/disposable.js";
 import {
-  getFrustrumPlanes,
-  getViewFrustrumDepthRange,
+  getFrustumPlanes,
+  getViewFrustumDepthRange,
   isAABBIntersectingPlane,
   isAABBVisible,
   mat4,
@@ -809,7 +809,7 @@ const tempVisibleVolumetricChunkUpper = new Float32Array(3);
 const tempVisibleVolumetricModelViewProjection = mat4.create();
 const tempVisibleVolumetricClippingPlanes = new Float32Array(24);
 
-function forEachVolumetricChunkWithinFrustrum<
+function forEachVolumetricChunkWithinFrustum<
   RLayer extends MultiscaleVolumetricDataRenderLayer,
 >(
   clippingPlanes: Float32Array,
@@ -913,12 +913,12 @@ export function forEachVisibleVolumetricChunk<
   }
 
   const clippingPlanes = tempVisibleVolumetricClippingPlanes;
-  getFrustrumPlanes(clippingPlanes, modelViewProjection);
+  getFrustumPlanes(clippingPlanes, modelViewProjection);
   const lower = tempVisibleVolumetricChunkLower;
   const upper = tempVisibleVolumetricChunkUpper;
   lower.fill(Number.NEGATIVE_INFINITY);
   upper.fill(Number.POSITIVE_INFINITY);
-  forEachVolumetricChunkWithinFrustrum(
+  forEachVolumetricChunkWithinFrustum(
     clippingPlanes,
     transformedSource,
     callback,
@@ -1014,7 +1014,7 @@ export function forEachPlaneIntersectingVolumetricChunk<
     console.log("modelViewProjection", modelViewProjection.join(","));
     console.log(`lower=${lower.join(",")}, upper=${upper.join(",")}`);
   }
-  forEachVolumetricChunkWithinFrustrum(
+  forEachVolumetricChunkWithinFrustum(
     clippingPlanes,
     transformedSource,
     callback,
@@ -1041,7 +1041,7 @@ export function getNormalizedChunkLayout(
   );
   tempChunkLayout.detTransform = chunkLayout.detTransform;
   const { invViewMatrix, width, height } = projectionParameters;
-  const depth = getViewFrustrumDepthRange(projectionParameters.projectionMat);
+  const depth = getViewFrustumDepthRange(projectionParameters.projectionMat);
   for (let chunkRenderDim = finiteRank; chunkRenderDim < 3; ++chunkRenderDim) {
     // we want to ensure chunk [0] fully covers the viewport
     const offset = invViewMatrix[12 + chunkRenderDim];

--- a/src/util/geom.spec.ts
+++ b/src/util/geom.spec.ts
@@ -17,7 +17,7 @@
 import { describe, it, expect } from "vitest";
 import type { OrientedSliceScales } from "#src/util/geom.js";
 import {
-  getFrustrumPlanes,
+  getFrustumPlanes,
   isAABBVisible,
   mat4,
   quat,
@@ -33,10 +33,10 @@ const AXES_RELATIVE_ORIENTATION = new Map<NamedAxes, quat | undefined>([
   ["yz", quat.rotateY(quat.create(), quat.create(), Math.PI / 2)],
 ]);
 
-describe("getFrustrumPlanes", () => {
+describe("getFrustumPlanes", () => {
   it("works for simple example", () => {
     const m = mat4.perspective(mat4.create(), Math.PI / 2, 4.0, 7, 113);
-    const planes = getFrustrumPlanes(new Float32Array(24), m);
+    const planes = getFrustumPlanes(new Float32Array(24), m);
     const expectedPlanes = [
       // left
       +0.25, 0, -1, 0,
@@ -58,7 +58,7 @@ describe("getFrustrumPlanes", () => {
 describe("isAABBVisible", () => {
   it("works for simple example", () => {
     const m = mat4.perspective(mat4.create(), Math.PI / 2, 4.0, 7, 113);
-    const planes = getFrustrumPlanes(new Float32Array(24), m);
+    const planes = getFrustumPlanes(new Float32Array(24), m);
     expect(isAABBVisible(-1, -1, -20, 1, 1, -15, planes)).toBe(true);
     expect(isAABBVisible(-50, -1, -8, -40, 1, -7, planes)).toBe(false);
     expect(isAABBVisible(40, -1, -8, 50, 1, -7, planes)).toBe(false);

--- a/src/util/geom.ts
+++ b/src/util/geom.ts
@@ -219,7 +219,7 @@ export function mat3FromMat4(out: mat3, m: mat4) {
  * clipping plane.
  * @param m Projection matrix
  */
-export function getFrustrumPlanes(out: Float32Array, m: mat4): Float32Array {
+export function getFrustumPlanes(out: Float32Array, m: mat4): Float32Array {
   // http://web.archive.org/web/20120531231005/http://crazyjoke.free.fr/doc/3D/plane%20extraction.pdf
   const m00 = m[0];
   const m10 = m[1];
@@ -286,10 +286,10 @@ export function getFrustrumPlanes(out: Float32Array, m: mat4): Float32Array {
 }
 
 /**
- * Checks whether the specified axis-aligned bounding box (AABB) intersects the view frustrum.
+ * Checks whether the specified axis-aligned bounding box (AABB) intersects the view frustum.
  *
- * @param clippingPlanes Array of length 24 specifying the clipping planes of the view frustrum, as
- *     computed by `getFrustrumPlanes`
+ * @param clippingPlanes Array of length 24 specifying the clipping planes of the view frustum, as
+ *     computed by `getFrustumPlanes`
  */
 export function isAABBVisible(
   xLower: number,
@@ -413,7 +413,7 @@ export function scaleMat3Output(
   return out;
 }
 
-export function getViewFrustrumVolume(projectionMat: mat4) {
+export function getViewFrustumVolume(projectionMat: mat4) {
   if (projectionMat[15] === 1) {
     // orthographic projection
     const depth = 2 / Math.abs(projectionMat[10]);
@@ -433,7 +433,7 @@ export function getViewFrustrumVolume(projectionMat: mat4) {
   return (baseArea / 3) * (Math.abs(far) ** 3 - Math.abs(near) ** 3);
 }
 
-export function getViewFrustrumDepthRange(projectionMat: mat4) {
+export function getViewFrustumDepthRange(projectionMat: mat4) {
   if (projectionMat[15] === 1) {
     // orthographic projection
     const depth = 2 / Math.abs(projectionMat[10]);
@@ -461,11 +461,11 @@ export function disableZProjection(mat: mat4) {
 
 const tempVec3 = vec3.create();
 
-// Determines the bounding box in world coordinates of the view frustrum for a given view-projection
+// Determines the bounding box in world coordinates of the view frustum for a given view-projection
 // matrix.
 //
 // https://gamedev.stackexchange.com/questions/29999/how-do-i-create-a-bounding-frustum-from-a-view-projection-matrix
-export function getViewFrustrumWorldBounds(
+export function getViewFrustumWorldBounds(
   invViewProjectionMat: mat4,
   bounds: Float32Array,
 ) {

--- a/src/volume_rendering/base.ts
+++ b/src/volume_rendering/base.ts
@@ -23,7 +23,7 @@ import { forEachVisibleVolumetricChunk } from "#src/sliceview/base.js";
 import type { VolumeChunkSource } from "#src/sliceview/volume/base.js";
 import type { vec3 } from "#src/util/geom.js";
 import {
-  getViewFrustrumDepthRange,
+  getViewFrustumDepthRange,
   mat3,
   mat3FromMat4,
   prod3,
@@ -73,7 +73,7 @@ export function getVolumeRenderingNearFarBounds(
 //   const modelViewProjection = mat4.multiply(
 //       tempMat4, projectionParameters.viewProjectionMat, tsource.chunkLayout.transform);
 //   const clippingPlanes = tempVisibleVolumetricClippingPlanes;
-//   getFrustrumPlanes(clippingPlanes, modelViewProjection);
+//   getFrustumPlanes(clippingPlanes, modelViewProjection);
 //   const {near, far} = getVolumeRenderingNearFarBounds(
 //       clippingPlanes, tsource.lowerClipDisplayBound, tsource.upperClipDisplayBound);
 //   if (near === far) return -1;
@@ -112,7 +112,7 @@ export function forEachVisibleVolumeRenderingChunk<
   const { voxelPhysicalScales } = displayDimensionRenderInfo;
   const canonicalToPhysicalScale = prod3(voxelPhysicalScales);
 
-  const depthRange = getViewFrustrumDepthRange(projectionMat);
+  const depthRange = getViewFrustumDepthRange(projectionMat);
   // Target voxel spacing in view space
   const targetViewSpacing = depthRange / volumeRenderingDepthSamples;
   // Target voxel volume in view space.

--- a/src/volume_rendering/volume_render_layer.ts
+++ b/src/volume_rendering/volume_render_layer.ts
@@ -54,7 +54,7 @@ import {
   registerNested,
 } from "#src/trackable_value.js";
 import type { RefCountedValue } from "#src/util/disposable.js";
-import { getFrustrumPlanes, mat4, vec3 } from "#src/util/geom.js";
+import { getFrustumPlanes, mat4, vec3 } from "#src/util/geom.js";
 import { clampToInterval } from "#src/util/lerp.js";
 import { getObjectId } from "#src/util/object_id.js";
 import type { HistogramInformation } from "#src/volume_rendering/base.js";
@@ -367,7 +367,7 @@ void emitRGBA(vec4 rgba) {
             glsl_handleMaxProjectionUpdate = `
   float newIntensity = getIntensity();
   bool intensityChanged = newIntensity > savedIntensity;
-  savedIntensity = intensityChanged ? newIntensity : savedIntensity; 
+  savedIntensity = intensityChanged ? newIntensity : savedIntensity;
   savedDepth = intensityChanged ? depthAtRayPosition : savedDepth;
   outputColor = intensityChanged ? newColor : outputColor;
   emit(outputColor, savedDepth, savedIntensity, uPickId);
@@ -929,7 +929,7 @@ outputValue = vec4(1.0, 1.0, 1.0, 1.0);
           chunkLayout.transform,
         );
         const clippingPlanes = tempVisibleVolumetricClippingPlanes;
-        getFrustrumPlanes(clippingPlanes, modelViewProjection);
+        getFrustumPlanes(clippingPlanes, modelViewProjection);
         const inverseModelViewProjection = mat4.create();
         mat4.invert(inverseModelViewProjection, modelViewProjection);
         const { near, far, adjustedNear, adjustedFar } =


### PR DESCRIPTION
Very minor change, but recently I was trying to debug something and was grepping the codebase for uses of "frustum". I couldn't find any, which was surprising. Then I noticed it was across the codebase as "frustrum" instead. This is just to change that spelling
