### PR TITLE
Design draft: Annotation prop input enhancements

### DIFF
--- a/src/layer/annotation/index.ts
+++ b/src/layer/annotation/index.ts
@@ -108,6 +108,8 @@ import { Tab } from "#src/widget/tab_view.js";
 const POINTS_JSON_KEY = "points";
 const ANNOTATIONS_JSON_KEY = "annotations";
 const ANNOTATION_PROPERTIES_JSON_KEY = "annotationProperties";
+const ANNOTATION_LIST_COLUMNS_KEY = "annotationListColumns";
+const ANNOTATION_LIST_SORT_KEY = "annotationListSort";
 const ANNOTATION_RELATIONSHIPS_JSON_KEY = "annotationRelationships";
 const CROSS_SECTION_RENDER_SCALE_JSON_KEY = "crossSectionAnnotationSpacing";
 const PROJECTION_RENDER_SCALE_JSON_KEY = "projectionAnnotationSpacing";
@@ -708,6 +710,26 @@ export class AnnotationUserLayer extends Base {
     this.annotationDisplayState.shaderControls.restoreState(
       specification[SHADER_CONTROLS_JSON_KEY],
     );
+    const shownColumns = verifyOptionalObjectProperty(
+      specification,
+      ANNOTATION_LIST_COLUMNS_KEY,
+      verifyStringArray,
+    );
+    if (shownColumns !== undefined) {
+      this.annotationListShownColumns.value = shownColumns;
+    }
+    const sortJson = verifyOptionalObjectProperty(
+      specification,
+      ANNOTATION_LIST_SORT_KEY,
+      verifyObject,
+    );
+    if (sortJson !== undefined) {
+      const propertyId = verifyString(sortJson["propertyId"]);
+      const order = verifyString(sortJson["order"]);
+      if (order === "asc" || order === "desc") {
+        this.annotationListSortState.value = { propertyId, order };
+      }
+    }
   }
 
   getLegacyDataSourceSpecifications(
@@ -983,6 +1005,14 @@ export class AnnotationUserLayer extends Base {
     x[SHADER_CONTROLS_JSON_KEY] =
       this.annotationDisplayState.shaderControls.toJSON();
     Object.assign(x, this.linkedSegmentationLayers.toJSON());
+    const shownColumns = this.annotationListShownColumns.value;
+    if (shownColumns.length > 0) {
+      x[ANNOTATION_LIST_COLUMNS_KEY] = shownColumns;
+    }
+    const sortState = this.annotationListSortState.value;
+    if (sortState !== null) {
+      x[ANNOTATION_LIST_SORT_KEY] = sortState;
+    }
     return x;
   }
 

--- a/src/layer/annotation/index.ts
+++ b/src/layer/annotation/index.ts
@@ -19,10 +19,14 @@ import "#src/layer/annotation/style.css";
 import type { AnnotationDisplayState } from "#src/annotation/annotation_layer_state.js";
 import { AnnotationLayerState } from "#src/annotation/annotation_layer_state.js";
 import { MultiscaleAnnotationSource } from "#src/annotation/frontend_source.js";
-import type { AnnotationPropertySpec } from "#src/annotation/index.js";
+import type {
+  AnnotationNumericPropertySpec,
+  AnnotationPropertySpec,
+} from "#src/annotation/index.js";
 import {
   annotationPropertySpecsToJson,
   AnnotationType,
+  isAnnotationNumericPropertySpec,
   LocalAnnotationSource,
   parseAnnotationPropertySpecs,
 } from "#src/annotation/index.js";
@@ -54,12 +58,18 @@ import {
   WatchableValue,
   observeWatchable,
 } from "#src/trackable_value.js";
+import {
+  setEnumPropertyToolJson,
+  toggleBoolPropertyToolJson,
+} from "#src/ui/annotation_properties.js";
 import { AnnotationSchemaTab } from "#src/ui/annotation_schema_tab.js";
 import type {
   AnnotationLayerView,
   MergedAnnotationStates,
 } from "#src/ui/annotations.js";
 import { UserLayerWithAnnotationsMixin } from "#src/ui/annotations.js";
+import type { ToolActivation } from "#src/ui/tool.js";
+import { LayerTool, registerTool, unregisterTool } from "#src/ui/tool.js";
 import { animationFrameDebounce } from "#src/util/animation_frame_debounce.js";
 import type { Borrowed, Owned } from "#src/util/disposable.js";
 import { RefCounted } from "#src/util/disposable.js";
@@ -398,6 +408,120 @@ class LinkedSegmentationLayersWidget extends RefCounted {
   }
 }
 
