### PR TITLE
fix: protect against parsing omero color if none provided

### DIFF
--- a/src/datasource/zarr/ome.ts
+++ b/src/datasource/zarr/ome.ts
@@ -126,7 +126,10 @@ function parseOmeroChannel(omeroChannel: unknown): SingleChannelMetadata {
   if (colorString && /^[0-9a-f]{6}$/i.test(colorString)) {
     colorString = `#${colorString}`;
   }
-  const color = parseRGBColorSpecification(colorString);
+  const color =
+    colorString !== undefined
+      ? parseRGBColorSpecification(colorString)
+      : undefined;
   const inverted = getProp("inverted", verifyBoolean);
   const label = getProp("label", verifyString);
 


### PR DESCRIPTION
I have extracted out the color parsing guard fix from @r2dliu in #886 since I think that got a bit held up by the automated tests and it now also has conflicts to due a different fix for the omero parsing in v0.5 onwards.