### PR TITLE
auto hide controls

### DIFF
--- a/python/neuroglancer/viewer_state.py
+++ b/python/neuroglancer/viewer_state.py
@@ -605,6 +605,9 @@ class ImageLayer(Layer, _AnnotationLayerOptions):
     shader_controls = shaderControls = wrapped_property(
         "shaderControls", ShaderControls
     )
+    hide_inactive_controls = hideInactiveControls = wrapped_property(
+        "hideInactiveControls", optional(bool, False)
+    )
     opacity = wrapped_property("opacity", optional(float, 0.5))
     blend = wrapped_property("blend", optional(str))
     volume_rendering_mode = volumeRenderingMode = VolumeRendering = volume_rendering = (
@@ -650,6 +653,9 @@ class SkeletonRenderingOptions(JsonObjectWrapper):
     shader = wrapped_property("shader", optional(str))
     shader_controls = shaderControls = wrapped_property(
         "shaderControls", ShaderControls
+    )
+    hide_inactive_controls = hideInactiveControls = wrapped_property(
+        "hideInactiveControls", optional(bool, False)
     )
     mode2d = wrapped_property("mode2d", optional(str))
     line_width2d = lineWidth2d = wrapped_property("lineWidth2d", optional(float, 2))
@@ -1027,6 +1033,9 @@ class SingleMeshLayer(Layer):
     vertex_attribute_names = vertexAttributeNames = wrapped_property(
         "vertexAttributeNames", optional(typed_list(optional(str)))
     )
+    hide_inactive_controls = hideInactiveControls = wrapped_property(
+        "hideInactiveControls", optional(bool, False)
+    )
 
 
 def _factory_new(
@@ -1182,6 +1191,9 @@ class AnnotationLayer(Layer, _AnnotationLayerOptions):
     shader = wrapped_property("shader", str)
     shader_controls = shaderControls = wrapped_property(
         "shaderControls", ShaderControls
+    )
+    hide_inactive_controls = hideInactiveControls = wrapped_property(
+        "hideInactiveControls", optional(bool, False)
     )
 
     @staticmethod

--- a/python/neuroglancer/viewer_state.py
+++ b/python/neuroglancer/viewer_state.py
@@ -605,8 +605,8 @@ class ImageLayer(Layer, _AnnotationLayerOptions):
     shader_controls = shaderControls = wrapped_property(
         "shaderControls", ShaderControls
     )
-    hide_inactive_controls = hideInactiveControls = wrapped_property(
-        "hideInactiveControls", optional(bool, False)
+    hide_inactive_shader_controls = hideInactiveShaderControls = wrapped_property(
+        "hideInactiveShaderControls", optional(bool, False)
     )
     opacity = wrapped_property("opacity", optional(float, 0.5))
     blend = wrapped_property("blend", optional(str))
@@ -654,8 +654,8 @@ class SkeletonRenderingOptions(JsonObjectWrapper):
     shader_controls = shaderControls = wrapped_property(
         "shaderControls", ShaderControls
     )
-    hide_inactive_controls = hideInactiveControls = wrapped_property(
-        "hideInactiveControls", optional(bool, False)
+    hide_inactive_shader_controls = hideInactiveShaderControls = wrapped_property(
+        "hideInactiveShaderControls", optional(bool, False)
     )
     mode2d = wrapped_property("mode2d", optional(str))
     line_width2d = lineWidth2d = wrapped_property("lineWidth2d", optional(float, 2))
@@ -1033,8 +1033,8 @@ class SingleMeshLayer(Layer):
     vertex_attribute_names = vertexAttributeNames = wrapped_property(
         "vertexAttributeNames", optional(typed_list(optional(str)))
     )
-    hide_inactive_controls = hideInactiveControls = wrapped_property(
-        "hideInactiveControls", optional(bool, False)
+    hide_inactive_shader_controls = hideInactiveShaderControls = wrapped_property(
+        "hideInactiveShaderControls", optional(bool, False)
     )
 
 
@@ -1192,8 +1192,8 @@ class AnnotationLayer(Layer, _AnnotationLayerOptions):
     shader_controls = shaderControls = wrapped_property(
         "shaderControls", ShaderControls
     )
-    hide_inactive_controls = hideInactiveControls = wrapped_property(
-        "hideInactiveControls", optional(bool, False)
+    hide_inactive_shader_controls = hideInactiveShaderControls = wrapped_property(
+        "hideInactiveShaderControls", optional(bool, False)
     )
 
     @staticmethod

--- a/src/layer/annotation/index.ts
+++ b/src/layer/annotation/index.ts
@@ -156,6 +156,7 @@ const LINKED_SEGMENTATION_LAYER_JSON_KEY = "linkedSegmentationLayer";
 const FILTER_BY_SEGMENTATION_JSON_KEY = "filterBySegmentation";
 const IGNORE_NULL_SEGMENT_FILTER_JSON_KEY = "ignoreNullSegmentFilter";
 const CODE_VISIBLE_KEY = "codeVisible";
+const HIDE_INACTIVE_CONTROLS_JSON_KEY = "hideInactiveControls";
 
 class LinkedSegmentationLayers extends RefCounted {
   changed = new NullarySignal();
@@ -401,6 +402,7 @@ const Base = UserLayerWithAnnotationsMixin(UserLayer);
 export class AnnotationUserLayer extends Base {
   localAnnotations: LocalAnnotationSource | undefined;
   codeVisible = new TrackableBoolean(true);
+  hideInactiveControls = new TrackableBoolean(false);
   private localAnnotationProperties: WatchableValue<AnnotationPropertySpec[]> =
     new WatchableValue([]);
   private localAnnotationRelationships: string[];
@@ -430,6 +432,7 @@ export class AnnotationUserLayer extends Base {
       this.specificationChanged.dispatch,
     );
     this.codeVisible.changed.add(this.specificationChanged.dispatch);
+    this.hideInactiveControls.changed.add(this.specificationChanged.dispatch);
     this.annotationDisplayState.ignoreNullSegmentFilter.changed.add(
       this.specificationChanged.dispatch,
     );
@@ -456,6 +459,9 @@ export class AnnotationUserLayer extends Base {
     super.restoreState(specification);
     this.linkedSegmentationLayers.restoreState(specification);
     this.codeVisible.restoreState(specification[CODE_VISIBLE_KEY]);
+    this.hideInactiveControls.restoreState(
+      specification[HIDE_INACTIVE_CONTROLS_JSON_KEY],
+    );
     this.localAnnotationsJson = specification[ANNOTATIONS_JSON_KEY];
     const properties = verifyOptionalObjectProperty(
       specification,
@@ -737,6 +743,7 @@ export class AnnotationUserLayer extends Base {
     x[CROSS_SECTION_RENDER_SCALE_JSON_KEY] =
       this.annotationCrossSectionRenderScaleTarget.toJSON();
     x[CODE_VISIBLE_KEY] = this.codeVisible.toJSON();
+    x[HIDE_INACTIVE_CONTROLS_JSON_KEY] = this.hideInactiveControls.toJSON();
     x[PROJECTION_RENDER_SCALE_JSON_KEY] =
       this.annotationProjectionRenderScaleTarget.toJSON();
     if (this.localAnnotations !== undefined) {
@@ -858,7 +865,10 @@ class RenderingOptionsTab extends Tab {
           layer.annotationDisplayState.shaderControls,
           this.layer.manager.root.display,
           this.layer,
-          { visibility: this.visibility },
+          {
+            visibility: this.visibility,
+            hideInactiveControls: layer.hideInactiveControls,
+          },
         ),
       ).element,
     );

--- a/src/layer/annotation/index.ts
+++ b/src/layer/annotation/index.ts
@@ -156,7 +156,7 @@ const LINKED_SEGMENTATION_LAYER_JSON_KEY = "linkedSegmentationLayer";
 const FILTER_BY_SEGMENTATION_JSON_KEY = "filterBySegmentation";
 const IGNORE_NULL_SEGMENT_FILTER_JSON_KEY = "ignoreNullSegmentFilter";
 const CODE_VISIBLE_KEY = "codeVisible";
-const HIDE_INACTIVE_CONTROLS_JSON_KEY = "hideInactiveControls";
+const hide_inactive_shader_controls_JSON_KEY = "hideInactiveShaderControls";
 
 class LinkedSegmentationLayers extends RefCounted {
   changed = new NullarySignal();
@@ -402,7 +402,7 @@ const Base = UserLayerWithAnnotationsMixin(UserLayer);
 export class AnnotationUserLayer extends Base {
   localAnnotations: LocalAnnotationSource | undefined;
   codeVisible = new TrackableBoolean(true);
-  hideInactiveControls = new TrackableBoolean(false);
+  hideInactiveShaderControls = new TrackableBoolean(false);
   private localAnnotationProperties: WatchableValue<AnnotationPropertySpec[]> =
     new WatchableValue([]);
   private localAnnotationRelationships: string[];
@@ -432,7 +432,7 @@ export class AnnotationUserLayer extends Base {
       this.specificationChanged.dispatch,
     );
     this.codeVisible.changed.add(this.specificationChanged.dispatch);
-    this.hideInactiveControls.changed.add(this.specificationChanged.dispatch);
+    this.hideInactiveShaderControls.changed.add(this.specificationChanged.dispatch);
     this.annotationDisplayState.ignoreNullSegmentFilter.changed.add(
       this.specificationChanged.dispatch,
     );
@@ -459,8 +459,8 @@ export class AnnotationUserLayer extends Base {
     super.restoreState(specification);
     this.linkedSegmentationLayers.restoreState(specification);
     this.codeVisible.restoreState(specification[CODE_VISIBLE_KEY]);
-    this.hideInactiveControls.restoreState(
-      specification[HIDE_INACTIVE_CONTROLS_JSON_KEY],
+    this.hideInactiveShaderControls.restoreState(
+      specification[hide_inactive_shader_controls_JSON_KEY],
     );
     this.localAnnotationsJson = specification[ANNOTATIONS_JSON_KEY];
     const properties = verifyOptionalObjectProperty(
@@ -743,7 +743,7 @@ export class AnnotationUserLayer extends Base {
     x[CROSS_SECTION_RENDER_SCALE_JSON_KEY] =
       this.annotationCrossSectionRenderScaleTarget.toJSON();
     x[CODE_VISIBLE_KEY] = this.codeVisible.toJSON();
-    x[HIDE_INACTIVE_CONTROLS_JSON_KEY] = this.hideInactiveControls.toJSON();
+    x[hide_inactive_shader_controls_JSON_KEY] = this.hideInactiveShaderControls.toJSON();
     x[PROJECTION_RENDER_SCALE_JSON_KEY] =
       this.annotationProjectionRenderScaleTarget.toJSON();
     if (this.localAnnotations !== undefined) {
@@ -867,7 +867,7 @@ class RenderingOptionsTab extends Tab {
           this.layer,
           {
             visibility: this.visibility,
-            hideInactiveControls: layer.hideInactiveControls,
+            hideInactiveShaderControls: layer.hideInactiveShaderControls,
           },
         ),
       ).element,

--- a/src/layer/annotation/index.ts
+++ b/src/layer/annotation/index.ts
@@ -432,7 +432,9 @@ export class AnnotationUserLayer extends Base {
       this.specificationChanged.dispatch,
     );
     this.codeVisible.changed.add(this.specificationChanged.dispatch);
-    this.hideInactiveShaderControls.changed.add(this.specificationChanged.dispatch);
+    this.hideInactiveShaderControls.changed.add(
+      this.specificationChanged.dispatch,
+    );
     this.annotationDisplayState.ignoreNullSegmentFilter.changed.add(
       this.specificationChanged.dispatch,
     );
@@ -743,7 +745,8 @@ export class AnnotationUserLayer extends Base {
     x[CROSS_SECTION_RENDER_SCALE_JSON_KEY] =
       this.annotationCrossSectionRenderScaleTarget.toJSON();
     x[CODE_VISIBLE_KEY] = this.codeVisible.toJSON();
-    x[HIDE_INACTIVE_SHADER_CONTROLS_JSON_KEY] = this.hideInactiveShaderControls.toJSON();
+    x[HIDE_INACTIVE_SHADER_CONTROLS_JSON_KEY] =
+      this.hideInactiveShaderControls.toJSON();
     x[PROJECTION_RENDER_SCALE_JSON_KEY] =
       this.annotationProjectionRenderScaleTarget.toJSON();
     if (this.localAnnotations !== undefined) {

--- a/src/layer/annotation/index.ts
+++ b/src/layer/annotation/index.ts
@@ -156,7 +156,7 @@ const LINKED_SEGMENTATION_LAYER_JSON_KEY = "linkedSegmentationLayer";
 const FILTER_BY_SEGMENTATION_JSON_KEY = "filterBySegmentation";
 const IGNORE_NULL_SEGMENT_FILTER_JSON_KEY = "ignoreNullSegmentFilter";
 const CODE_VISIBLE_KEY = "codeVisible";
-const hide_inactive_shader_controls_JSON_KEY = "hideInactiveShaderControls";
+const HIDE_INACTIVE_SHADER_CONTROLS_JSON_KEY = "hideInactiveShaderControls";
 
 class LinkedSegmentationLayers extends RefCounted {
   changed = new NullarySignal();
@@ -460,7 +460,7 @@ export class AnnotationUserLayer extends Base {
     this.linkedSegmentationLayers.restoreState(specification);
     this.codeVisible.restoreState(specification[CODE_VISIBLE_KEY]);
     this.hideInactiveShaderControls.restoreState(
-      specification[hide_inactive_shader_controls_JSON_KEY],
+      specification[HIDE_INACTIVE_SHADER_CONTROLS_JSON_KEY],
     );
     this.localAnnotationsJson = specification[ANNOTATIONS_JSON_KEY];
     const properties = verifyOptionalObjectProperty(
@@ -743,7 +743,7 @@ export class AnnotationUserLayer extends Base {
     x[CROSS_SECTION_RENDER_SCALE_JSON_KEY] =
       this.annotationCrossSectionRenderScaleTarget.toJSON();
     x[CODE_VISIBLE_KEY] = this.codeVisible.toJSON();
-    x[hide_inactive_shader_controls_JSON_KEY] = this.hideInactiveShaderControls.toJSON();
+    x[HIDE_INACTIVE_SHADER_CONTROLS_JSON_KEY] = this.hideInactiveShaderControls.toJSON();
     x[PROJECTION_RENDER_SCALE_JSON_KEY] =
       this.annotationProjectionRenderScaleTarget.toJSON();
     if (this.localAnnotations !== undefined) {

--- a/src/layer/image/index.ts
+++ b/src/layer/image/index.ts
@@ -109,7 +109,7 @@ const BLEND_JSON_KEY = "blend";
 const SHADER_JSON_KEY = "shader";
 const CODE_VISIBLE_KEY = "codeVisible";
 const SHADER_CONTROLS_JSON_KEY = "shaderControls";
-const HIDE_INACTIVE_CONTROLS_JSON_KEY = "hideInactiveControls";
+const hide_inactive_shader_controls_JSON_KEY = "hideInactiveShaderControls";
 const CROSS_SECTION_RENDER_SCALE_JSON_KEY = "crossSectionRenderScale";
 const CHANNEL_DIMENSIONS_JSON_KEY = "channelDimensions";
 const VOLUME_RENDERING_JSON_KEY = "volumeRendering";
@@ -129,7 +129,7 @@ export class ImageUserLayer extends Base {
   opacity = trackableAlphaValue(0.5);
   blendMode = trackableBlendModeValue();
   codeVisible = new TrackableBoolean(true);
-  hideInactiveControls = new TrackableBoolean(false);
+  hideInactiveShaderControls = new TrackableBoolean(false);
   fragmentMain = getTrackableFragmentMain();
   shaderError = makeWatchableShaderError();
   dataType = new WatchableValue<DataType | undefined>(undefined);
@@ -211,7 +211,7 @@ export class ImageUserLayer extends Base {
     this.blendMode.changed.add(this.specificationChanged.dispatch);
     this.opacity.changed.add(this.specificationChanged.dispatch);
     this.codeVisible.changed.add(this.specificationChanged.dispatch);
-    this.hideInactiveControls.changed.add(this.specificationChanged.dispatch);
+    this.hideInactiveShaderControls.changed.add(this.specificationChanged.dispatch);
     this.volumeRenderingGain.changed.add(this.specificationChanged.dispatch);
     this.fragmentMain.changed.add(this.specificationChanged.dispatch);
     this.shaderControlState.changed.add(this.specificationChanged.dispatch);
@@ -302,8 +302,8 @@ export class ImageUserLayer extends Base {
     super.restoreState(specification);
     this.opacity.restoreState(specification[OPACITY_JSON_KEY]);
     this.codeVisible.restoreState(specification[CODE_VISIBLE_KEY]);
-    this.hideInactiveControls.restoreState(
-      specification[HIDE_INACTIVE_CONTROLS_JSON_KEY],
+    this.hideInactiveShaderControls.restoreState(
+      specification[hide_inactive_shader_controls_JSON_KEY],
     );
     verifyOptionalObjectProperty(specification, BLEND_JSON_KEY, (blendValue) =>
       this.blendMode.restoreState(blendValue),
@@ -351,7 +351,7 @@ export class ImageUserLayer extends Base {
     x[OPACITY_JSON_KEY] = this.opacity.toJSON();
     x[BLEND_JSON_KEY] = this.blendMode.toJSON();
     x[CODE_VISIBLE_KEY] = this.codeVisible.toJSON();
-    x[HIDE_INACTIVE_CONTROLS_JSON_KEY] = this.hideInactiveControls.toJSON();
+    x[hide_inactive_shader_controls_JSON_KEY] = this.hideInactiveShaderControls.toJSON();
     x[SHADER_JSON_KEY] = this.fragmentMain.toJSON();
     x[SHADER_CONTROLS_JSON_KEY] = this.shaderControlState.toJSON();
     x[CROSS_SECTION_RENDER_SCALE_JSON_KEY] =
@@ -576,7 +576,7 @@ class RenderingOptionsTab extends Tab {
           {
             visibility: this.visibility,
             legendShaderOptions: this.layer.getLegendShaderOptions(),
-            hideInactiveControls: layer.hideInactiveControls,
+            hideInactiveShaderControls: layer.hideInactiveShaderControls,
           },
         ),
       ).element,

--- a/src/layer/image/index.ts
+++ b/src/layer/image/index.ts
@@ -109,7 +109,7 @@ const BLEND_JSON_KEY = "blend";
 const SHADER_JSON_KEY = "shader";
 const CODE_VISIBLE_KEY = "codeVisible";
 const SHADER_CONTROLS_JSON_KEY = "shaderControls";
-const hide_inactive_shader_controls_JSON_KEY = "hideInactiveShaderControls";
+const HIDE_INACTIVE_SHADER_CONTROLS_JSON_KEY = "hideInactiveShaderControls";
 const CROSS_SECTION_RENDER_SCALE_JSON_KEY = "crossSectionRenderScale";
 const CHANNEL_DIMENSIONS_JSON_KEY = "channelDimensions";
 const VOLUME_RENDERING_JSON_KEY = "volumeRendering";
@@ -303,7 +303,7 @@ export class ImageUserLayer extends Base {
     this.opacity.restoreState(specification[OPACITY_JSON_KEY]);
     this.codeVisible.restoreState(specification[CODE_VISIBLE_KEY]);
     this.hideInactiveShaderControls.restoreState(
-      specification[hide_inactive_shader_controls_JSON_KEY],
+      specification[HIDE_INACTIVE_SHADER_CONTROLS_JSON_KEY],
     );
     verifyOptionalObjectProperty(specification, BLEND_JSON_KEY, (blendValue) =>
       this.blendMode.restoreState(blendValue),
@@ -351,7 +351,7 @@ export class ImageUserLayer extends Base {
     x[OPACITY_JSON_KEY] = this.opacity.toJSON();
     x[BLEND_JSON_KEY] = this.blendMode.toJSON();
     x[CODE_VISIBLE_KEY] = this.codeVisible.toJSON();
-    x[hide_inactive_shader_controls_JSON_KEY] = this.hideInactiveShaderControls.toJSON();
+    x[HIDE_INACTIVE_SHADER_CONTROLS_JSON_KEY] = this.hideInactiveShaderControls.toJSON();
     x[SHADER_JSON_KEY] = this.fragmentMain.toJSON();
     x[SHADER_CONTROLS_JSON_KEY] = this.shaderControlState.toJSON();
     x[CROSS_SECTION_RENDER_SCALE_JSON_KEY] =

--- a/src/layer/image/index.ts
+++ b/src/layer/image/index.ts
@@ -211,7 +211,9 @@ export class ImageUserLayer extends Base {
     this.blendMode.changed.add(this.specificationChanged.dispatch);
     this.opacity.changed.add(this.specificationChanged.dispatch);
     this.codeVisible.changed.add(this.specificationChanged.dispatch);
-    this.hideInactiveShaderControls.changed.add(this.specificationChanged.dispatch);
+    this.hideInactiveShaderControls.changed.add(
+      this.specificationChanged.dispatch,
+    );
     this.volumeRenderingGain.changed.add(this.specificationChanged.dispatch);
     this.fragmentMain.changed.add(this.specificationChanged.dispatch);
     this.shaderControlState.changed.add(this.specificationChanged.dispatch);
@@ -351,7 +353,8 @@ export class ImageUserLayer extends Base {
     x[OPACITY_JSON_KEY] = this.opacity.toJSON();
     x[BLEND_JSON_KEY] = this.blendMode.toJSON();
     x[CODE_VISIBLE_KEY] = this.codeVisible.toJSON();
-    x[HIDE_INACTIVE_SHADER_CONTROLS_JSON_KEY] = this.hideInactiveShaderControls.toJSON();
+    x[HIDE_INACTIVE_SHADER_CONTROLS_JSON_KEY] =
+      this.hideInactiveShaderControls.toJSON();
     x[SHADER_JSON_KEY] = this.fragmentMain.toJSON();
     x[SHADER_CONTROLS_JSON_KEY] = this.shaderControlState.toJSON();
     x[CROSS_SECTION_RENDER_SCALE_JSON_KEY] =

--- a/src/layer/image/index.ts
+++ b/src/layer/image/index.ts
@@ -109,6 +109,7 @@ const BLEND_JSON_KEY = "blend";
 const SHADER_JSON_KEY = "shader";
 const CODE_VISIBLE_KEY = "codeVisible";
 const SHADER_CONTROLS_JSON_KEY = "shaderControls";
+const HIDE_INACTIVE_CONTROLS_JSON_KEY = "hideInactiveControls";
 const CROSS_SECTION_RENDER_SCALE_JSON_KEY = "crossSectionRenderScale";
 const CHANNEL_DIMENSIONS_JSON_KEY = "channelDimensions";
 const VOLUME_RENDERING_JSON_KEY = "volumeRendering";
@@ -128,6 +129,7 @@ export class ImageUserLayer extends Base {
   opacity = trackableAlphaValue(0.5);
   blendMode = trackableBlendModeValue();
   codeVisible = new TrackableBoolean(true);
+  hideInactiveControls = new TrackableBoolean(false);
   fragmentMain = getTrackableFragmentMain();
   shaderError = makeWatchableShaderError();
   dataType = new WatchableValue<DataType | undefined>(undefined);
@@ -209,6 +211,7 @@ export class ImageUserLayer extends Base {
     this.blendMode.changed.add(this.specificationChanged.dispatch);
     this.opacity.changed.add(this.specificationChanged.dispatch);
     this.codeVisible.changed.add(this.specificationChanged.dispatch);
+    this.hideInactiveControls.changed.add(this.specificationChanged.dispatch);
     this.volumeRenderingGain.changed.add(this.specificationChanged.dispatch);
     this.fragmentMain.changed.add(this.specificationChanged.dispatch);
     this.shaderControlState.changed.add(this.specificationChanged.dispatch);
@@ -299,6 +302,9 @@ export class ImageUserLayer extends Base {
     super.restoreState(specification);
     this.opacity.restoreState(specification[OPACITY_JSON_KEY]);
     this.codeVisible.restoreState(specification[CODE_VISIBLE_KEY]);
+    this.hideInactiveControls.restoreState(
+      specification[HIDE_INACTIVE_CONTROLS_JSON_KEY],
+    );
     verifyOptionalObjectProperty(specification, BLEND_JSON_KEY, (blendValue) =>
       this.blendMode.restoreState(blendValue),
     );
@@ -345,6 +351,7 @@ export class ImageUserLayer extends Base {
     x[OPACITY_JSON_KEY] = this.opacity.toJSON();
     x[BLEND_JSON_KEY] = this.blendMode.toJSON();
     x[CODE_VISIBLE_KEY] = this.codeVisible.toJSON();
+    x[HIDE_INACTIVE_CONTROLS_JSON_KEY] = this.hideInactiveControls.toJSON();
     x[SHADER_JSON_KEY] = this.fragmentMain.toJSON();
     x[SHADER_CONTROLS_JSON_KEY] = this.shaderControlState.toJSON();
     x[CROSS_SECTION_RENDER_SCALE_JSON_KEY] =
@@ -569,6 +576,7 @@ class RenderingOptionsTab extends Tab {
           {
             visibility: this.visibility,
             legendShaderOptions: this.layer.getLegendShaderOptions(),
+            hideInactiveControls: layer.hideInactiveControls,
           },
         ),
       ).element,

--- a/src/layer/single_mesh/index.ts
+++ b/src/layer/single_mesh/index.ts
@@ -50,12 +50,12 @@ import { Tab } from "#src/widget/tab_view.js";
 const SHADER_JSON_KEY = "shader";
 const SHADER_CONTROLS_JSON_KEY = "shaderControls";
 const CODE_VISIBLE_KEY = "codeVisible";
-const HIDE_INACTIVE_CONTROLS_JSON_KEY = "hideInactiveControls";
+const hide_inactive_shader_controls_JSON_KEY = "hideInactiveShaderControls";
 
 export class SingleMeshUserLayer extends UserLayer {
   displayState = new SingleMeshDisplayState();
   codeVisible = new TrackableBoolean(true);
-  hideInactiveControls = new TrackableBoolean(false);
+  hideInactiveShaderControls = new TrackableBoolean(false);
 
   vertexAttributes = new WatchableValue<VertexAttributeInfo[] | undefined>(
     undefined,
@@ -63,7 +63,7 @@ export class SingleMeshUserLayer extends UserLayer {
   constructor(public managedLayer: Borrowed<ManagedUserLayer>) {
     super(managedLayer);
     this.codeVisible.changed.add(this.specificationChanged.dispatch);
-    this.hideInactiveControls.changed.add(this.specificationChanged.dispatch);
+    this.hideInactiveShaderControls.changed.add(this.specificationChanged.dispatch);
     this.registerDisposer(
       this.displayState.shaderControlState.changed.add(
         this.specificationChanged.dispatch,
@@ -85,8 +85,8 @@ export class SingleMeshUserLayer extends UserLayer {
   restoreState(specification: any) {
     super.restoreState(specification);
     this.codeVisible.restoreState(specification[CODE_VISIBLE_KEY]);
-    this.hideInactiveControls.restoreState(
-      specification[HIDE_INACTIVE_CONTROLS_JSON_KEY],
+    this.hideInactiveShaderControls.restoreState(
+      specification[hide_inactive_shader_controls_JSON_KEY],
     );
     this.displayState.fragmentMain.restoreState(specification[SHADER_JSON_KEY]);
     this.displayState.shaderControlState.restoreState(
@@ -130,7 +130,7 @@ export class SingleMeshUserLayer extends UserLayer {
     x[SHADER_JSON_KEY] = this.displayState.fragmentMain.toJSON();
     x[SHADER_CONTROLS_JSON_KEY] = this.displayState.shaderControlState.toJSON();
     x[CODE_VISIBLE_KEY] = this.codeVisible.toJSON();
-    x[HIDE_INACTIVE_CONTROLS_JSON_KEY] = this.hideInactiveControls.toJSON();
+    x[hide_inactive_shader_controls_JSON_KEY] = this.hideInactiveShaderControls.toJSON();
     return x;
   }
 
@@ -241,7 +241,7 @@ class DisplayOptionsTab extends Tab {
           this.layer,
           {
             visibility: this.visibility,
-            hideInactiveControls: layer.hideInactiveControls,
+            hideInactiveShaderControls: layer.hideInactiveShaderControls,
           },
         ),
       ).element,

--- a/src/layer/single_mesh/index.ts
+++ b/src/layer/single_mesh/index.ts
@@ -50,10 +50,12 @@ import { Tab } from "#src/widget/tab_view.js";
 const SHADER_JSON_KEY = "shader";
 const SHADER_CONTROLS_JSON_KEY = "shaderControls";
 const CODE_VISIBLE_KEY = "codeVisible";
+const HIDE_INACTIVE_CONTROLS_JSON_KEY = "hideInactiveControls";
 
 export class SingleMeshUserLayer extends UserLayer {
   displayState = new SingleMeshDisplayState();
   codeVisible = new TrackableBoolean(true);
+  hideInactiveControls = new TrackableBoolean(false);
 
   vertexAttributes = new WatchableValue<VertexAttributeInfo[] | undefined>(
     undefined,
@@ -61,6 +63,7 @@ export class SingleMeshUserLayer extends UserLayer {
   constructor(public managedLayer: Borrowed<ManagedUserLayer>) {
     super(managedLayer);
     this.codeVisible.changed.add(this.specificationChanged.dispatch);
+    this.hideInactiveControls.changed.add(this.specificationChanged.dispatch);
     this.registerDisposer(
       this.displayState.shaderControlState.changed.add(
         this.specificationChanged.dispatch,
@@ -82,6 +85,9 @@ export class SingleMeshUserLayer extends UserLayer {
   restoreState(specification: any) {
     super.restoreState(specification);
     this.codeVisible.restoreState(specification[CODE_VISIBLE_KEY]);
+    this.hideInactiveControls.restoreState(
+      specification[HIDE_INACTIVE_CONTROLS_JSON_KEY],
+    );
     this.displayState.fragmentMain.restoreState(specification[SHADER_JSON_KEY]);
     this.displayState.shaderControlState.restoreState(
       specification[SHADER_CONTROLS_JSON_KEY],
@@ -124,6 +130,7 @@ export class SingleMeshUserLayer extends UserLayer {
     x[SHADER_JSON_KEY] = this.displayState.fragmentMain.toJSON();
     x[SHADER_CONTROLS_JSON_KEY] = this.displayState.shaderControlState.toJSON();
     x[CODE_VISIBLE_KEY] = this.codeVisible.toJSON();
+    x[HIDE_INACTIVE_CONTROLS_JSON_KEY] = this.hideInactiveControls.toJSON();
     return x;
   }
 
@@ -232,7 +239,10 @@ class DisplayOptionsTab extends Tab {
           layer.displayState.shaderControlState,
           this.layer.manager.root.display,
           this.layer,
-          { visibility: this.visibility },
+          {
+            visibility: this.visibility,
+            hideInactiveControls: layer.hideInactiveControls,
+          },
         ),
       ).element,
     );

--- a/src/layer/single_mesh/index.ts
+++ b/src/layer/single_mesh/index.ts
@@ -63,7 +63,9 @@ export class SingleMeshUserLayer extends UserLayer {
   constructor(public managedLayer: Borrowed<ManagedUserLayer>) {
     super(managedLayer);
     this.codeVisible.changed.add(this.specificationChanged.dispatch);
-    this.hideInactiveShaderControls.changed.add(this.specificationChanged.dispatch);
+    this.hideInactiveShaderControls.changed.add(
+      this.specificationChanged.dispatch,
+    );
     this.registerDisposer(
       this.displayState.shaderControlState.changed.add(
         this.specificationChanged.dispatch,
@@ -130,7 +132,8 @@ export class SingleMeshUserLayer extends UserLayer {
     x[SHADER_JSON_KEY] = this.displayState.fragmentMain.toJSON();
     x[SHADER_CONTROLS_JSON_KEY] = this.displayState.shaderControlState.toJSON();
     x[CODE_VISIBLE_KEY] = this.codeVisible.toJSON();
-    x[HIDE_INACTIVE_SHADER_CONTROLS_JSON_KEY] = this.hideInactiveShaderControls.toJSON();
+    x[HIDE_INACTIVE_SHADER_CONTROLS_JSON_KEY] =
+      this.hideInactiveShaderControls.toJSON();
     return x;
   }
 

--- a/src/layer/single_mesh/index.ts
+++ b/src/layer/single_mesh/index.ts
@@ -50,7 +50,7 @@ import { Tab } from "#src/widget/tab_view.js";
 const SHADER_JSON_KEY = "shader";
 const SHADER_CONTROLS_JSON_KEY = "shaderControls";
 const CODE_VISIBLE_KEY = "codeVisible";
-const hide_inactive_shader_controls_JSON_KEY = "hideInactiveShaderControls";
+const HIDE_INACTIVE_SHADER_CONTROLS_JSON_KEY = "hideInactiveShaderControls";
 
 export class SingleMeshUserLayer extends UserLayer {
   displayState = new SingleMeshDisplayState();
@@ -86,7 +86,7 @@ export class SingleMeshUserLayer extends UserLayer {
     super.restoreState(specification);
     this.codeVisible.restoreState(specification[CODE_VISIBLE_KEY]);
     this.hideInactiveShaderControls.restoreState(
-      specification[hide_inactive_shader_controls_JSON_KEY],
+      specification[HIDE_INACTIVE_SHADER_CONTROLS_JSON_KEY],
     );
     this.displayState.fragmentMain.restoreState(specification[SHADER_JSON_KEY]);
     this.displayState.shaderControlState.restoreState(
@@ -130,7 +130,7 @@ export class SingleMeshUserLayer extends UserLayer {
     x[SHADER_JSON_KEY] = this.displayState.fragmentMain.toJSON();
     x[SHADER_CONTROLS_JSON_KEY] = this.displayState.shaderControlState.toJSON();
     x[CODE_VISIBLE_KEY] = this.codeVisible.toJSON();
-    x[hide_inactive_shader_controls_JSON_KEY] = this.hideInactiveShaderControls.toJSON();
+    x[HIDE_INACTIVE_SHADER_CONTROLS_JSON_KEY] = this.hideInactiveShaderControls.toJSON();
     return x;
   }
 

--- a/src/skeleton/frontend.ts
+++ b/src/skeleton/frontend.ts
@@ -430,7 +430,7 @@ export class SkeletonRenderingOptions implements Trackable {
 
   shader = makeTrackableFragmentMain(DEFAULT_FRAGMENT_MAIN);
   shaderControlState = new ShaderControlState(this.shader);
-  hideInactiveControls = new TrackableBoolean(false);
+  hideInactiveShaderControls = new TrackableBoolean(false);
   params2d: ViewSpecificSkeletonRenderingOptions = {
     mode: new TrackableSkeletonRenderMode(SkeletonRenderMode.LINES_AND_POINTS),
     lineWidth: new TrackableSkeletonLineWidth(2),
@@ -444,7 +444,7 @@ export class SkeletonRenderingOptions implements Trackable {
     const { compound } = this;
     compound.add("shader", this.shader);
     compound.add("shaderControls", this.shaderControlState);
-    compound.add("hideInactiveControls", this.hideInactiveControls);
+    compound.add("hideInactiveShaderControls", this.hideInactiveShaderControls);
     compound.add("mode2d", this.params2d.mode);
     compound.add("lineWidth2d", this.params2d.lineWidth);
     compound.add("mode3d", this.params3d.mode);

--- a/src/skeleton/frontend.ts
+++ b/src/skeleton/frontend.ts
@@ -41,6 +41,7 @@ import { SKELETON_LAYER_RPC_ID } from "#src/skeleton/base.js";
 import type { SliceViewPanel } from "#src/sliceview/panel.js";
 import type { SliceViewPanelRenderContext } from "#src/sliceview/renderlayer.js";
 import { SliceViewPanelRenderLayer } from "#src/sliceview/renderlayer.js";
+import { TrackableBoolean } from "#src/trackable_boolean.js";
 import { TrackableValue, WatchableValue } from "#src/trackable_value.js";
 import { DataType } from "#src/util/data_type.js";
 import { RefCounted } from "#src/util/disposable.js";
@@ -429,6 +430,7 @@ export class SkeletonRenderingOptions implements Trackable {
 
   shader = makeTrackableFragmentMain(DEFAULT_FRAGMENT_MAIN);
   shaderControlState = new ShaderControlState(this.shader);
+  hideInactiveControls = new TrackableBoolean(false);
   params2d: ViewSpecificSkeletonRenderingOptions = {
     mode: new TrackableSkeletonRenderMode(SkeletonRenderMode.LINES_AND_POINTS),
     lineWidth: new TrackableSkeletonLineWidth(2),
@@ -442,6 +444,7 @@ export class SkeletonRenderingOptions implements Trackable {
     const { compound } = this;
     compound.add("shader", this.shader);
     compound.add("shaderControls", this.shaderControlState);
+    compound.add("hideInactiveControls", this.hideInactiveControls);
     compound.add("mode2d", this.params2d.mode);
     compound.add("lineWidth2d", this.params2d.lineWidth);
     compound.add("mode3d", this.params3d.mode);

--- a/src/ui/segmentation_display_options_tab.ts
+++ b/src/ui/segmentation_display_options_tab.ts
@@ -112,9 +112,9 @@ export class DisplayOptionsTab extends Tab {
                 {
                   visibility: this.visibility,
                   toolId: SKELETON_RENDERING_SHADER_CONTROL_TOOL_ID,
-                  hideInactiveControls:
+                  hideInactiveShaderControls:
                     layer.displayState.skeletonRenderingOptions
-                      .hideInactiveControls,
+                      .hideInactiveShaderControls,
                 },
               ),
             ).element,

--- a/src/ui/segmentation_display_options_tab.ts
+++ b/src/ui/segmentation_display_options_tab.ts
@@ -112,6 +112,9 @@ export class DisplayOptionsTab extends Tab {
                 {
                   visibility: this.visibility,
                   toolId: SKELETON_RENDERING_SHADER_CONTROL_TOOL_ID,
+                  hideInactiveControls:
+                    layer.displayState.skeletonRenderingOptions
+                      .hideInactiveControls,
                 },
               ),
             ).element,

--- a/src/webgl/shader_control_reachability.ts
+++ b/src/webgl/shader_control_reachability.ts
@@ -23,9 +23,23 @@ function uniformName(controlName: string): string {
   return `${UNIFORM_PREFIX}${controlName}`;
 }
 
+function escapeRegExp(text: string): string {
+  return text.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function isCheckboxUsedInCode(
+  controlName: string,
+  parseResult: ShaderControlsParseResult,
+): boolean {
+  return new RegExp(`\\b${escapeRegExp(controlName)}\\b`).test(
+    parseResult.code,
+  );
+}
+
 // Returns the set of #uicontrol names whose generated uniforms survived GLSL
 // link-time dead-code elimination. Controls that compile to no uniforms
-// (checkbox, which becomes a `#define`) are always considered active.
+// (checkbox, which becomes a `#define`) are considered active only if the
+// parsed shader code actually references the generated identifier.
 //
 // `shader.uniforms` is the map populated by ShaderProgram at link time:
 // each declared uniform name maps to its location (`WebGLUniformLocation`)
@@ -38,9 +52,11 @@ export function computeActiveControls(
   const { uniforms } = shader;
   for (const [name, control] of parseResult.controls) {
     if (control.type === "checkbox") {
-      // Checkboxes become `#define`s at compile time; they have no uniform.
-      // They gate other controls, so always show them.
-      active.add(name);
+      // Checkboxes become `#define`s at compile time; they have no uniform, so
+      // infer reachability from whether the shader code references the symbol.
+      if (isCheckboxUsedInCode(name, parseResult)) {
+        active.add(name);
+      }
       continue;
     }
     if (

--- a/src/webgl/shader_control_reachability.ts
+++ b/src/webgl/shader_control_reachability.ts
@@ -1,0 +1,83 @@
+/**
+ * @license
+ * Copyright 2026 Google Inc.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { ShaderProgram } from "#src/webgl/shader.js";
+import type { ShaderControlsParseResult } from "#src/webgl/shader_ui_controls.js";
+
+const UNIFORM_PREFIX = "u_shaderControl_";
+
+function uniformName(controlName: string): string {
+  return `${UNIFORM_PREFIX}${controlName}`;
+}
+
+// Returns the set of #uicontrol names whose generated uniforms survived GLSL
+// link-time dead-code elimination. Controls that compile to no uniforms
+// (checkbox, which becomes a `#define`) are always considered active.
+//
+// `shader.uniforms` is the map populated by ShaderProgram at link time:
+// each declared uniform name maps to its location (`WebGLUniformLocation`)
+// or `null` if the GLSL driver eliminated it.
+export function computeActiveControls(
+  shader: ShaderProgram,
+  parseResult: ShaderControlsParseResult,
+): Set<string> {
+  const active = new Set<string>();
+  const { uniforms } = shader;
+  for (const [name, control] of parseResult.controls) {
+    if (control.type === "checkbox") {
+      // Checkboxes become `#define`s at compile time; they have no uniform.
+      // They gate other controls, so always show them.
+      active.add(name);
+      continue;
+    }
+    if (
+      control.type === "imageInvlerp" ||
+      control.type === "propertyInvlerp" ||
+      control.type === "transferFunction"
+    ) {
+      // These inject helper functions plus one or more underlying uniforms
+      // (bound/interval uniforms for invlerp, texture sampler for transfer
+      // function). Any surviving uniform with the control's prefix means the
+      // helper is reachable.
+      const prefix = uniformName(name);
+      let found = false;
+      for (const [uName, location] of uniforms) {
+        if (location !== null && uName.startsWith(prefix)) {
+          found = true;
+          break;
+        }
+      }
+      if (found) active.add(name);
+      continue;
+    }
+    // slider, color: single uniform per control.
+    if (uniforms.get(uniformName(name)) != null) {
+      active.add(name);
+    }
+  }
+  return active;
+}
+
+export function activeControlsEqual(
+  a: Set<string> | undefined,
+  b: Set<string> | undefined,
+): boolean {
+  if (a === b) return true;
+  if (a === undefined || b === undefined) return false;
+  if (a.size !== b.size) return false;
+  for (const name of a) if (!b.has(name)) return false;
+  return true;
+}

--- a/src/webgl/shader_ui_controls.ts
+++ b/src/webgl/shader_ui_controls.ts
@@ -1502,13 +1502,11 @@ export class ShaderControlState
         this.controls.value = result.controls;
       }
     }
-    // The active-controls set was derived from the previous shader and no
-    // longer matches the new control names; clear it so the UI shows
-    // everything until the next shader links.
+    // The active-controls set was derived from the previous shader. Forget the
+    // last reported program so `reportLinkedShader` recomputes it on the next
+    // link, rather than clearing `activeControls` here: linking happens fast
+    // enough that clearing would just flicker the controls in and back out.
     this.lastReportedProgram = undefined;
-    if (this.activeControls.value !== undefined) {
-      this.activeControls.value = undefined;
-    }
     this.parseResultChanged.dispatch();
   }
 

--- a/src/webgl/shader_ui_controls.ts
+++ b/src/webgl/shader_ui_controls.ts
@@ -25,6 +25,7 @@ import {
   makeCachedDerivedWatchableValue,
   makeCachedLazyDerivedWatchableValue,
   TrackableValue,
+  WatchableValue,
 } from "#src/trackable_value.js";
 import { arraysEqual, arraysEqualWithPredicate } from "#src/util/array.js";
 import {
@@ -65,6 +66,10 @@ import {
   enableLerpShaderFunction,
 } from "#src/webgl/lerp.js";
 import type { ShaderBuilder, ShaderProgram } from "#src/webgl/shader.js";
+import {
+  activeControlsEqual,
+  computeActiveControls,
+} from "#src/webgl/shader_control_reachability.js";
 import type { TransferFunctionParameters } from "#src/widget/transfer_function.js";
 import {
   defineTransferFunctionShader,
@@ -1313,6 +1318,11 @@ export function getFallbackBuilderState(
   };
 }
 
+// JSON key under which `hideInactiveControls` is serialized inside the
+// shaderControlState object. The double-underscore prefix avoids collisions
+// with #uicontrol names (which by convention start with a letter).
+const HIDE_INACTIVE_JSON_KEY = "__hideInactiveControls";
+
 export class ShaderControlState
   extends RefCounted
   implements Trackable, WatchableValueInterface<ShaderControlMap>
@@ -1324,6 +1334,12 @@ export class ShaderControlState
   parseResult: WatchableValueInterface<ShaderControlsParseResult>;
   builderState: WatchableValueInterface<ShaderControlsBuilderState>;
   histogramSpecifications: HistogramSpecifications;
+  // Set of #uicontrol names that survived GLSL link-time dead-code elimination
+  // for the most recently rendered shader. `undefined` means "not yet known"
+  // (no shader has linked yet); UI treats that as "show everything".
+  activeControls = new WatchableValue<Set<string> | undefined>(undefined);
+  // When true, the controls panel hides any control not in `activeControls`.
+  hideInactiveControls = new TrackableBoolean(false);
 
   private fragmentMainGeneration = -1;
   private dataContextGeneration = -1;
@@ -1332,6 +1348,7 @@ export class ShaderControlState
   private parseResult_: ShaderControlsParseResult;
   private controlsGeneration = -1;
   private parseResultChanged = new NullarySignal();
+  private lastReportedProgram: WebGLProgram | undefined = undefined;
 
   constructor(
     public fragmentMain: WatchableValueInterface<string>,
@@ -1349,6 +1366,9 @@ export class ShaderControlState
     );
     this.registerDisposer(
       this.dataContext.changed.add(() => this.handleFragmentMainChanged()),
+    );
+    this.registerDisposer(
+      this.hideInactiveControls.changed.add(this.changed.dispatch),
     );
     this.handleFragmentMainChanged();
     const self = this;
@@ -1482,7 +1502,27 @@ export class ShaderControlState
         this.controls.value = result.controls;
       }
     }
+    // The active-controls set was derived from the previous shader and no
+    // longer matches the new control names; clear it so the UI shows
+    // everything until the next shader links.
+    this.lastReportedProgram = undefined;
+    if (this.activeControls.value !== undefined) {
+      this.activeControls.value = undefined;
+    }
     this.parseResultChanged.dispatch();
+  }
+
+  // Called by `setControlsInShader` once per linked shader program. Reads
+  // which uniforms survived link-time dead-code elimination and publishes the
+  // resulting set on `activeControls`. Idempotent for repeated calls with the
+  // same program.
+  reportLinkedShader(shader: ShaderProgram) {
+    if (shader.program === this.lastReportedProgram) return;
+    this.lastReportedProgram = shader.program;
+    const next = computeActiveControls(shader, this.parseResult_);
+    if (!activeControlsEqual(this.activeControls.value, next)) {
+      this.activeControls.value = next;
+    }
   }
 
   private handleControlsChanged() {
@@ -1562,6 +1602,11 @@ export class ShaderControlState
     if (value === undefined) return;
     const { state } = this;
     verifyObject(value);
+    if (Object.prototype.hasOwnProperty.call(value, HIDE_INACTIVE_JSON_KEY)) {
+      this.hideInactiveControls.restoreState(value[HIDE_INACTIVE_JSON_KEY]);
+    } else {
+      this.hideInactiveControls.reset();
+    }
     const controls = this.controls.value;
     if (controls === undefined) {
       this.unparsedJson = value;
@@ -1583,6 +1628,7 @@ export class ShaderControlState
   }
 
   reset() {
+    this.hideInactiveControls.reset();
     for (const controlState of this.state.values()) {
       controlState.trackable.reset();
     }
@@ -1598,6 +1644,11 @@ export class ShaderControlState
     if (unparsedJson !== undefined) return unparsedJson;
     const obj: any = {};
     let empty = true;
+    const hideInactiveJson = this.hideInactiveControls.toJSON();
+    if (hideInactiveJson !== undefined) {
+      obj[HIDE_INACTIVE_JSON_KEY] = hideInactiveJson;
+      empty = false;
+    }
     for (const [key, value] of state) {
       const valueJson = value.trackable.toJSON();
       if (valueJson !== undefined) {
@@ -1665,6 +1716,11 @@ export function setControlsInShader(
   shaderControlState: ShaderControlState,
   controls: Controls,
 ) {
+  // Each renderer calls this once per draw, so it's the natural place to
+  // record which controls survived link-time DCE for the current shader.
+  // The call is idempotent for the same program — no GL roundtrip beyond
+  // the initial computation.
+  shaderControlState.reportLinkedShader(shader);
   const { state } = shaderControlState;
   if (shaderControlState.controls.value === controls) {
     // Case when shader doesn't have any errors.

--- a/src/webgl/shader_ui_controls.ts
+++ b/src/webgl/shader_ui_controls.ts
@@ -1318,11 +1318,6 @@ export function getFallbackBuilderState(
   };
 }
 
-// JSON key under which `hideInactiveControls` is serialized inside the
-// shaderControlState object. The double-underscore prefix avoids collisions
-// with #uicontrol names (which by convention start with a letter).
-const HIDE_INACTIVE_JSON_KEY = "__hideInactiveControls";
-
 export class ShaderControlState
   extends RefCounted
   implements Trackable, WatchableValueInterface<ShaderControlMap>
@@ -1338,8 +1333,6 @@ export class ShaderControlState
   // for the most recently rendered shader. `undefined` means "not yet known"
   // (no shader has linked yet); UI treats that as "show everything".
   activeControls = new WatchableValue<Set<string> | undefined>(undefined);
-  // When true, the controls panel hides any control not in `activeControls`.
-  hideInactiveControls = new TrackableBoolean(false);
 
   private fragmentMainGeneration = -1;
   private dataContextGeneration = -1;
@@ -1366,9 +1359,6 @@ export class ShaderControlState
     );
     this.registerDisposer(
       this.dataContext.changed.add(() => this.handleFragmentMainChanged()),
-    );
-    this.registerDisposer(
-      this.hideInactiveControls.changed.add(this.changed.dispatch),
     );
     this.handleFragmentMainChanged();
     const self = this;
@@ -1600,11 +1590,6 @@ export class ShaderControlState
     if (value === undefined) return;
     const { state } = this;
     verifyObject(value);
-    if (Object.prototype.hasOwnProperty.call(value, HIDE_INACTIVE_JSON_KEY)) {
-      this.hideInactiveControls.restoreState(value[HIDE_INACTIVE_JSON_KEY]);
-    } else {
-      this.hideInactiveControls.reset();
-    }
     const controls = this.controls.value;
     if (controls === undefined) {
       this.unparsedJson = value;
@@ -1626,7 +1611,6 @@ export class ShaderControlState
   }
 
   reset() {
-    this.hideInactiveControls.reset();
     for (const controlState of this.state.values()) {
       controlState.trackable.reset();
     }
@@ -1642,11 +1626,6 @@ export class ShaderControlState
     if (unparsedJson !== undefined) return unparsedJson;
     const obj: any = {};
     let empty = true;
-    const hideInactiveJson = this.hideInactiveControls.toJSON();
-    if (hideInactiveJson !== undefined) {
-      obj[HIDE_INACTIVE_JSON_KEY] = hideInactiveJson;
-      empty = false;
-    }
     for (const [key, value] of state) {
       const valueJson = value.trackable.toJSON();
       if (valueJson !== undefined) {

--- a/src/widget/shader_controls.css
+++ b/src/widget/shader_controls.css
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright 2024 Google Inc.
+ * Copyright 2026 Google Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/src/widget/shader_controls.css
+++ b/src/widget/shader_controls.css
@@ -1,0 +1,22 @@
+/**
+ * @license
+ * Copyright 2024 Google Inc.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+.neuroglancer-shader-controls-hide-inactive {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  font-size: smaller;
+}

--- a/src/widget/shader_controls.ts
+++ b/src/widget/shader_controls.ts
@@ -166,6 +166,7 @@ function getShaderLayerControlDefinition<LayerType extends UserLayer>(
 export class ShaderControls extends Tab {
   private controlDisposer: RefCounted | undefined = undefined;
   private controlsContainer: HTMLDivElement;
+  private hiddenCountElement: HTMLSpanElement;
   private toolId: string;
   constructor(
     public state: ShaderControlState,
@@ -200,6 +201,12 @@ export class ShaderControls extends Tab {
     );
     header.appendChild(checkbox.element);
     header.appendChild(document.createTextNode("Hide inactive controls"));
+    // Trailing "(X hidden)" annotation, updated by `updateControls()`.
+    const hiddenCountElement = (this.hiddenCountElement =
+      document.createElement("span"));
+    hiddenCountElement.className =
+      "neuroglancer-shader-controls-hidden-count";
+    header.appendChild(hiddenCountElement);
     element.appendChild(header);
 
     // Separate container so the rebuild loop only tears down the controls,
@@ -234,6 +241,7 @@ export class ShaderControls extends Tab {
     });
     const hideInactive = this.state.hideInactiveControls.value;
     const activeControls = this.state.activeControls.value;
+    let hiddenCount = 0;
     for (const name of this.state.state.keys()) {
       // Skip when the user has opted in and we have a known active set
       // (computed from the last linked shader) that does not include `name`.
@@ -244,6 +252,7 @@ export class ShaderControls extends Tab {
         activeControls !== undefined &&
         !activeControls.has(name)
       ) {
+        ++hiddenCount;
         continue;
       }
       container.appendChild(
@@ -259,6 +268,8 @@ export class ShaderControls extends Tab {
         ),
       );
     }
+    this.hiddenCountElement.textContent =
+      hiddenCount > 0 ? ` (${hiddenCount} hidden)` : "";
   }
 
   disposed() {

--- a/src/widget/shader_controls.ts
+++ b/src/widget/shader_controls.ts
@@ -204,8 +204,7 @@ export class ShaderControls extends Tab {
     // Trailing "(X hidden)" annotation, updated by `updateControls()`.
     const hiddenCountElement = (this.hiddenCountElement =
       document.createElement("span"));
-    hiddenCountElement.className =
-      "neuroglancer-shader-controls-hidden-count";
+    hiddenCountElement.className = "neuroglancer-shader-controls-hidden-count";
     header.appendChild(hiddenCountElement);
     element.appendChild(header);
 

--- a/src/widget/shader_controls.ts
+++ b/src/widget/shader_controls.ts
@@ -17,6 +17,7 @@
 import { debounce } from "lodash-es";
 import type { DisplayContext } from "#src/display_context.js";
 import type { UserLayer, UserLayerConstructor } from "#src/layer/index.js";
+import { TrackableBooleanCheckbox } from "#src/trackable_boolean.js";
 import { registerTool } from "#src/ui/tool.js";
 import { RefCounted } from "#src/util/disposable.js";
 import { removeChildren } from "#src/util/dom.js";
@@ -164,6 +165,7 @@ function getShaderLayerControlDefinition<LayerType extends UserLayer>(
 
 export class ShaderControls extends Tab {
   private controlDisposer: RefCounted | undefined = undefined;
+  private controlsContainer: HTMLDivElement;
   private toolId: string;
   constructor(
     public state: ShaderControlState,
@@ -176,28 +178,75 @@ export class ShaderControls extends Tab {
     this.toolId = toolId;
     const { element } = this;
     element.style.display = "contents";
+
+    // Header row with the "Hide inactive controls" toggle. Built once and
+    // never torn down by `updateControls()`, so its UI state is stable
+    // across shader recompiles.
+    const header = document.createElement("label");
+    header.className = "neuroglancer-shader-controls-hide-inactive";
+    header.style.display = "flex";
+    header.style.alignItems = "center";
+    header.style.gap = "4px";
+    header.style.fontSize = "smaller";
+    const checkbox = this.registerDisposer(
+      new TrackableBooleanCheckbox(state.hideInactiveControls, {
+        enabledTitle:
+          "Show all #uicontrols (including ones with no effect on the current render).",
+        disabledTitle:
+          "Hide #uicontrols whose uniforms are eliminated by the GLSL compiler" +
+          " for the current shader (e.g. controls only referenced inside an" +
+          " `if (checkbox)` branch that's currently false).",
+      }),
+    );
+    header.appendChild(checkbox.element);
+    header.appendChild(document.createTextNode("Hide inactive controls"));
+    element.appendChild(header);
+
+    // Separate container so the rebuild loop only tears down the controls,
+    // not the header.
+    const controlsContainer = (this.controlsContainer =
+      document.createElement("div"));
+    controlsContainer.style.display = "contents";
+    element.appendChild(controlsContainer);
+
     const { controls } = state;
+    const scheduleUpdate = this.registerCancellable(
+      debounce(() => this.updateControls(), 0),
+    );
+    this.registerDisposer(controls.changed.add(scheduleUpdate));
+    this.registerDisposer(state.activeControls.changed.add(scheduleUpdate));
     this.registerDisposer(
-      controls.changed.add(
-        this.registerCancellable(debounce(() => this.updateControls(), 0)),
-      ),
+      state.hideInactiveControls.changed.add(scheduleUpdate),
     );
     this.updateControls();
   }
 
   updateControls() {
-    const { element } = this;
+    const container = this.controlsContainer;
     if (this.controlDisposer !== undefined) {
       this.controlDisposer.dispose();
-      removeChildren(element);
+      removeChildren(container);
     }
     const controlDisposer = (this.controlDisposer = new RefCounted());
     const layerShaderControlsGetter = () => ({
       shaderControlState: this.state,
       legendShaderOptions: this.options.legendShaderOptions,
     });
+    const hideInactive = this.state.hideInactiveControls.value;
+    const activeControls = this.state.activeControls.value;
     for (const name of this.state.state.keys()) {
-      element.appendChild(
+      // Skip when the user has opted in and we have a known active set
+      // (computed from the last linked shader) that does not include `name`.
+      // `activeControls === undefined` means we haven't rendered yet; show
+      // everything in that case to avoid hiding controls prematurely.
+      if (
+        hideInactive &&
+        activeControls !== undefined &&
+        !activeControls.has(name)
+      ) {
+        continue;
+      }
+      container.appendChild(
         addLayerControlToOptionsTab(
           controlDisposer,
           this.layer,

--- a/src/widget/shader_controls.ts
+++ b/src/widget/shader_controls.ts
@@ -15,6 +15,7 @@
  */
 
 import { debounce } from "lodash-es";
+import "#src/widget/shader_controls.css";
 import type { DisplayContext } from "#src/display_context.js";
 import type { UserLayer, UserLayerConstructor } from "#src/layer/index.js";
 import { TrackableBooleanCheckbox } from "#src/trackable_boolean.js";
@@ -180,33 +181,29 @@ export class ShaderControls extends Tab {
     const { element } = this;
     element.style.display = "contents";
 
-    // Header row with the "Hide inactive controls" toggle. Built once and
-    // never torn down by `updateControls()`, so its UI state is stable
-    // across shader recompiles.
-    const header = document.createElement("label");
-    header.className = "neuroglancer-shader-controls-hide-inactive";
-    header.style.display = "flex";
-    header.style.alignItems = "center";
-    header.style.gap = "4px";
-    header.style.fontSize = "smaller";
+    // "Hide inactive controls" toggle. Built once and never torn down by
+    // `updateControls()`, so its UI state is stable across shader recompiles.
+    // The tooltip lives on the label so hovering the text shows it too.
+    const hideInactiveControl = document.createElement("label");
+    hideInactiveControl.className =
+      "neuroglancer-shader-controls-hide-inactive";
+    hideInactiveControl.title =
+      "Hide #uicontrols that have no effect on the current render (their" +
+      " uniforms were eliminated by the GLSL compiler, e.g. controls only" +
+      " referenced inside an `if (checkbox)` branch that's currently false).";
     const checkbox = this.registerDisposer(
-      new TrackableBooleanCheckbox(state.hideInactiveControls, {
-        enabledTitle:
-          "Show all #uicontrols (including ones with no effect on the current render).",
-        disabledTitle:
-          "Hide #uicontrols whose uniforms are eliminated by the GLSL compiler" +
-          " for the current shader (e.g. controls only referenced inside an" +
-          " `if (checkbox)` branch that's currently false).",
-      }),
+      new TrackableBooleanCheckbox(state.hideInactiveControls),
     );
-    header.appendChild(checkbox.element);
-    header.appendChild(document.createTextNode("Hide inactive controls"));
+    hideInactiveControl.appendChild(checkbox.element);
+    hideInactiveControl.appendChild(
+      document.createTextNode("Hide inactive controls"),
+    );
     // Trailing "(X hidden)" annotation, updated by `updateControls()`.
     const hiddenCountElement = (this.hiddenCountElement =
       document.createElement("span"));
     hiddenCountElement.className = "neuroglancer-shader-controls-hidden-count";
-    header.appendChild(hiddenCountElement);
-    element.appendChild(header);
+    hideInactiveControl.appendChild(hiddenCountElement);
+    element.appendChild(hideInactiveControl);
 
     // Separate container so the rebuild loop only tears down the controls,
     // not the header.
@@ -228,10 +225,10 @@ export class ShaderControls extends Tab {
   }
 
   updateControls() {
-    const container = this.controlsContainer;
+    const { controlsContainer } = this;
     if (this.controlDisposer !== undefined) {
       this.controlDisposer.dispose();
-      removeChildren(container);
+      removeChildren(controlsContainer);
     }
     const controlDisposer = (this.controlDisposer = new RefCounted());
     const layerShaderControlsGetter = () => ({
@@ -254,7 +251,7 @@ export class ShaderControls extends Tab {
         ++hiddenCount;
         continue;
       }
-      container.appendChild(
+      controlsContainer.appendChild(
         addLayerControlToOptionsTab(
           controlDisposer,
           this.layer,

--- a/src/widget/shader_controls.ts
+++ b/src/widget/shader_controls.ts
@@ -207,7 +207,7 @@ export class ShaderControls extends Tab {
     );
     hideInactiveControl.appendChild(checkbox.element);
     hideInactiveControl.appendChild(
-      document.createTextNode("Hide inactive controls"),
+      document.createTextNode("Hide inactive shader controls"),
     );
     // Trailing "(X hidden)" annotation, updated by `updateControls()`.
     const hiddenCountElement = (this.hiddenCountElement =

--- a/src/widget/shader_controls.ts
+++ b/src/widget/shader_controls.ts
@@ -60,7 +60,7 @@ export interface ShaderControlsOptions {
   toolId?: string;
   // Toggle controlling whether inactive controls are hidden. Owned and
   // persisted by the layer; when omitted a non-persisted toggle is created.
-  hideInactiveControls?: TrackableBoolean;
+  hideInactiveShaderControls?: TrackableBoolean;
 }
 
 function getShaderLayerControlFactory<LayerType extends UserLayer>(
@@ -174,7 +174,7 @@ export class ShaderControls extends Tab {
   private controlDisposer: RefCounted | undefined = undefined;
   private controlsContainer: HTMLDivElement;
   private hiddenCountElement: HTMLSpanElement;
-  private hideInactiveControls: TrackableBoolean;
+  private hideInactiveShaderControls: TrackableBoolean;
   private toolId: string;
   constructor(
     public state: ShaderControlState,
@@ -187,8 +187,8 @@ export class ShaderControls extends Tab {
     this.toolId = toolId;
     // The layer owns and persists this toggle; fall back to a non-persisted
     // one if a caller doesn't supply it.
-    const hideInactiveControls = (this.hideInactiveControls =
-      options.hideInactiveControls ?? new TrackableBoolean(false));
+    const hideInactiveShaderControls = (this.hideInactiveShaderControls =
+      options.hideInactiveShaderControls ?? new TrackableBoolean(false));
     const { element } = this;
     element.style.display = "contents";
 
@@ -203,7 +203,7 @@ export class ShaderControls extends Tab {
       " uniforms were eliminated by the GLSL compiler, e.g. controls only" +
       " referenced inside an `if (checkbox)` branch that's currently false).";
     const checkbox = this.registerDisposer(
-      new TrackableBooleanCheckbox(hideInactiveControls),
+      new TrackableBooleanCheckbox(hideInactiveShaderControls),
     );
     hideInactiveControl.appendChild(checkbox.element);
     hideInactiveControl.appendChild(
@@ -229,7 +229,7 @@ export class ShaderControls extends Tab {
     );
     this.registerDisposer(controls.changed.add(scheduleUpdate));
     this.registerDisposer(state.activeControls.changed.add(scheduleUpdate));
-    this.registerDisposer(hideInactiveControls.changed.add(scheduleUpdate));
+    this.registerDisposer(hideInactiveShaderControls.changed.add(scheduleUpdate));
     this.updateControls();
   }
 
@@ -244,7 +244,7 @@ export class ShaderControls extends Tab {
       shaderControlState: this.state,
       legendShaderOptions: this.options.legendShaderOptions,
     });
-    const hideInactive = this.hideInactiveControls.value;
+    const hideInactive = this.hideInactiveShaderControls.value;
     const activeControls = this.state.activeControls.value;
     let hiddenCount = 0;
     for (const name of this.state.state.keys()) {

--- a/src/widget/shader_controls.ts
+++ b/src/widget/shader_controls.ts
@@ -18,7 +18,10 @@ import { debounce } from "lodash-es";
 import "#src/widget/shader_controls.css";
 import type { DisplayContext } from "#src/display_context.js";
 import type { UserLayer, UserLayerConstructor } from "#src/layer/index.js";
-import { TrackableBooleanCheckbox } from "#src/trackable_boolean.js";
+import {
+  TrackableBoolean,
+  TrackableBooleanCheckbox,
+} from "#src/trackable_boolean.js";
 import { registerTool } from "#src/ui/tool.js";
 import { RefCounted } from "#src/util/disposable.js";
 import { removeChildren } from "#src/util/dom.js";
@@ -55,6 +58,9 @@ export interface ShaderControlsOptions {
   legendShaderOptions?: LegendShaderOptions;
   visibility?: WatchableVisibilityPriority;
   toolId?: string;
+  // Toggle controlling whether inactive controls are hidden. Owned and
+  // persisted by the layer; when omitted a non-persisted toggle is created.
+  hideInactiveControls?: TrackableBoolean;
 }
 
 function getShaderLayerControlFactory<LayerType extends UserLayer>(
@@ -168,6 +174,7 @@ export class ShaderControls extends Tab {
   private controlDisposer: RefCounted | undefined = undefined;
   private controlsContainer: HTMLDivElement;
   private hiddenCountElement: HTMLSpanElement;
+  private hideInactiveControls: TrackableBoolean;
   private toolId: string;
   constructor(
     public state: ShaderControlState,
@@ -178,6 +185,10 @@ export class ShaderControls extends Tab {
     super(options.visibility);
     const { toolId = SHADER_CONTROL_TOOL_ID } = options;
     this.toolId = toolId;
+    // The layer owns and persists this toggle; fall back to a non-persisted
+    // one if a caller doesn't supply it.
+    const hideInactiveControls = (this.hideInactiveControls =
+      options.hideInactiveControls ?? new TrackableBoolean(false));
     const { element } = this;
     element.style.display = "contents";
 
@@ -192,7 +203,7 @@ export class ShaderControls extends Tab {
       " uniforms were eliminated by the GLSL compiler, e.g. controls only" +
       " referenced inside an `if (checkbox)` branch that's currently false).";
     const checkbox = this.registerDisposer(
-      new TrackableBooleanCheckbox(state.hideInactiveControls),
+      new TrackableBooleanCheckbox(hideInactiveControls),
     );
     hideInactiveControl.appendChild(checkbox.element);
     hideInactiveControl.appendChild(
@@ -218,9 +229,7 @@ export class ShaderControls extends Tab {
     );
     this.registerDisposer(controls.changed.add(scheduleUpdate));
     this.registerDisposer(state.activeControls.changed.add(scheduleUpdate));
-    this.registerDisposer(
-      state.hideInactiveControls.changed.add(scheduleUpdate),
-    );
+    this.registerDisposer(hideInactiveControls.changed.add(scheduleUpdate));
     this.updateControls();
   }
 
@@ -235,7 +244,7 @@ export class ShaderControls extends Tab {
       shaderControlState: this.state,
       legendShaderOptions: this.options.legendShaderOptions,
     });
-    const hideInactive = this.state.hideInactiveControls.value;
+    const hideInactive = this.hideInactiveControls.value;
     const activeControls = this.state.activeControls.value;
     let hiddenCount = 0;
     for (const name of this.state.state.keys()) {

--- a/src/widget/shader_controls.ts
+++ b/src/widget/shader_controls.ts
@@ -229,7 +229,9 @@ export class ShaderControls extends Tab {
     );
     this.registerDisposer(controls.changed.add(scheduleUpdate));
     this.registerDisposer(state.activeControls.changed.add(scheduleUpdate));
-    this.registerDisposer(hideInactiveShaderControls.changed.add(scheduleUpdate));
+    this.registerDisposer(
+      hideInactiveShaderControls.changed.add(scheduleUpdate),
+    );
     this.updateControls();
   }
 


### PR DESCRIPTION
Based on a feature request from @stuarteberg  this allows the option for the uicontrols which are not accessed based on the current compilation of the GLSL code to be hidden from the user.  The principle use case is having check boxes of rendering modes, and unselecting those boxes will cause options be not relevant to the user.  Ideally this will work with #909 as well once it gets in, but if we adopt it this should be modified to also support the dropdown. 

@jbms and I discussed that long term we should move to some GLSL > AST parser, which will be required for moving to WebGPU anyway, but also will allow for more robust static analysis of the shader language. 

presently for example nested checkboxes will not disappear, even if the nested checkbox is not accessed becuase checkboxes are implemented as uniforms.  Also, if code paths are defined based on run-time evaluation of the UI control (such as the location of the slider) then this method will also fail. 