### PR TITLE
fix(datasource/deepzoom): remove extra slash when constructing tile path

### DIFF
--- a/src/datasource/deepzoom/backend.ts
+++ b/src/datasource/deepzoom/backend.ts
@@ -81,7 +81,7 @@ export class DeepzoomImageTileSource extends WithParameters(
     const [x, y] = chunk.chunkGridPosition;
     const ox = x === 0 ? 0 : overlap;
     const oy = y === 0 ? 0 : overlap;
-    const path = `${this.tileKvStore.path}/${x}_${y}.${parameters.format}`;
+    const path = `${this.tileKvStore.path}${x}_${y}.${parameters.format}`;
     const response = await this.tileKvStore.store.read(path, {
       signal,
     });

--- a/tests/datasource/deepzoom.browser_test.ts
+++ b/tests/datasource/deepzoom.browser_test.ts
@@ -14,8 +14,45 @@
  * limitations under the License.
  */
 
-import "#src/datasource/deepzoom/register_default";
+import "#src/datasource/deepzoom/register_default.js";
 import "#src/sliceview/uncompressed_chunk_format.js";
+import { test } from "vitest";
+import { DeepzoomImageTileSource } from "#src/datasource/deepzoom/backend.js";
+import { ImageTileEncoding } from "#src/datasource/deepzoom/base.js";
 import { datasourceMetadataSnapshotTests } from "#tests/datasource/metadata_snapshot_test_util.js";
 
 datasourceMetadataSnapshotTests("deepzoom", ["14122_mPPC_BDA_s186.dzi"]);
+
+test("download reads tiles relative to trailing-slash directory paths", async ({
+  expect,
+}) => {
+  let readPath: string | undefined;
+  let readSignal: AbortSignal | undefined;
+  const source = {
+    parameters: {
+      url: "image_files/12/",
+      encoding: ImageTileEncoding.JPG,
+      format: "jpg",
+      overlap: 0,
+      tilesize: 256,
+    },
+    tileKvStore: {
+      path: "image_files/12/",
+      store: {
+        read(path: string, options: { signal: AbortSignal }) {
+          readPath = path;
+          readSignal = options.signal;
+          return Promise.resolve(undefined);
+        },
+      },
+    },
+  };
+  const controller = new AbortController();
+  await DeepzoomImageTileSource.prototype.download.call(
+    source as never,
+    { chunkGridPosition: Uint32Array.of(3, 4) } as never,
+    controller.signal,
+  );
+  expect(readPath).toBe("image_files/12/3_4.jpg");
+  expect(readSignal).toBe(controller.signal);
+});


### PR DESCRIPTION
resolves https://github.com/google/neuroglancer/issues/1028

Curious about thoughts on how this test is implemented, it's a bit verbose for a fix that deletes a single character