### PR TITLE
Add annotation reordering

### DIFF
--- a/src/annotation/frontend_source.ts
+++ b/src/annotation/frontend_source.ts
@@ -1042,6 +1042,7 @@ export class MultiscaleAnnotationSource
   childUpdated: Signal<(annotation: Annotation) => void>;
   childCommitted: Signal<(annotationId: string) => void>;
   childDeleted: Signal<(annotationId: string) => void>;
+  childrenReordered = new NullarySignal();
 }
 
 registerRPC(ANNOTATION_COMMIT_UPDATE_RESULT_RPC_ID, function (x) {

--- a/src/annotation/index.ts
+++ b/src/annotation/index.ts
@@ -1478,14 +1478,9 @@ export class AnnotationSource
     if (placement === "after") targetIndex += 1;
     ids.splice(targetIndex, 0, sourceId);
     // No-op if order is unchanged.
-    let changed = false;
-    let i = 0;
-    for (const id of annotationMap.keys()) {
-      if (id !== ids[i++]) {
-        changed = true;
-        break;
-      }
-    }
+    const changed = !Array.from(annotationMap.keys()).every(
+      (id, i) => id === ids[i],
+    );
     if (!changed) return false;
     const entries = ids.map(
       (id) => [id, annotationMap.get(id)!] as [AnnotationId, Annotation],

--- a/src/annotation/index.ts
+++ b/src/annotation/index.ts
@@ -1370,6 +1370,7 @@ export interface AnnotationSourceSignals {
   childUpdated: Signal<(annotation: Annotation) => void>;
   childCommitted: Signal<(annotationId: string) => void>;
   childDeleted: Signal<(annotationId: string) => void>;
+  childrenReordered: NullarySignal;
 }
 
 export class AnnotationSource
@@ -1383,6 +1384,7 @@ export class AnnotationSource
   childUpdated = new Signal<(annotation: Annotation) => void>();
   childCommitted = new Signal<(annotationId: string) => void>();
   childDeleted = new Signal<(annotationId: string) => void>();
+  childrenReordered = new NullarySignal();
 
   public pending = new Set<AnnotationId>();
 
@@ -1452,6 +1454,49 @@ export class AnnotationSource
     reference.changed.dispatch();
     this.changed.dispatch();
     this.childUpdated.dispatch(annotation);
+  }
+
+  // Moves the annotation with id `sourceId` so it sits immediately before
+  // (placement === "before") or after (placement === "after") `targetId`,
+  // preserving the relative order of all other annotations. Returns true if
+  // the order actually changed.
+  reorder(
+    sourceId: AnnotationId,
+    targetId: AnnotationId,
+    placement: "before" | "after",
+  ): boolean {
+    this.ensureUpdated();
+    if (sourceId === targetId) return false;
+    const { annotationMap } = this;
+    if (!annotationMap.has(sourceId) || !annotationMap.has(targetId)) {
+      return false;
+    }
+    const ids = Array.from(annotationMap.keys());
+    const fromIndex = ids.indexOf(sourceId);
+    ids.splice(fromIndex, 1);
+    let targetIndex = ids.indexOf(targetId);
+    if (placement === "after") targetIndex += 1;
+    ids.splice(targetIndex, 0, sourceId);
+    // No-op if order is unchanged.
+    let changed = false;
+    let i = 0;
+    for (const id of annotationMap.keys()) {
+      if (id !== ids[i++]) {
+        changed = true;
+        break;
+      }
+    }
+    if (!changed) return false;
+    const entries = ids.map(
+      (id) => [id, annotationMap.get(id)!] as [AnnotationId, Annotation],
+    );
+    annotationMap.clear();
+    for (const [id, annotation] of entries) {
+      annotationMap.set(id, annotation);
+    }
+    this.changed.dispatch();
+    this.childrenReordered.dispatch();
+    return true;
   }
 
   [Symbol.iterator]() {

--- a/src/ui/annotations.css
+++ b/src/ui/annotations.css
@@ -99,6 +99,18 @@
   background-color: #969;
 }
 
+.neuroglancer-annotation-dragging {
+  opacity: 0.5;
+}
+
+.neuroglancer-annotation-drop-before {
+  box-shadow: inset 0 2px 0 0 #fc0;
+}
+
+.neuroglancer-annotation-drop-after {
+  box-shadow: inset 0 -2px 0 0 #fc0;
+}
+
 .neuroglancer-tab-content.neuroglancer-annotation-details {
   flex: 0 0 auto;
   align-self: stretch;

--- a/src/ui/annotations.css
+++ b/src/ui/annotations.css
@@ -93,6 +93,13 @@
   visibility: hidden;
 }
 
+/* Suppress text selection while reordering. Firefox in particular starts a
+   (rectangular) selection on alt+drag, which is the gesture used to reorder. */
+.neuroglancer-annotation-list-dragging {
+  user-select: none;
+  -moz-user-select: none;
+}
+
 .neuroglancer-annotation-hover {
   background-color: #333;
 }

--- a/src/ui/annotations.css
+++ b/src/ui/annotations.css
@@ -87,6 +87,12 @@
   visibility: visible;
 }
 
+.neuroglancer-annotation-list-dragging
+  .neuroglancer-annotation-list-entry:hover
+  > .neuroglancer-annotation-list-entry-delete {
+  visibility: hidden;
+}
+
 .neuroglancer-annotation-hover {
   background-color: #333;
 }

--- a/src/ui/annotations.ts
+++ b/src/ui/annotations.ts
@@ -594,6 +594,7 @@ export class AnnotationLayerView extends Tab {
       if (dragState === undefined) return;
       const { sourceId, state, sourceRow, dropRow, dropPlacement } = dragState;
       sourceRow.classList.remove("neuroglancer-annotation-dragging");
+      listElement.classList.remove("neuroglancer-annotation-list-dragging");
       clearDropTarget();
       document.removeEventListener("mousemove", onMouseMove, true);
       document.removeEventListener("mouseup", onMouseUp, true);
@@ -680,6 +681,7 @@ export class AnnotationLayerView extends Tab {
       event.preventDefault();
       event.stopPropagation();
       row.classList.add("neuroglancer-annotation-dragging");
+      listElement.classList.add("neuroglancer-annotation-list-dragging");
       dragState = {
         sourceId,
         state,

--- a/src/ui/annotations.ts
+++ b/src/ui/annotations.ts
@@ -321,6 +321,9 @@ export class AnnotationLayerView extends Tab {
             this.deleteAnnotationElement(annotationId, state),
           ),
         );
+        refCounted.registerDisposer(
+          source.childrenReordered.add(this.forceUpdateView),
+        );
       }
       refCounted.registerDisposer(
         state.transform.changed.add(this.forceUpdateView),
@@ -504,9 +507,9 @@ export class AnnotationLayerView extends Tab {
 
     const helpIcon = makeIcon({
       title:
-        "The left icons allow you to select the type of the anotation. Color and other display settings are available in the 'Rendering' tab.",
+        "The left icons allow you to select the type of the annotation. Color and other display settings are available in the 'Rendering' tab. Click for documentation.",
       svg: svg_help,
-      clickable: false,
+      href: "https://neuroglancer-docs.web.app/user-guide/annotation.html",
     });
     helpIcon.style.marginLeft = "auto";
     mutableControls.appendChild(helpIcon);
@@ -550,6 +553,150 @@ export class AnnotationLayerView extends Tab {
     this.updateCoordinateSpace();
     this.updateAttachedAnnotationLayerStates();
     this.updateSelectionView();
+    this.setupListReorder();
+  }
+
+  private findStateForAnnotationId(
+    annotationId: AnnotationId,
+  ): AnnotationLayerState | undefined {
+    for (const [state, info] of this.attachedAnnotationStates) {
+      if (info.idToIndex.has(annotationId)) return state;
+    }
+    return undefined;
+  }
+
+  // Wires alt+left-click-drag on annotation list rows to reorder annotations
+  // within a single local annotation source.
+  private setupListReorder() {
+    const listElement = this.virtualList.element;
+    let dragState:
+      | {
+          sourceId: AnnotationId;
+          state: AnnotationLayerState;
+          sourceRow: HTMLElement;
+          dropRow: HTMLElement | undefined;
+          dropPlacement: "before" | "after" | undefined;
+        }
+      | undefined;
+
+    const clearDropTarget = () => {
+      if (dragState?.dropRow !== undefined) {
+        dragState.dropRow.classList.remove(
+          "neuroglancer-annotation-drop-before",
+          "neuroglancer-annotation-drop-after",
+        );
+        dragState.dropRow = undefined;
+        dragState.dropPlacement = undefined;
+      }
+    };
+
+    const finish = (commit: boolean) => {
+      if (dragState === undefined) return;
+      const { sourceId, state, sourceRow, dropRow, dropPlacement } = dragState;
+      sourceRow.classList.remove("neuroglancer-annotation-dragging");
+      clearDropTarget();
+      document.removeEventListener("mousemove", onMouseMove, true);
+      document.removeEventListener("mouseup", onMouseUp, true);
+      document.removeEventListener("keydown", onKeyDown, true);
+      dragState = undefined;
+      if (!commit || dropRow === undefined || dropPlacement === undefined) {
+        return;
+      }
+      const targetId = dropRow.dataset.annotationId;
+      if (targetId === undefined || targetId === sourceId) return;
+      const source = state.source;
+      if (!(source instanceof AnnotationSource)) return;
+      source.reorder(sourceId, targetId, dropPlacement);
+    };
+
+    const onMouseMove = (event: MouseEvent) => {
+      if (dragState === undefined) return;
+      const target = (event.target as HTMLElement | null)?.closest(
+        ".neuroglancer-annotation-list-entry",
+      ) as HTMLElement | null;
+      if (
+        target === null ||
+        target === dragState.sourceRow ||
+        target.dataset.annotationId === undefined
+      ) {
+        clearDropTarget();
+        return;
+      }
+      // Only allow drops within the same annotation source.
+      const targetState = this.findStateForAnnotationId(
+        target.dataset.annotationId,
+      );
+      if (targetState !== dragState.state) {
+        clearDropTarget();
+        return;
+      }
+      const rect = target.getBoundingClientRect();
+      const placement: "before" | "after" =
+        event.clientY < rect.top + rect.height / 2 ? "before" : "after";
+      if (
+        dragState.dropRow === target &&
+        dragState.dropPlacement === placement
+      ) {
+        return;
+      }
+      clearDropTarget();
+      target.classList.add(
+        placement === "before"
+          ? "neuroglancer-annotation-drop-before"
+          : "neuroglancer-annotation-drop-after",
+      );
+      dragState.dropRow = target;
+      dragState.dropPlacement = placement;
+    };
+
+    const onMouseUp = (event: MouseEvent) => {
+      if (event.button !== 0) return;
+      finish(true);
+    };
+
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        event.preventDefault();
+        finish(false);
+      }
+    };
+
+    const onMouseDown = (event: MouseEvent) => {
+      if (event.button !== 0 || !event.altKey) return;
+      const row = (event.target as HTMLElement | null)?.closest(
+        ".neuroglancer-annotation-list-entry",
+      ) as HTMLElement | null;
+      if (row === null) return;
+      const sourceId = row.dataset.annotationId;
+      if (sourceId === undefined) return;
+      const state = this.findStateForAnnotationId(sourceId);
+      if (state === undefined) return;
+      if (
+        !(state.source instanceof AnnotationSource) ||
+        state.source.readonly
+      ) {
+        return;
+      }
+      event.preventDefault();
+      event.stopPropagation();
+      row.classList.add("neuroglancer-annotation-dragging");
+      dragState = {
+        sourceId,
+        state,
+        sourceRow: row,
+        dropRow: undefined,
+        dropPlacement: undefined,
+      };
+      document.addEventListener("mousemove", onMouseMove, true);
+      document.addEventListener("mouseup", onMouseUp, true);
+      document.addEventListener("keydown", onKeyDown, true);
+    };
+
+    listElement.addEventListener("mousedown", onMouseDown);
+    this.registerDisposer(() => {
+      finish(false);
+      listElement.removeEventListener("mousedown", onMouseDown);
+    });
   }
 
   private getRenderedAnnotationListElement(
@@ -2563,6 +2710,7 @@ export function makeAnnotationListElement(
   const element = document.createElement("div");
   element.classList.add("neuroglancer-annotation-list-entry");
   element.dataset.color = state.displayState.color.toString();
+  element.dataset.annotationId = annotation.id;
   element.style.gridTemplateColumns = gridTemplate;
   const icon = document.createElement("div");
   icon.className = "neuroglancer-annotation-icon";

--- a/src/ui/annotations.ts
+++ b/src/ui/annotations.ts
@@ -600,6 +600,7 @@ export class AnnotationLayerView extends Tab {
       document.removeEventListener("mousemove", onMouseMove, true);
       document.removeEventListener("mouseup", onMouseUp, true);
       document.removeEventListener("keydown", onKeyDown, true);
+      window.removeEventListener("blur", onBlur, true);
       dragState = undefined;
       if (!commit || dropRow === undefined || dropPlacement === undefined) {
         return;
@@ -613,9 +614,13 @@ export class AnnotationLayerView extends Tab {
 
     const onMouseMove = (event: MouseEvent) => {
       if (dragState === undefined) return;
-      const target = (event.target as HTMLElement | null)?.closest(
-        ".neuroglancer-annotation-list-entry",
-      ) as HTMLElement | null;
+      const eventTarget = event.target;
+      const target =
+        eventTarget instanceof Element
+          ? (eventTarget.closest(
+              ".neuroglancer-annotation-list-entry",
+            ) as HTMLElement | null)
+          : null;
       if (
         target === null ||
         target === dragState.sourceRow ||
@@ -663,6 +668,10 @@ export class AnnotationLayerView extends Tab {
       }
     };
 
+    const onBlur = () => {
+      finish(false);
+    };
+
     const onReorderStart = (event: ActionEvent<MouseEvent>) => {
       const row = (event.detail.target as HTMLElement | null)?.closest(
         ".neuroglancer-annotation-list-entry",
@@ -690,6 +699,7 @@ export class AnnotationLayerView extends Tab {
       document.addEventListener("mousemove", onMouseMove, true);
       document.addEventListener("mouseup", onMouseUp, true);
       document.addEventListener("keydown", onKeyDown, true);
+      window.addEventListener("blur", onBlur, true);
     };
 
     const unregister = registerActionListener<MouseEvent>(

--- a/src/ui/annotations.ts
+++ b/src/ui/annotations.ts
@@ -508,7 +508,7 @@ export class AnnotationLayerView extends Tab {
 
     const helpIcon = makeIcon({
       title:
-         "The left icons allow you to select the type of the anotation. Color and other display settings are available in the 'Rendering' tab.",
+        "The left icons allow you to select the type of the anotation. Color and other display settings are available in the 'Rendering' tab.",
       svg: svg_help,
       clickable: false,
     });

--- a/src/ui/annotations.ts
+++ b/src/ui/annotations.ts
@@ -102,6 +102,7 @@ import { Endianness, ENDIANNESS } from "#src/util/endian.js";
 import type { ValueOrError } from "#src/util/error.js";
 import { vec3, vec4 } from "#src/util/geom.js";
 import { parseUint64 } from "#src/util/json.js";
+import type { ActionEvent } from "#src/util/keyboard_bindings.js";
 import {
   EventActionMap,
   KeyboardEventBinder,
@@ -662,9 +663,8 @@ export class AnnotationLayerView extends Tab {
       }
     };
 
-    const onMouseDown = (event: MouseEvent) => {
-      if (event.button !== 0 || !event.altKey) return;
-      const row = (event.target as HTMLElement | null)?.closest(
+    const onReorderStart = (event: ActionEvent<MouseEvent>) => {
+      const row = (event.detail.target as HTMLElement | null)?.closest(
         ".neuroglancer-annotation-list-entry",
       ) as HTMLElement | null;
       if (row === null) return;
@@ -678,8 +678,6 @@ export class AnnotationLayerView extends Tab {
       ) {
         return;
       }
-      event.preventDefault();
-      event.stopPropagation();
       row.classList.add("neuroglancer-annotation-dragging");
       listElement.classList.add("neuroglancer-annotation-list-dragging");
       dragState = {
@@ -694,10 +692,14 @@ export class AnnotationLayerView extends Tab {
       document.addEventListener("keydown", onKeyDown, true);
     };
 
-    listElement.addEventListener("mousedown", onMouseDown);
+    const unregister = registerActionListener<MouseEvent>(
+      listElement,
+      "reorder-annotation",
+      onReorderStart,
+    );
     this.registerDisposer(() => {
       finish(false);
-      listElement.removeEventListener("mousedown", onMouseDown);
+      unregister();
     });
   }
 

--- a/src/ui/annotations.ts
+++ b/src/ui/annotations.ts
@@ -508,9 +508,9 @@ export class AnnotationLayerView extends Tab {
 
     const helpIcon = makeIcon({
       title:
-        "The left icons allow you to select the type of the annotation. Color and other display settings are available in the 'Rendering' tab. Click for documentation.",
+         "The left icons allow you to select the type of the anotation. Color and other display settings are available in the 'Rendering' tab.",
       svg: svg_help,
-      href: "https://neuroglancer-docs.web.app/user-guide/annotation.html",
+      clickable: false,
     });
     helpIcon.style.marginLeft = "auto";
     mutableControls.appendChild(helpIcon);
@@ -606,7 +606,7 @@ export class AnnotationLayerView extends Tab {
       }
       const targetId = dropRow.dataset.annotationId;
       if (targetId === undefined || targetId === sourceId) return;
-      const source = state.source;
+      const { source } = state;
       if (!(source instanceof AnnotationSource)) return;
       source.reorder(sourceId, targetId, dropPlacement);
     };

--- a/src/ui/default_input_event_bindings.ts
+++ b/src/ui/default_input_event_bindings.ts
@@ -71,6 +71,7 @@ export function getDefaultAnnotationListBindings() {
       {
         click0: "pin-annotation",
         mousedown2: "move-to-annotation",
+        "alt+mousedown0": "reorder-annotation",
       },
       { parents: [[getDefaultSelectBindings(), 0]] },
     );


### PR DESCRIPTION
Allows reordering of local annotations via alt+drag in the annotation list. Includes the reorder() method on AnnotationSource, the childrenReordered signal, drag-and-drop UI wiring, drop indicator styles, and a documentation link on the annotation help icon.