### PR TITLE
fix: remove pointer cancel event in relative mouse drag

### DIFF
--- a/src/util/mouse_drag.ts
+++ b/src/util/mouse_drag.ts
@@ -38,6 +38,7 @@ export function startRelativeMouseDrag(
   const cancel = (e: PointerEvent) => {
     document.removeEventListener("pointermove", mouseMoveHandler, true);
     document.removeEventListener("pointerup", mouseUpHandler, false);
+    document.removeEventListener("pointercancel", cancel, false);
 
     if (finishDragHandler !== undefined) {
       finishDragHandler(e, e.clientX - prevClientX, e.clientY - prevClientY);


### PR DESCRIPTION
This removes `pointercancel` listener in `startRelativeMouseDrag` on `cancel` otherwise it could remain registered indefinitely since it is added at the document level and keep triggering on any unrelated `pointercancel`.

For many cases this was pretty harmless, but it could lead to calling the `finishDragHandler` with stale data over and over again on unrelated `pointercancel`, such as when dragging panels around.