+// A keybindable tool that sets the currently-selected (iterated) annotation's
+// enum property to a specific value, then advances to the next annotation so
+// the user can rapidly classify a list with keystrokes alone.
+class SetEnumPropertyTool extends LayerTool<AnnotationUserLayer> {
+  constructor(
+    public propertyIdentifier: string,
+    public enumValue: number,
+    layer: AnnotationUserLayer,
+  ) {
+    super(layer, true);
+  }
+
+  private get property(): AnnotationNumericPropertySpec | undefined {
+    const properties = this.layer.localAnnotations?.properties.value;
+    const property = properties?.find(
+      (x) => x.identifier === this.propertyIdentifier,
+    );
+    if (property !== undefined && isAnnotationNumericPropertySpec(property)) {
+      return property;
+    }
+    return undefined;
+  }
+
+  private get enumLabel(): string {
+    const { property } = this;
+    const enumIndex = property?.enumValues?.indexOf(this.enumValue) ?? -1;
+    if (enumIndex !== -1 && property?.enumLabels !== undefined) {
+      return property.enumLabels[enumIndex];
+    }
+    return String(this.enumValue);
+  }
+
+  activate(activation: ToolActivation<this>) {
+    const { layer } = this;
+    const context = layer.getSelectedAnnotationContext();
+    if (context !== undefined) {
+      const { annotationLayerState, annotationId } = context;
+      const { source } = annotationLayerState;
+      const propertyIndex = source.properties.value.findIndex(
+        (x) => x.identifier === this.propertyIdentifier,
+      );
+      if (propertyIndex > -1) {
+        const reference = source.getReference(annotationId);
+        try {
+          const annotation = reference.value;
+          if (annotation != null) {
+            const properties = annotation.properties.slice();
+            properties[propertyIndex] = this.enumValue;
+            source.update(reference, { ...annotation, properties });
+            source.commit(reference);
+          }
+        } finally {
+          reference.dispose();
+        }
+      }
+    }
+    activation.cancel();
+  }
+
+  toJSON() {
+    return setEnumPropertyToolJson(this.propertyIdentifier, this.enumValue);
+  }
+
+  get description() {
+    return `set ${this.propertyIdentifier} = ${this.enumLabel}`;
+  }
+}
+
+// A keybindable tool that toggles a boolean annotation property on the
+// currently-selected (iterated) annotation.
+class ToggleBoolPropertyTool extends LayerTool<AnnotationUserLayer> {
+  constructor(
+    public propertyIdentifier: string,
+    layer: AnnotationUserLayer,
+  ) {
+    super(layer, true);
+  }
+
+  activate(activation: ToolActivation<this>) {
+    const { layer } = this;
+    const context = layer.getSelectedAnnotationContext();
+    if (context !== undefined) {
+      const { annotationLayerState, annotationId } = context;
+      const { source } = annotationLayerState;
+      const propertyIndex = source.properties.value.findIndex(
+        (x) => x.identifier === this.propertyIdentifier,
+      );
+      if (propertyIndex > -1) {
+        const reference = source.getReference(annotationId);
+        try {
+          const annotation = reference.value;
+          if (annotation != null) {
+            const properties = annotation.properties.slice();
+            properties[propertyIndex] = properties[propertyIndex] ? 0 : 1;
+            source.update(reference, { ...annotation, properties });
+            source.commit(reference);
+          }
+        } finally {
+          reference.dispose();
+        }
+      }
+    }
+    activation.cancel();
+  }
+
+  toJSON() {
+    return toggleBoolPropertyToolJson(this.propertyIdentifier);
+  }
+
+  get description() {
+    return `toggle ${this.propertyIdentifier}`;
+  }
+}
+
 const Base = UserLayerWithAnnotationsMixin(UserLayer);
 export class AnnotationUserLayer extends Base {
   localAnnotations: LocalAnnotationSource | undefined;
@@ -407,6 +531,13 @@ export class AnnotationUserLayer extends Base {
     new WatchableValue([]);
   private localAnnotationRelationships: string[];
   private localAnnotationsJson: any = undefined;
+  // Tool ids currently registered for enum property values, keyed by tool id.
+  private registeredEnumTools = new Map<
+    string,
+    { propertyIdentifier: string; enumValue: number }
+  >();
+  // Tool ids currently registered for bool property toggles, keyed by tool id.
+  private registeredBoolTools = new Set<string>();
   private pointAnnotationsJson: any = undefined;
   static supportColorPickerInAnnotationTab = false;
 
@@ -455,9 +586,97 @@ export class AnnotationUserLayer extends Base {
       getter: () => new AnnotationSchemaTab(this),
     });
     this.tabs.default = "annotations";
+    this.registerDisposer(
+      this.localAnnotationProperties.changed.add(() => {
+        this.syncEnumPropertyTools();
+      }),
+    );
+  }
+
+  // Keep one keybindable tool registered per (enum property × enum value) and
+  // per bool property so each can be bound to a hotkey in the schema editor.
+  // Registers newly-added options and tears down removed ones, including any
+  // live keybindings in this layer's tool binder.
+  private syncEnumPropertyTools(
+    properties: readonly AnnotationPropertySpec[] = this
+      .localAnnotationProperties.value,
+  ) {
+    // --- enum tools ---
+    const desiredEnum = new Map<
+      string,
+      { propertyIdentifier: string; enumValue: number }
+    >();
+    for (const property of properties) {
+      if (
+        !isAnnotationNumericPropertySpec(property) ||
+        property.enumValues === undefined
+      ) {
+        continue;
+      }
+      for (const enumValue of property.enumValues) {
+        desiredEnum.set(
+          setEnumPropertyToolJson(property.identifier, enumValue),
+          { propertyIdentifier: property.identifier, enumValue },
+        );
+      }
+    }
+    for (const toolId of this.registeredEnumTools.keys()) {
+      if (!desiredEnum.has(toolId)) {
+        this.toolBinder.removeJsonString(JSON.stringify(toolId));
+        unregisterTool(AnnotationUserLayer, toolId);
+        this.registeredEnumTools.delete(toolId);
+      }
+    }
+    for (const [toolId, { propertyIdentifier, enumValue }] of desiredEnum) {
+      if (!this.registeredEnumTools.has(toolId)) {
+        registerTool(
+          AnnotationUserLayer,
+          toolId,
+          (layer) =>
+            new SetEnumPropertyTool(propertyIdentifier, enumValue, layer),
+        );
+        this.registeredEnumTools.set(toolId, { propertyIdentifier, enumValue });
+      }
+    }
+
+    // --- bool tools ---
+    const desiredBool = new Set<string>();
+    for (const property of properties) {
+      if (property.type === "bool") {
+        desiredBool.add(toggleBoolPropertyToolJson(property.identifier));
+      }
+    }
+    for (const toolId of this.registeredBoolTools) {
+      if (!desiredBool.has(toolId)) {
+        this.toolBinder.removeJsonString(JSON.stringify(toolId));
+        unregisterTool(AnnotationUserLayer, toolId);
+        this.registeredBoolTools.delete(toolId);
+      }
+    }
+    for (const toolId of desiredBool) {
+      if (!this.registeredBoolTools.has(toolId)) {
+        const propertyIdentifier = toolId.slice(
+          toggleBoolPropertyToolJson("").length,
+        );
+        registerTool(
+          AnnotationUserLayer,
+          toolId,
+          (layer) => new ToggleBoolPropertyTool(propertyIdentifier, layer),
+        );
+        this.registeredBoolTools.add(toolId);
+      }
+    }
   }
 
   restoreState(specification: any) {
+    const properties = verifyOptionalObjectProperty(
+      specification,
+      ANNOTATION_PROPERTIES_JSON_KEY,
+      parseAnnotationPropertySpecs,
+    );
+    // Register enum-value tools before `super.restoreState` restores the tool
+    // binder, so that any saved enum keybindings resolve to a registered tool.
+    this.syncEnumPropertyTools(properties ?? []);
     super.restoreState(specification);
     this.linkedSegmentationLayers.restoreState(specification);
     this.codeVisible.restoreState(specification[CODE_VISIBLE_KEY]);
@@ -465,11 +684,6 @@ export class AnnotationUserLayer extends Base {
       specification[HIDE_INACTIVE_SHADER_CONTROLS_JSON_KEY],
     );
     this.localAnnotationsJson = specification[ANNOTATIONS_JSON_KEY];
-    const properties = verifyOptionalObjectProperty(
-      specification,
-      ANNOTATION_PROPERTIES_JSON_KEY,
-      parseAnnotationPropertySpecs,
-    );
     this.localAnnotationProperties.value = properties ?? [];
 
     this.localAnnotationRelationships = verifyOptionalObjectProperty(

--- a/src/layer/index.ts
+++ b/src/layer/index.ts
@@ -100,7 +100,7 @@ import {
 } from "#src/util/json.js";
 import { MessageList } from "#src/util/message_list.js";
 import type { AnyConstructor } from "#src/util/mixin.js";
-import { NullarySignal } from "#src/util/signal.js";
+import { NullarySignal, Signal } from "#src/util/signal.js";
 import type { SignalBindingUpdater } from "#src/util/signal_binding_updater.js";
 import {
   addSignalBinding,
@@ -194,6 +194,25 @@ export class UserLayer extends RefCounted {
   selectionState: UserLayerSelectionState;
 
   messages = new MessageList();
+
+  layerEventListeners = new Map<string, Signal>();
+
+  dispatchLayerEvent(type: string) {
+    this.layerEventListeners.get(type)?.dispatch();
+  }
+
+  registerLayerEvent(type: string, handler: () => void) {
+    const { layerEventListeners } = this;
+    let existingSignal = layerEventListeners.get(type);
+    if (!existingSignal) {
+      existingSignal = new Signal();
+      layerEventListeners.set(type, existingSignal);
+    }
+    const unregister = existingSignal.add(handler);
+    return () => {
+      return unregister();
+    };
+  }
 
   observeLayerColor(_: () => void): () => void {
     return () => {};

--- a/src/ui/annotation_properties.ts
+++ b/src/ui/annotation_properties.ts
@@ -32,6 +32,29 @@ import { makeIcon } from "#src/widget/icon.js";
 export type AnnotationColorKey = AnnotationColorPropertySpec["type"];
 export type AnnotationPropertyType = AnnotationPropertySpec["type"];
 
+export const SET_ENUM_PROPERTY_TOOL_ID = "setEnumProperty";
+
+// Deterministic, locale-independent tool id for the keybindable tool that sets
+// an annotation's enum property to a specific value.  Defined here (a neutral
+// leaf module) so that both the tool registration in
+// `src/layer/annotation/index.ts` and the schema-editor keybind button in
+// `src/ui/annotation_schema_tab.ts` produce identical ids, letting bindings
+// round-trip through saved state.
+export function setEnumPropertyToolJson(
+  propertyIdentifier: string,
+  enumValue: number,
+) {
+  return `${SET_ENUM_PROPERTY_TOOL_ID}_${propertyIdentifier}_${String(enumValue)}`;
+}
+
+export const TOGGLE_BOOL_PROPERTY_TOOL_ID = "toggleBoolProperty";
+
+// Deterministic tool id for the keybindable tool that toggles a boolean
+// annotation property on the currently-selected annotation.
+export function toggleBoolPropertyToolJson(propertyIdentifier: string) {
+  return `${TOGGLE_BOOL_PROPERTY_TOOL_ID}_${propertyIdentifier}`;
+}
+
 export const ANNOTATION_TYPES: AnnotationPropertyType[] = [
   "bool",
   "rgb",

--- a/src/ui/annotation_schema_tab.css
+++ b/src/ui/annotation_schema_tab.css
@@ -258,6 +258,11 @@
   margin-bottom: 2px;
 }
 
+.neuroglancer-annotation-schema-enum-keybind {
+  flex-shrink: 0;
+  align-self: center;
+}
+
 .neuroglancer-annotation-schema-enum-entry
   .neuroglancer-annotation-schema-default-value-input {
   line-height: 18px;

--- a/src/ui/annotation_schema_tab.ts
+++ b/src/ui/annotation_schema_tab.ts
@@ -59,10 +59,13 @@ import {
   makeReadonlyColorProperty,
   isEnumType,
   createTextAreaElement,
+  setEnumPropertyToolJson,
+  toggleBoolPropertyToolJson,
 } from "#src/ui/annotation_properties.js";
 import type { UserLayerWithAnnotations } from "#src/ui/annotations.js";
 import type { NumberDisplayConfig } from "#src/ui/bounded_number_input.js";
 import { createBoundedNumberInputElement } from "#src/ui/bounded_number_input.js";
+import { makeToolButton } from "#src/ui/tool.js";
 import { arraysEqual } from "#src/util/array.js";
 import { setClipboard } from "#src/util/clipboard.js";
 import {
@@ -545,6 +548,16 @@ class AnnotationUIProperty extends RefCounted {
     container.appendChild(checkbox);
     if (!this.readonly) {
       this.registerEventListener(checkbox, "change", changeFunction);
+      const toolButton = makeToolButton(
+        this,
+        this.parentView.layer.toolBinder,
+        {
+          toolJson: toggleBoolPropertyToolJson(oldProperty.identifier),
+          title: `Bind a key to toggle the selected annotation's ${oldProperty.identifier}`,
+        },
+      );
+      toolButton.classList.add("neuroglancer-annotation-schema-enum-keybind");
+      container.appendChild(toolButton);
     }
 
     return [checkbox];
@@ -730,6 +743,20 @@ class AnnotationUIProperty extends RefCounted {
     enumRow.appendChild(valueInput);
 
     if (!this.readonly) {
+      // Keybind affordance: bind a key so that pressing it while iterating the
+      // annotation list sets the selected annotation's property to this enum
+      // value (and advances to the next annotation).
+      const toolButton = makeToolButton(
+        this,
+        this.parentView.layer.toolBinder,
+        {
+          toolJson: setEnumPropertyToolJson(oldProperty.identifier, value),
+          title: `Bind a key to set the selected annotation's ${oldProperty.identifier} to "${label}"`,
+        },
+      );
+      toolButton.classList.add("neuroglancer-annotation-schema-enum-keybind");
+      enumRow.appendChild(toolButton);
+
       const deleteIcon = this.createEnumDeleteIcon(enumIndex, oldProperty);
       enumRow.appendChild(deleteIcon);
     }

--- a/src/ui/annotations.css
+++ b/src/ui/annotations.css
@@ -112,6 +112,80 @@
   background-color: #969;
 }
 
+/* Property column selector row — chips that toggle a property column on/off */
+.neuroglancer-annotation-column-selector {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  padding: 3px 4px;
+  border-bottom: 1px solid #2a2a2a;
+}
+
+.neuroglancer-annotation-column-chip {
+  background: transparent;
+  border: 1px solid #555;
+  color: rgba(255, 255, 255, 0.45);
+  padding: 1px 6px;
+  cursor: pointer;
+  font-size: 11px;
+  border-radius: 2px;
+  line-height: 1.4;
+}
+
+.neuroglancer-annotation-column-chip:hover {
+  border-color: rgba(255, 255, 255, 0.6);
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.neuroglancer-annotation-column-chip[data-active="true"] {
+  border-color: #4e9ac0;
+  color: #4e9ac0;
+}
+
+/* Property column headers */
+.neuroglancer-annotation-property-header {
+  display: flex;
+  align-items: center;
+  gap: 1px;
+  white-space: nowrap;
+  overflow: hidden;
+}
+
+.neuroglancer-annotation-property-header-name {
+  font-size: 0.85em;
+  color: rgba(255, 255, 255, 0.6);
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.neuroglancer-annotation-property-sort-btn {
+  flex-shrink: 0;
+  background: none;
+  border: none;
+  color: rgba(255, 255, 255, 0.25);
+  cursor: pointer;
+  padding: 0 1px;
+  font-size: 9px;
+  line-height: 1;
+}
+
+.neuroglancer-annotation-property-sort-btn:hover {
+  color: rgba(255, 255, 255, 0.75);
+}
+
+.neuroglancer-annotation-property-sort-btn[data-active="true"] {
+  color: #4e9ac0;
+}
+
+/* Per-annotation property value cells in the annotation list */
+.neuroglancer-annotation-list-property-value {
+  font-family: monospace;
+  font-size: 0.9em;
+  text-align: right;
+  color: rgba(255, 255, 255, 0.6);
+  padding-right: 4px;
+}
+
 .neuroglancer-annotation-dragging {
   opacity: 0.5;
 }

--- a/src/ui/annotations.ts
+++ b/src/ui/annotations.ts
@@ -30,6 +30,7 @@ import type {
   Annotation,
   AnnotationId,
   AnnotationNumericPropertySpec,
+  AnnotationPropertySpec,
   AnnotationReference,
   AxisAlignedBoundingBox,
   Ellipsoid,
@@ -349,6 +350,13 @@ export class AnnotationLayerView extends Tab {
       refCounted.registerDisposer(
         state.transform.changed.add(this.forceUpdateView),
       );
+      refCounted.registerDisposer(
+        source.properties.changed.add(() => {
+          this.updatePropertyColumnSelector();
+          ++this.curColumnConfigGeneration;
+          this.forceUpdateView();
+        }),
+      );
       newAttachedAnnotationStates.set(state, {
         refCounted,
         annotations: [],
@@ -359,6 +367,7 @@ export class AnnotationLayerView extends Tab {
     this.attachedAnnotationStates = newAttachedAnnotationStates;
     attachedAnnotationStates.clear();
     this.updateCoordinateSpace();
+    this.updatePropertyColumnSelector();
     this.forceUpdateView();
   }
 
@@ -373,6 +382,16 @@ export class AnnotationLayerView extends Tab {
   private prevCoordinateSpaceGeneration = -1;
   private columnWidths: number[] = [];
   private gridTemplate = "";
+  // Property column state
+  private shownPropertyIds = new Set<string>();
+  private sortState: { propertyId: string; order: "asc" | "desc" } | undefined =
+    undefined;
+  private curColumnConfigGeneration = 0;
+  private prevColumnConfigGeneration = -1;
+  private numDimColumns = 0;
+  private shownPropertySpecs: readonly AnnotationPropertySpec[] = [];
+  private idToFlatIndex = new Map<string, number>();
+  private propertyColumnSelectorRow = document.createElement("div");
 
   private updateCoordinateSpace() {
     const localCoordinateSpace = this.layer.localCoordinateSpace.value;
@@ -537,6 +556,10 @@ export class AnnotationLayerView extends Tab {
 
     toolbox.appendChild(mutableControls);
     this.element.appendChild(toolbox);
+    this.propertyColumnSelectorRow.classList.add(
+      "neuroglancer-annotation-column-selector",
+    );
+    this.element.appendChild(this.propertyColumnSelectorRow);
 
     this.element.appendChild(this.headerRow);
     const { virtualList } = this;
@@ -575,6 +598,9 @@ export class AnnotationLayerView extends Tab {
     this.updateAttachedAnnotationLayerStates();
     this.updateSelectionView();
     this.setupListReorder();
+    this.registerDisposer(() => {
+      this.layer.annotationListOrder = undefined;
+    });
   }
 
   private findStateForAnnotationId(
@@ -738,13 +764,19 @@ export class AnnotationLayerView extends Tab {
     id: AnnotationId,
     scrollIntoView = false,
   ): HTMLElement | undefined {
+    if (this.idToFlatIndex.size > 0) {
+      const listIndex = this.idToFlatIndex.get(id);
+      if (listIndex === undefined) return undefined;
+      if (scrollIntoView) this.virtualList.scrollItemIntoView(listIndex);
+      return this.virtualList.getItemElement(listIndex);
+    }
     const attached = this.attachedAnnotationStates.get(state);
     if (attached === undefined) return undefined;
     const index = attached.idToIndex.get(id);
     if (index === undefined) return undefined;
     const listIndex = attached.listOffset + index;
     if (scrollIntoView) {
-      this.virtualList.scrollItemIntoView(index);
+      this.virtualList.scrollItemIntoView(listIndex);
     }
     return this.virtualList.getItemElement(listIndex);
   }
@@ -840,6 +872,8 @@ export class AnnotationLayerView extends Tab {
       gridTemplate,
       globalDimensionIndices,
       localDimensionIndices,
+      shownPropertySpecs,
+      numDimColumns,
     } = this;
     const [element, elementColumnWidths] = makeAnnotationListElement(
       layer,
@@ -848,6 +882,9 @@ export class AnnotationLayerView extends Tab {
       gridTemplate,
       globalDimensionIndices,
       localDimensionIndices,
+      shownPropertySpecs.length > 0
+        ? { specs: shownPropertySpecs, dimColumnCount: numDimColumns }
+        : undefined,
     );
     for (const [column, width] of elementColumnWidths.entries()) {
       this.setColumnWidth(column, width);
@@ -878,12 +915,115 @@ export class AnnotationLayerView extends Tab {
     );
   }
 
+  private getAllPropertySpecs(): AnnotationPropertySpec[] {
+    const seen = new Set<string>();
+    const result: AnnotationPropertySpec[] = [];
+    for (const [state] of this.attachedAnnotationStates) {
+      for (const prop of state.source.properties.value) {
+        if (
+          !seen.has(prop.identifier) &&
+          prop.type !== "rgb" &&
+          prop.type !== "rgba"
+        ) {
+          seen.add(prop.identifier);
+          result.push(prop);
+        }
+      }
+    }
+    return result;
+  }
+
+  private updatePropertyColumnSelector() {
+    const allProps = this.getAllPropertySpecs();
+    const { propertyColumnSelectorRow, shownPropertyIds } = this;
+    removeChildren(propertyColumnSelectorRow);
+    if (allProps.length === 0) {
+      propertyColumnSelectorRow.style.display = "none";
+      return;
+    }
+    propertyColumnSelectorRow.style.display = "";
+    for (const prop of allProps) {
+      const chip = document.createElement("button");
+      chip.textContent = prop.identifier;
+      if (prop.description) chip.title = prop.description;
+      chip.dataset.active = String(shownPropertyIds.has(prop.identifier));
+      chip.classList.add("neuroglancer-annotation-column-chip");
+      chip.addEventListener("click", (event) => {
+        event.stopPropagation();
+        if (shownPropertyIds.has(prop.identifier)) {
+          shownPropertyIds.delete(prop.identifier);
+          if (this.sortState?.propertyId === prop.identifier) {
+            this.sortState = undefined;
+          }
+        } else {
+          shownPropertyIds.add(prop.identifier);
+        }
+        ++this.curColumnConfigGeneration;
+        this.forceUpdateView();
+        // Re-render selector so chip active state reflects new set.
+        this.updatePropertyColumnSelector();
+      });
+      propertyColumnSelectorRow.appendChild(chip);
+    }
+  }
+
+  private createPropertyColumnHeader(
+    spec: AnnotationPropertySpec,
+  ): HTMLDivElement {
+    const header = document.createElement("div");
+    header.classList.add("neuroglancer-annotation-property-header");
+    const name = document.createElement("span");
+    name.classList.add("neuroglancer-annotation-property-header-name");
+    name.textContent = spec.identifier;
+    if (spec.description) name.title = spec.description;
+    header.appendChild(name);
+    const makeBtn = (
+      arrow: string,
+      titleText: string,
+      clickOrder: "asc" | "desc",
+    ) => {
+      const btn = document.createElement("button");
+      btn.textContent = arrow;
+      btn.title = titleText;
+      btn.classList.add("neuroglancer-annotation-property-sort-btn");
+      if (
+        this.sortState?.propertyId === spec.identifier &&
+        this.sortState.order === clickOrder
+      ) {
+        btn.dataset.active = "true";
+      }
+      btn.addEventListener("click", (e) => {
+        e.stopPropagation();
+        if (
+          this.sortState?.propertyId === spec.identifier &&
+          this.sortState.order === clickOrder
+        ) {
+          this.sortState = undefined;
+        } else {
+          this.sortState = { propertyId: spec.identifier, order: clickOrder };
+        }
+        ++this.curColumnConfigGeneration;
+        this.forceUpdateView();
+      });
+      return btn;
+    };
+    header.appendChild(
+      makeBtn("▲", `Sort ${spec.identifier} ascending`, "asc"),
+    );
+    header.appendChild(
+      makeBtn("▼", `Sort ${spec.identifier} descending`, "desc"),
+    );
+    return header;
+  }
+
   private updateView() {
     if (!this.visible) {
       return;
     }
     if (
-      this.curCoordinateSpaceGeneration !== this.prevCoordinateSpaceGeneration
+      this.curCoordinateSpaceGeneration !==
+        this.prevCoordinateSpaceGeneration ||
+      this.curColumnConfigGeneration !== this.prevColumnConfigGeneration
     ) {
       this.updated = false;
       const { columnWidths } = this;
@@ -935,11 +1075,41 @@ export class AnnotationLayerView extends Tab {
       for (const localDim of this.localDimensionIndices) {
         addDimension(localCoordinateSpace, localDim);
       }
+      this.numDimColumns = i;
+
+      // Property column headers for each toggled-on property.
+      const shownPropertySpecs: AnnotationPropertySpec[] = [];
+      for (const propId of this.shownPropertyIds) {
+        let spec: AnnotationPropertySpec | undefined;
+        for (const [state] of this.attachedAnnotationStates) {
+          const found = state.source.properties.value.find(
+            (p) => p.identifier === propId,
+          );
+          if (found !== undefined) {
+            spec = found;
+            break;
+          }
+        }
+        if (spec === undefined || spec.type === "rgb" || spec.type === "rgba") {
+          continue;
+        }
+        const propColIdx = shownPropertySpecs.length;
+        shownPropertySpecs.push(spec);
+        const propHeader = this.createPropertyColumnHeader(spec);
+        propHeader.style.gridColumn = `prop ${propColIdx + 1}`;
+        headerRow.appendChild(propHeader);
+        const colIdx = this.numDimColumns + propColIdx;
+        this.setColumnWidth(colIdx, spec.identifier.length + 2);
+        gridTemplate += ` [prop] var(--neuroglancer-column-${colIdx}-width)`;
+      }
+      this.shownPropertySpecs = shownPropertySpecs;
+
       headerRow.appendChild(deletePlaceholder);
       gridTemplate += " [delete] 2ch";
       this.gridTemplate = gridTemplate;
       headerRow.style.gridTemplateColumns = gridTemplate;
       this.prevCoordinateSpaceGeneration = this.curCoordinateSpaceGeneration;
+      this.prevColumnConfigGeneration = this.curColumnConfigGeneration;
     }
     if (this.updated) {
       return;
@@ -963,6 +1133,38 @@ export class AnnotationLayerView extends Tab {
         listElements.push({ state, annotation });
       }
     }
+    // Sort by active property sort state.
+    if (this.sortState !== undefined) {
+      const { propertyId, order } = this.sortState;
+      const sign = order === "asc" ? 1 : -1;
+      listElements.sort(
+        ({ annotation: a, state: sa }, { annotation: b, state: sb }) => {
+          const propsA = sa.source.properties.value;
+          const propsB = sb.source.properties.value;
+          const idxA = propsA.findIndex((p) => p.identifier === propertyId);
+          const idxB = propsB.findIndex((p) => p.identifier === propertyId);
+          const valA =
+            idxA >= 0 && idxA < a.properties.length
+              ? (a.properties[idxA] as number)
+              : undefined;
+          const valB =
+            idxB >= 0 && idxB < b.properties.length
+              ? (b.properties[idxB] as number)
+              : undefined;
+          if (valA === undefined && valB === undefined) return 0;
+          if (valA === undefined) return sign; // undefined sorts to end
+          if (valB === undefined) return -sign;
+          return (valA - valB) * sign;
+        },
+      );
+      // Build a flat id→index map for getRenderedAnnotationListElement.
+      this.idToFlatIndex.clear();
+      for (let k = 0; k < listElements.length; k++) {
+        this.idToFlatIndex.set(listElements[k].annotation.id, k);
+      }
+    } else {
+      this.idToFlatIndex.clear();
+    }
     const oldLength = this.virtualListSource.length;
     this.updateListLength();
     this.virtualListSource.changed!.dispatch([
@@ -973,6 +1175,7 @@ export class AnnotationLayerView extends Tab {
       },
     ]);
     this.mutableControls.style.display = isMutable ? "contents" : "none";
+    this.layer.annotationListOrder = this.listElements;
     this.resetOnUpdate();
   }
 
@@ -991,6 +1194,10 @@ export class AnnotationLayerView extends Tab {
   ) {
     if (!this.visible) {
       this.updated = false;
+      return;
+    }
+    if (this.sortState !== undefined) {
+      this.forceUpdateView();
       return;
     }
     if (!this.updated) {
@@ -1020,6 +1227,10 @@ export class AnnotationLayerView extends Tab {
       this.updated = false;
       return;
     }
+    if (this.sortState !== undefined) {
+      this.forceUpdateView();
+      return;
+    }
     if (!this.updated) {
       this.updateView();
       return;
@@ -1045,6 +1256,10 @@ export class AnnotationLayerView extends Tab {
   ) {
     if (!this.visible) {
       this.updated = false;
+      return;
+    }
+    if (this.sortState !== undefined) {
+      this.forceUpdateView();
       return;
     }
     if (!this.updated) {
@@ -1957,6 +2172,11 @@ export function UserLayerWithAnnotationsMixin<
     annotationProjectionRenderScaleTarget = trackableRenderScaleTarget(8);
     allowDependentAnnotationViewUpdate = new TrackableBoolean(true);
     static supportColorPickerInAnnotationTab = true;
+    // Set by AnnotationLayerView after each list rebuild; used by changeSelectedIndex
+    // to step through annotations in the sorted display order rather than source order.
+    annotationListOrder:
+      | ReadonlyArray<{ state: AnnotationLayerState; annotation: Annotation }>
+      | undefined = undefined;
 
     constructor(...args: any[]) {
       super(...args);
@@ -2061,6 +2281,24 @@ export function UserLayerWithAnnotationsMixin<
       const context = this.getSelectedAnnotationContext();
       if (context === undefined) return;
       const { annotationId } = context;
+
+      // When the annotation list view has a sort active it publishes its
+      // ordered list here so navigation follows the display order.
+      const { annotationListOrder } = this;
+      if (annotationListOrder !== undefined && annotationListOrder.length > 0) {
+        const idx = annotationListOrder.findIndex(
+          (x) => x.annotation.id === annotationId,
+        );
+        if (idx === -1) return;
+        const nextIdx = idx + offset;
+        if (nextIdx < 0 || nextIdx >= annotationListOrder.length) return;
+        const { annotation, state } = annotationListOrder[nextIdx];
+        this.selectAnnotation(state, annotation.id, true);
+        moveToAnnotation(this, annotation, state);
+        return;
+      }
+
+      // Fallback: step through source order across all annotation layer states.
       let annotationLayerState = context.annotationLayerState;
       let annotationLayerStateIndex =
         this.annotationStates.states.indexOf(annotationLayerState);
@@ -2526,7 +2764,7 @@ export function UserLayerWithAnnotationsMixin<
                         }
                         select.value = String(value);
                         select.addEventListener("change", () => {
-                          changeFunction(select.value);
+                          changeFunction(Number(select.value));
                         });
                         valueElement = select;
                       } else {
@@ -2798,6 +3036,23 @@ type UserLayerWithAnnotationsClass = ReturnType<
 export type UserLayerWithAnnotations =
   InstanceType<UserLayerWithAnnotationsClass>;
 
+// Compact per-cell formatter for the annotation list: enum → label only,
+// bool → +/–, float → 4 sig-figs, int → string.  Color properties excluded.
+function formatPropertyForList(
+  spec: AnnotationPropertySpec,
+  value: number,
+): string {
+  if (spec.type === "bool") return value ? "+" : "–";
+  if (spec.type === "rgb" || spec.type === "rgba") return "";
+  const numSpec = spec as AnnotationNumericPropertySpec;
+  if (numSpec.enumValues !== undefined) {
+    const idx = numSpec.enumValues.indexOf(value);
+    if (idx !== -1) return numSpec.enumLabels![idx];
+  }
+  if (spec.type === "float32") return value.toPrecision(4);
+  return String(value);
+}
+
 export function makeAnnotationListElement(
   layer: UserLayerWithAnnotations,
   annotation: Annotation,
@@ -2805,6 +3060,10 @@ export function makeAnnotationListElement(
   gridTemplate: string,
   globalDimensionIndices: number[],
   localDimensionIndices: number[],
+  propertyColumns?: {
+    specs: readonly AnnotationPropertySpec[];
+    dimColumnCount: number;
+  },
 ): [HTMLDivElement, number[]] {
   const chunkTransform = state.chunkTransform.value as ChunkTransformParameters;
   const element = document.createElement("div");
@@ -2882,6 +3141,32 @@ export function makeAnnotationListElement(
       maybeAddDeleteButton();
     },
   );
+  if (propertyColumns !== undefined && propertyColumns.specs.length > 0) {
+    const { specs, dimColumnCount } = propertyColumns;
+    const sourceProps = state.source.properties.value;
+    for (let j = 0; j < specs.length; j++) {
+      const spec = specs[j];
+      const propIdx = sourceProps.findIndex(
+        (p) => p.identifier === spec.identifier,
+      );
+      const propCell = document.createElement("div");
+      propCell.classList.add("neuroglancer-annotation-list-property-value");
+      propCell.style.gridColumn = `prop ${j + 1}`;
+      propCell.style.gridRow = "1";
+      if (propIdx >= 0 && propIdx < annotation.properties.length) {
+        const text = formatPropertyForList(
+          spec,
+          annotation.properties[propIdx] as number,
+        );
+        propCell.textContent = text;
+        columnWidths[dimColumnCount + j] = Math.max(
+          columnWidths[dimColumnCount + j] || 0,
+          text.length,
+        );
+      }
+      element.appendChild(propCell);
+    }
+  }
   if (annotation.description) {
     ++numRows;
     const description = document.createElement("div");

--- a/src/ui/annotations.ts
+++ b/src/ui/annotations.ts
@@ -594,6 +594,14 @@ export class AnnotationLayerView extends Tab {
         this.updateView();
       }),
     );
+    // Initialize column/sort state from persisted layer values.
+    for (const id of this.layer.annotationListShownColumns.value) {
+      this.shownPropertyIds.add(id);
+    }
+    const persistedSort = this.layer.annotationListSortState.value;
+    if (persistedSort !== null) {
+      this.sortState = persistedSort;
+    }
     this.updateCoordinateSpace();
     this.updateAttachedAnnotationLayerStates();
     this.updateSelectionView();
@@ -958,6 +966,8 @@ export class AnnotationLayerView extends Tab {
         } else {
           shownPropertyIds.add(prop.identifier);
         }
+        this.layer.annotationListShownColumns.value = [...shownPropertyIds];
+        this.layer.annotationListSortState.value = this.sortState ?? null;
         ++this.curColumnConfigGeneration;
         this.forceUpdateView();
         // Re-render selector so chip active state reflects new set.
@@ -1002,6 +1012,7 @@ export class AnnotationLayerView extends Tab {
         } else {
           this.sortState = { propertyId: spec.identifier, order: clickOrder };
         }
+        this.layer.annotationListSortState.value = this.sortState ?? null;
         ++this.curColumnConfigGeneration;
         this.forceUpdateView();
       });
@@ -2177,6 +2188,14 @@ export function UserLayerWithAnnotationsMixin<
     annotationListOrder:
       | ReadonlyArray<{ state: AnnotationLayerState; annotation: Annotation }>
       | undefined = undefined;
+    // Persisted column-selector and sort state for the annotation list view.
+    // Written by AnnotationLayerView on every user interaction; serialized by
+    // AnnotationUserLayer.toJSON / restoreState.
+    annotationListShownColumns = new WatchableValue<string[]>([]);
+    annotationListSortState = new WatchableValue<{
+      propertyId: string;
+      order: "asc" | "desc";
+    } | null>(null);
 
     constructor(...args: any[]) {
       super(...args);
@@ -2187,6 +2206,12 @@ export function UserLayerWithAnnotationsMixin<
         this.specificationChanged.dispatch,
       );
       this.annotationDisplayState.shaderControls.changed.add(
+        this.specificationChanged.dispatch,
+      );
+      this.annotationListShownColumns.changed.add(
+        this.specificationChanged.dispatch,
+      );
+      this.annotationListSortState.changed.add(
         this.specificationChanged.dispatch,
       );
       this.tabs.add("annotations", {

--- a/src/ui/annotations.ts
+++ b/src/ui/annotations.ts
@@ -216,6 +216,26 @@ function setLayerPosition(
   layer.setLayerPosition(chunkTransform.modelTransform, layerPosition);
 }
 
+const moveToAnnotation = (
+  layer: UserLayer,
+  annotation: Annotation,
+  state: AnnotationLayerState,
+) => {
+  const chunkTransform = state.chunkTransform.value as ChunkTransformParameters;
+  const { layerRank } = chunkTransform;
+  const chunkPosition = new Float32Array(layerRank);
+  const layerPosition = new Float32Array(layerRank);
+  getCenterPosition(chunkPosition, annotation);
+  matrix.transformPoint(
+    layerPosition,
+    chunkTransform.chunkToLayerTransform,
+    layerRank + 1,
+    chunkPosition,
+    layerRank,
+  );
+  setLayerPosition(layer, chunkTransform, layerPosition);
+};
+
 function visitTransformedAnnotationGeometry(
   annotation: Annotation,
   chunkTransform: ChunkTransformParameters,
@@ -1998,10 +2018,76 @@ export function UserLayerWithAnnotationsMixin<
           this.annotationDisplayState.hoverState.value = undefined;
         }),
       );
+      this.registerDisposer(
+        this.registerLayerEvent("select-previous", () => {
+          this.changeSelectedIndex(-1);
+        }),
+      );
+      this.registerDisposer(
+        this.registerLayerEvent("select-next", () => {
+          this.changeSelectedIndex(1);
+        }),
+      );
     }
 
     initializeAnnotationLayerViewTab(tab: AnnotationLayerView) {
       tab;
+    }
+
+    // Returns the currently pinned/iterated selected annotation for this layer
+    // (the one navigated to via select-next/select-previous), or undefined.
+    getSelectedAnnotationContext():
+      | { annotationLayerState: AnnotationLayerState; annotationId: string }
+      | undefined {
+      const selectionState = this.manager.root.selectionState.value;
+      if (selectionState === undefined) return undefined;
+      const layerSelectionState = selectionState.layers.find(
+        (s) => s.layer === this,
+      )?.state;
+      if (layerSelectionState === undefined) return undefined;
+      const { annotationId } = layerSelectionState;
+      if (annotationId === undefined) return undefined;
+      const annotationLayerState = this.annotationStates.states.find(
+        (x) =>
+          x.sourceIndex === layerSelectionState.annotationSourceIndex &&
+          (layerSelectionState.annotationSubsource === undefined ||
+            x.subsourceId === layerSelectionState.annotationSubsource),
+      );
+      if (annotationLayerState === undefined) return undefined;
+      return { annotationLayerState, annotationId };
+    }
+
+    changeSelectedIndex(offset: number) {
+      const context = this.getSelectedAnnotationContext();
+      if (context === undefined) return;
+      const { annotationId } = context;
+      let annotationLayerState = context.annotationLayerState;
+      let annotationLayerStateIndex =
+        this.annotationStates.states.indexOf(annotationLayerState);
+      let { source } = annotationLayerState;
+      let annotations = Array.from(source);
+      let index = annotations.findIndex((x) => x.id === annotationId);
+      while (true) {
+        index = index + offset;
+        if (index === -1) {
+          // this only happens if offset is negative
+          annotationLayerStateIndex -= 1;
+        } else if (index === annotations.length) {
+          // this only happens if offset is positive
+          annotationLayerStateIndex += 1;
+        } else {
+          const annotation = annotations[index];
+          this.selectAnnotation(annotationLayerState, annotation.id, true);
+          moveToAnnotation(this, annotation, annotationLayerState);
+          return;
+        }
+        annotationLayerState =
+          this.annotationStates.states[annotationLayerStateIndex];
+        if (annotationLayerState === undefined) return;
+        source = annotationLayerState.source;
+        annotations = Array.from(source);
+        index = index === -1 ? annotations.length : 0;
+      }
     }
 
     restoreState(specification: any) {

--- a/src/ui/bounded_number_input.ts
+++ b/src/ui/bounded_number_input.ts
@@ -94,6 +94,7 @@ export function createBoundedNumberInputElement(
   input.value = numberToStringFixed(inputValue, config.numDecimals || 4);
   input.autocomplete = "off";
   input.spellcheck = false;
+  input.addEventListener("focus", () => input.select());
   if (config.className) input.classList.add(config.className);
   return input;
 }

--- a/src/ui/default_input_event_bindings.ts
+++ b/src/ui/default_input_event_bindings.ts
@@ -48,6 +48,10 @@ export function getDefaultGlobalBindings() {
     map.set("space", "toggle-layout");
     map.set("shift+space", "toggle-layout-alternative");
     map.set("backslash", "toggle-show-statistics");
+
+    map.set("alt+arrowup", "select-previous");
+    map.set("alt+arrowdown", "select-next");
+
     defaultGlobalBindings = map;
   }
   return defaultGlobalBindings;

--- a/src/ui/tool.ts
+++ b/src/ui/tool.ts
@@ -242,6 +242,17 @@ export function registerTool<Context extends object>(
   tools.set(type, { getter, lister });
 }
 
+export function unregisterTool<Context extends object>(
+  contextType: AnyConstructor<Context>,
+  type: string,
+) {
+  const { prototype } = contextType;
+  const tools = toolsForPrototype.get(prototype);
+  if (tools) {
+    tools.delete(type);
+  }
+}
+
 export class SelectedLegacyTool
   extends RefCounted
   implements TrackableValueInterface<LegacyTool | undefined>

--- a/src/viewer.ts
+++ b/src/viewer.ts
@@ -1078,6 +1078,21 @@ export class Viewer extends RefCounted implements ViewerState {
       });
     }
 
+    const sendEventToSelectedLayer = (type: string) => {
+      const selectedLayer = this.selectedLayer.layer?.layer;
+      if (selectedLayer) {
+        selectedLayer.dispatchLayerEvent(type);
+      }
+    };
+
+    this.bindAction("select-previous", () => {
+      sendEventToSelectedLayer("select-previous");
+    });
+
+    this.bindAction("select-next", () => {
+      sendEventToSelectedLayer("select-next");
+    });
+
     this.bindAction("help", () => this.toggleHelpPanel());
 
     for (let i = 1; i <= 9; ++i) {


### PR DESCRIPTION
This is an design attempt to reconcile the functionality of #650 (which was an update to #136 ) with the new structured annotation schema introduced by #809.

This PR is a functional design PR, where'd I think it would be good to focus on the UI design and debate the conceptual implementation, independent of the actual implementation before we worry too much about the code. 

The use case for this design is that a user wants to rapidly iterate through a set of annotations/locations and annotate that they belong to a certain class.  Clicking into the annotation property box to label each class is un-ergonomic.  

To accomplish this, this PR proposes adding tool keybinds to the boolean and enum fields of the schema tab.

<img width="467" height="344" alt="image" src="https://github.com/user-attachments/assets/9d47a852-6ec3-4c3b-8e3c-74e4d250c36b" />

So that users can quickly cause the selected annotation to change the enum value to the bound hotkey or toggle the boolean value. 

The PR (like #650) adds hotkey binds of alt-up and alt-down to allow users to navigate the list.

Relatedly, once a user has tagged a bunch of annotations with this metadata, they often want to review a subset of them.  For example, they may tagged a subset with "uncertain", or simply want to show a colleague a subset of examples that they found that were put into some relatively rare class.  

This is related to a more general need to be able to see the properties in the list view, and be able to sort the list by those properties, similar to how the segment properties currently works. 

To accomplish this the PR lets users add numerical properties to the annotation list view.  It also provides up and down arrow buttons to let users sort the list.  This doesn't actually change the order of annotations in the state, so that unsorting all columns leaves the list in its original order. The up/down arrow actions move the selection in the currently displayed list and not the order of annotations in the state. 

<img width="463" height="631" alt="image" src="https://github.com/user-attachments/assets/69c17006-ef9c-437a-a177-871cff205632" />

<img width="478" height="666" alt="image" src="https://github.com/user-attachments/assets/6336ed5f-4563-4cc7-b1df-34d4b7fa87df" />

I think this follows the spirit of the UI where the description field shows up in the annotation list below the annotation, so that users can find the annotations that they left particular notes on.  With the structured schema now incorporated, users need a way to find those annotations. 

The workflow setup in #650 would be accomplished by adding a boolean property for each tag that you wanted to enter, and assigning each a keybind.  This is more general in that you could either do that, or implement a "forced-choice" workflow with an enum, such that selecting one category implicitly deselects the other categories, depending on what is appropriate for your use-case.

I thought about, but didn't add, a more general query box like in segment properties that would allow users to search/filter through annotations by combining filters on columns, but that is something we could debate.

I have not considered deeply how to reconcile this with other non-local annotation sources which might be dynamically loading annotations into view.  We currently don't show any list of annotations in that case, or way to visualize their properties.  Large annotations lists will be dynamically adding/removing data from the view and the list will almost never be authoritative or complete. 