### PR TITLE
fix: correct screenshot ui styling by using new framed dialog class

### DIFF
--- a/src/overlay.css
+++ b/src/overlay.css
@@ -75,8 +75,50 @@
   margin-top: 1px;
 }
 
-.neuroglancer-framed-dialog-close-button {
-  cursor: pointer;
+.neuroglancer-framed-dialog:focus-visible {
+  outline: none;
+}
+
+.neuroglancer-framed-dialog-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.5rem 1.5rem;
+  border-bottom: 1px solid #ccc;
+  height: 2rem;
+  margin-bottom: 1px;
+}
+
+.neuroglancer-framed-dialog-body {
+  display: flex;
+  padding: 0 1.5rem;
+  overflow: auto;
+}
+
+.neuroglancer-framed-dialog-title {
+  margin-right: auto;
+  font-size: large;
+  font-weight: bold;
+  color: #333;
+}
+
+.neuroglancer-framed-dialog-footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1rem 1.5rem;
+  border-top: 1px solid #ccc;
+  margin-top: 1px;
+}
+
+.neuroglancer-framed-dialog-primary-button {
+  margin-left: auto;
+}
+
+.neuroglancer-framed-dialog-close-icon {
+  background-color: transparent;
+  border: none;
+  padding: 0;
 }
 
 .neuroglancer-framed-dialog-close-icon svg {

--- a/src/overlay.ts
+++ b/src/overlay.ts
@@ -69,51 +69,51 @@ export class FramedDialog extends Overlay {
   header: HTMLDivElement;
   headerTitle: HTMLSpanElement;
   closeMenuIcon: HTMLElement;
-  closeButton: HTMLButtonElement;
+  primaryButton: HTMLButtonElement;
   body: HTMLDivElement;
   footer: HTMLDivElement;
   constructor(
     title: string = "Dialog",
-    closeText: string = "Close",
+    primaryButtonText: string = "Close",
     extraClassPrefix?: string,
+    primaryButtonClickListener?: () => void,
   ) {
     super();
-    this.content.classList.add("neuroglancer-framed-dialog");
 
     const header = (this.header = document.createElement("div"));
     const closeMenuIcon = (this.closeMenuIcon = makeIcon({ svg: svg_close }));
     closeMenuIcon.addEventListener("click", () => this.close());
-    closeMenuIcon.classList.add("neuroglancer-framed-dialog-close-icon");
     const headerTitle = (this.headerTitle = document.createElement("span"));
     headerTitle.textContent = title;
-    headerTitle.classList.add("neuroglancer-framed-dialog-title");
-    header.classList.add("neuroglancer-framed-dialog-header");
     header.appendChild(headerTitle);
     header.appendChild(closeMenuIcon);
     this.content.appendChild(header);
 
     const body = (this.body = document.createElement("div"));
-    body.classList.add("neuroglancer-framed-dialog-body");
     this.content.appendChild(body);
 
     const footer = (this.footer = document.createElement("div"));
-    footer.classList.add("neuroglancer-framed-dialog-footer");
-    const closeFooterButton = (this.closeButton =
+    const primaryButton = (this.primaryButton =
       document.createElement("button"));
-    closeFooterButton.textContent = closeText;
-    closeFooterButton.classList.add("neuroglancer-framed-dialog-close-button");
-    closeFooterButton.addEventListener("click", () => this.close());
-    footer.appendChild(closeFooterButton);
+    primaryButton.textContent = primaryButtonText;
+    const onPrimaryClick = primaryButtonClickListener ?? (() => this.close());
+    primaryButton.addEventListener("click", onPrimaryClick);
+    footer.appendChild(primaryButton);
     this.content.appendChild(this.footer);
 
+    const classPrefixes = ["neuroglancer-framed-dialog"];
     if (extraClassPrefix !== undefined) {
-      this.content.classList.add(`${extraClassPrefix}`);
-      this.header.classList.add(`${extraClassPrefix}-header`);
-      this.headerTitle.classList.add(`${extraClassPrefix}-title`);
-      this.closeMenuIcon.classList.add(`${extraClassPrefix}-close-icon`);
-      this.body.classList.add(`${extraClassPrefix}-body`);
-      this.footer.classList.add(`${extraClassPrefix}-footer`);
-      this.closeButton.classList.add(`${extraClassPrefix}-close-button`);
+      classPrefixes.push(extraClassPrefix);
+    }
+
+    for (const classPrefix of classPrefixes) {
+      this.content.classList.add(`${classPrefix}`);
+      this.header.classList.add(`${classPrefix}-header`);
+      this.headerTitle.classList.add(`${classPrefix}-title`);
+      this.closeMenuIcon.classList.add(`${classPrefix}-close-icon`);
+      this.body.classList.add(`${classPrefix}-body`);
+      this.footer.classList.add(`${classPrefix}-footer`);
+      this.primaryButton.classList.add(`${classPrefix}-primary-button`);
     }
   }
 }

--- a/src/ui/screenshot_menu.css
+++ b/src/ui/screenshot_menu.css
@@ -34,23 +34,23 @@
   outline: 0;
 }
 
-.neuroglancer-screenshot-dialog {
+.neuroglancer-screenshot {
   width: 48.75rem;
-  padding: 0;
   margin: 1.25rem auto;
   position: relative;
   transform: none;
   left: auto;
   top: auto;
-  border-radius: 0.5rem;
   font-family: sans-serif;
 }
 
-.neuroglancer-screenshot-main-body-container {
+.neuroglancer-screenshot-body {
   height: auto;
   max-height: calc(100vh - 200px);
   overflow-y: auto;
   overflow-x: hidden;
+  display: block;
+  padding: 0;
 }
 
 .neuroglancer-screenshot-title {
@@ -73,12 +73,8 @@
 }
 
 /* Div at the top which contains the close */
-.neuroglancer-screenshot-close {
-  border-bottom: 1px solid var(--gray50);
-  display: flex;
-  align-items: center;
-  padding: 0.75rem 1rem;
-  gap: 10px;
+.neuroglancer-screenshot-header {
+  padding: 1.5rem 1rem;
 }
 
 /* Filename input menu */
@@ -185,12 +181,6 @@
   padding: 0;
 }
 
-.neuroglancer-screenshot-close-button {
-  margin-left: auto;
-  background-color: transparent;
-  border: 0;
-}
-
 /* Screenshot resolution table - voxel resolution, panel resolution */
 .neuroglancer-screenshot-size-text {
   margin: 0.75rem 0 0.75rem 0;
@@ -218,8 +208,8 @@
 }
 
 .neuroglancer-screenshot-resolution-preview-container {
-  border-top: 1px solid var(--gray50);
-  border-bottom: 1px solid var(--gray50);
+  border-top: 1px solid #ccc;
+  border-bottom: 1px solid #ccc;
   background: var(--gray500);
   width: 100%;
   padding: 1rem 1rem 0.5rem 1rem;
@@ -265,11 +255,17 @@
   outline: 0;
   border: 0;
   cursor: pointer;
-  height: 1rem;
   margin-left: auto;
   position: relative;
-  width: 33.33%;
   justify-content: flex-end;
+}
+
+.neuroglancer-screenshot-copy-icon:hover svg {
+  stroke: var(--gray600);
+}
+
+.neuroglancer-screenshot-copy-icon:hover {
+  background-color: var(--gray300);
 }
 
 .neuroglancer-screenshot-dimension {
@@ -320,41 +316,45 @@
 }
 
 /* Icons in the dialog */
-.neuroglancer-screenshot-dialog .neuroglancer-icon svg {
-  stroke: rgba(20, 20, 21, 0.4);
+.neuroglancer-screenshot-tooltip svg,
+.neuroglancer-screenshot-copy-icon svg {
+  stroke: var(--gray400);
   width: 1rem;
   height: 1rem;
 }
 
-.neuroglancer-screenshot-dialog .neuroglancer-icon {
-  width: 1rem;
-  height: 1rem;
-  min-width: inherit;
-  min-height: inherit;
+.neuroglancer-screenshot-tooltip {
   padding: 0;
+  width: 1rem;
+  height: 1rem;
+  min-height: inherit;
+  cursor: auto;
 }
 
-.neuroglancer-screenshot-dialog .neuroglancer-icon:hover {
+.neuroglancer-screenshot-tooltip:hover {
   background: none;
 }
 
+.neuroglancer-screenshot-tooltip:hover svg {
+  stroke: var(--gray600);
+}
+
 /* Footer with progress and buttons */
-.neuroglancer-screenshot-footer-container {
+.neuroglancer-screenshot-footer {
   margin: 0;
   display: flex;
   padding: 0.75rem 1rem;
-  border-top: 1px solid var(--gray50);
 }
 
 .neuroglancer-screenshot-progress-text {
   margin: 0;
   flex: 1;
   font-weight: 590;
-  cursor: pointer;
   padding: 0;
   font-size: 0.813rem;
   align-self: center;
   color: var(--primary700);
+  cursor: wait;
 }
 
 .neuroglancer-screenshot-footer-button {
@@ -366,6 +366,11 @@
   font-weight: 590;
   color: var(--gray800);
   margin: 0 0 0 0.25rem;
+  cursor: pointer;
+}
+
+.neuroglancer-screenshot-footer-button:hover {
+  color: var(--gray600);
 }
 
 .neuroglancer-screenshot-footer-button:disabled {

--- a/src/ui/screenshot_menu.ts
+++ b/src/ui/screenshot_menu.ts
@@ -17,10 +17,9 @@
  */
 
 import "#src/ui/screenshot_menu.css";
-import svg_close from "ikonate/icons/close.svg?raw";
 import svg_help from "ikonate/icons/help.svg?raw";
 import { throttle } from "lodash-es";
-import { Overlay } from "#src/overlay.js";
+import { FramedDialog } from "#src/overlay.js";
 import { StatusMessage } from "#src/status.js";
 import { setClipboard } from "#src/util/clipboard.js";
 import type {
@@ -242,10 +241,8 @@ function parseResolution<T extends ResolutionMetadata>(
  * For example, an x2 scale will cause the viewer in slice views to zoom in by a factor of 2
  * such that when the number of pixels in the slice view is doubled, the FOV remains the same.
  */
-export class ScreenshotDialog extends Overlay {
+export class ScreenshotDialog extends FramedDialog {
   private nameInput: HTMLInputElement;
-  private takeScreenshotButton: HTMLButtonElement;
-  private closeMenuButton: HTMLButtonElement;
   private cancelScreenshotButton: HTMLButtonElement;
   private forceScreenshotButton: HTMLButtonElement;
   private statisticsTable: HTMLTableElement;
@@ -255,7 +252,6 @@ export class ScreenshotDialog extends Overlay {
   private filenameInputContainer: HTMLDivElement;
   private screenshotSizeText: HTMLDivElement;
   private warningElement: HTMLDivElement;
-  private footerScreenshotActionBtnsContainer: HTMLDivElement;
   private progressText: HTMLParagraphElement;
   private scaleRadioButtonsContainer: HTMLDivElement;
   private keepSliceFOVFixedCheckbox: HTMLInputElement;
@@ -281,7 +277,14 @@ export class ScreenshotDialog extends Overlay {
   private screenshotHeight: number = 0;
   private screenshotPixelSize: HTMLElement;
   constructor(private screenshotManager: ScreenshotManager) {
-    super();
+    super(
+      "Screenshot" /* Header title */,
+      "Take screenshot" /* Primary button text */,
+      "neuroglancer-screenshot" /* Extra class prefix */,
+      () => {
+        this.screenshot();
+      } /* Primary button action */,
+    );
 
     this.initializeUI();
     this.setupEventListeners();
@@ -312,39 +315,30 @@ export class ScreenshotDialog extends Overlay {
   }
 
   private setupHelpTooltips() {
-    const generalSettingsTooltip = makeIcon({
-      svg: svg_help,
-      title: splitIntoLines(TOOLTIPS.generalSettingsTooltip),
-    });
-
-    const orthographicSettingsTooltip = makeIcon({
-      svg: svg_help,
-      title: TOOLTIPS.orthographicSettingsTooltip,
-    });
-    orthographicSettingsTooltip.classList.add(
-      "neuroglancer-screenshot-resolution-table-tooltip",
+    const makeTooltip = (title: string, inTable = false) => {
+      const tooltip = makeIcon({
+        svg: svg_help,
+        title: splitIntoLines(title),
+      });
+      tooltip.classList.add("neuroglancer-screenshot-tooltip");
+      if (inTable) {
+        tooltip.classList.add(
+          "neuroglancer-screenshot-resolution-table-tooltip",
+        );
+      }
+      return tooltip;
+    };
+    const generalSettingsTooltip = makeTooltip(TOOLTIPS.generalSettingsTooltip);
+    const orthographicSettingsTooltip = makeTooltip(
+      TOOLTIPS.orthographicSettingsTooltip,
+      true,
     );
-
-    const layerDataTooltip = makeIcon({
-      svg: svg_help,
-      title: splitIntoLines(TOOLTIPS.layerDataTooltip),
-    });
-    layerDataTooltip.classList.add(
-      "neuroglancer-screenshot-resolution-table-tooltip",
+    const layerDataTooltip = makeTooltip(TOOLTIPS.layerDataTooltip, true);
+    const scaleFactorHelpTooltip = makeTooltip(
+      TOOLTIPS.scaleFactorHelpTooltip,
+      true,
     );
-
-    const scaleFactorHelpTooltip = makeIcon({
-      svg: svg_help,
-      title: splitIntoLines(TOOLTIPS.scaleFactorHelpTooltip),
-    });
-
-    const panelScaleTooltip = makeIcon({
-      svg: svg_help,
-      title: splitIntoLines(TOOLTIPS.panelScaleTooltip),
-    });
-    panelScaleTooltip.classList.add(
-      "neuroglancer-screenshot-resolution-table-tooltip",
-    );
+    const panelScaleTooltip = makeTooltip(TOOLTIPS.panelScaleTooltip, true);
 
     return (this.helpTooltips = {
       generalSettingsTooltip,
@@ -363,27 +357,13 @@ export class ScreenshotDialog extends Overlay {
       parentElement.classList.add("neuroglancer-screenshot-overlay");
     }
 
-    const titleText = document.createElement("h2");
-    titleText.classList.add("neuroglancer-screenshot-title");
-    titleText.textContent = "Screenshot";
-
-    this.closeMenuButton = this.createButton(
-      null,
-      () => this.close(),
-      "neuroglancer-screenshot-close-button",
-      svg_close,
-    );
-
     this.cancelScreenshotButton = this.createButton(
       "Cancel screenshot",
       () => this.cancelScreenshot(),
       "neuroglancer-screenshot-footer-button",
     );
-    this.takeScreenshotButton = this.createButton(
-      "Take screenshot",
-      () => this.screenshot(),
-      "neuroglancer-screenshot-footer-button",
-    );
+    const takeScreenshotButton = this.primaryButton;
+    takeScreenshotButton.classList.add("neuroglancer-screenshot-footer-button");
     this.forceScreenshotButton = this.createButton(
       "Force screenshot",
       () => this.forceScreenshot(),
@@ -407,21 +387,8 @@ export class ScreenshotDialog extends Overlay {
     this.filenameInputContainer.appendChild(nameInputLabel);
     this.filenameInputContainer.appendChild(this.createNameInput());
 
-    const closeAndHelpContainer = document.createElement("div");
-    closeAndHelpContainer.classList.add("neuroglancer-screenshot-close");
-
-    closeAndHelpContainer.appendChild(titleText);
-    closeAndHelpContainer.appendChild(this.closeMenuButton);
-
-    // This is the header
-    this.content.appendChild(closeAndHelpContainer);
-
-    const mainBody = document.createElement("div");
-    mainBody.classList.add("neuroglancer-screenshot-main-body-container");
-    this.content.appendChild(mainBody);
-
-    mainBody.appendChild(this.filenameInputContainer);
-    mainBody.appendChild(this.createScaleRadioButtons());
+    this.body.appendChild(this.filenameInputContainer);
+    this.body.appendChild(this.createScaleRadioButtons());
 
     const previewContainer = document.createElement("div");
     previewContainer.classList.add(
@@ -477,26 +444,15 @@ export class ScreenshotDialog extends Overlay {
     settingsPreview.appendChild(this.createPanelResolutionTable());
     settingsPreview.appendChild(this.createLayerResolutionTable());
 
-    mainBody.appendChild(previewContainer);
-    mainBody.appendChild(this.createStatisticsTable());
+    this.body.appendChild(previewContainer);
+    this.body.appendChild(this.createStatisticsTable());
 
-    this.footerScreenshotActionBtnsContainer = document.createElement("div");
-    this.footerScreenshotActionBtnsContainer.classList.add(
-      "neuroglancer-screenshot-footer-container",
-    );
     this.progressText = document.createElement("p");
     this.progressText.classList.add("neuroglancer-screenshot-progress-text");
-    this.footerScreenshotActionBtnsContainer.appendChild(this.progressText);
-    this.footerScreenshotActionBtnsContainer.appendChild(
-      this.cancelScreenshotButton,
-    );
-    this.footerScreenshotActionBtnsContainer.appendChild(
-      this.takeScreenshotButton,
-    );
-    this.footerScreenshotActionBtnsContainer.appendChild(
-      this.forceScreenshotButton,
-    );
-    this.content.appendChild(this.footerScreenshotActionBtnsContainer);
+    this.footer.appendChild(this.progressText);
+    this.footer.appendChild(this.cancelScreenshotButton);
+    this.footer.appendChild(takeScreenshotButton);
+    this.footer.appendChild(this.forceScreenshotButton);
 
     this.screenshotManager.previewScreenshot();
     this.updateUIBasedOnMode();
@@ -932,7 +888,8 @@ export class ScreenshotDialog extends Overlay {
       this.keepSliceFOVFixedCheckbox.disabled = false;
       this.forceScreenshotButton.disabled = true;
       this.cancelScreenshotButton.disabled = true;
-      this.takeScreenshotButton.disabled = false;
+      const takeScreenshotButton = this.primaryButton;
+      takeScreenshotButton.disabled = false;
       this.progressText.textContent = "";
       this.forceScreenshotButton.title = "";
     } else {
@@ -945,7 +902,8 @@ export class ScreenshotDialog extends Overlay {
       this.keepSliceFOVFixedCheckbox.disabled = true;
       this.forceScreenshotButton.disabled = false;
       this.cancelScreenshotButton.disabled = false;
-      this.takeScreenshotButton.disabled = true;
+      const takeScreenshotButton = this.primaryButton;
+      takeScreenshotButton.disabled = true;
       this.progressText.textContent = "Screenshot in progress...";
       this.forceScreenshotButton.title =
         "Force a screenshot of the current view without waiting for all data to be loaded and rendered";


### PR DESCRIPTION
The main benefit of this is fixing some styling in the screenshot menu, especially around hover states and pointers. The screenshot menu in the UI previously used the generic overlay class, but since framed dialog was introduced we can use this instead and be more consistent. For example, old:

https://github.com/user-attachments/assets/36fe22cc-166d-451e-bc94-82885c0cdfaf

And new:

https://github.com/user-attachments/assets/25cf1ba5-8803-4f53-b702-d90e4bb198af

This is related to https://github.com/google/neuroglancer/pull/805 but is extracting a subset of that PR which is focused just around styling fixes and leveraging the `FramedDialog` for the screenshot menu to help with that.