### PR TITLE
making selecting number input select on focus

### DIFF
--- a/src/ui/annotation_schema_tab.ts
+++ b/src/ui/annotation_schema_tab.ts
@@ -915,9 +915,11 @@ class AnnotationUIProperty extends RefCounted {
       input = this.createNumberInput(inputValue as number, config, readonly);
     } else if (config.type === "text") {
       input = createTextAreaElement(inputValue as string, readonly);
+      input.addEventListener("focus", () => input!.select());
     } else {
       input = document.createElement("input");
       input.type = config.type;
+      input.addEventListener("focus", () => input!.select());
     }
 
     this.setCommonInputAttributes(inputValue, input!, config, readonly);

--- a/src/ui/bounded_number_input.ts
+++ b/src/ui/bounded_number_input.ts
@@ -94,6 +94,7 @@ export function createBoundedNumberInputElement(
   input.value = numberToStringFixed(inputValue, config.numDecimals || 4);
   input.autocomplete = "off";
   input.spellcheck = false;
+  input.addEventListener("focus", () => input.select());
   if (config.className) input.classList.add(config.className);
   return input;
 }


### PR DESCRIPTION
This is a simple PR that makes it so that when you click into a numeric property input box, it will by default to selecting the entire value rather than simply putting the cursor into the box.  The most common use case for this UI is for people to enter a number for the first time, making it unlikely that they will want to be editing an existing digit on a number.  Once can simply click again to get to the digit/space you want to edit if you want to make a more targeted correction to the number field, but I think that is a much smaller set of use cases and so this is a preferable behavior. 