### PR TITLE
refactor: move render scale histogram parameters: bin size, num bins, scale origin, to constructor

### DIFF
--- a/src/render_scale_statistics.ts
+++ b/src/render_scale_statistics.ts
@@ -26,15 +26,17 @@ export const renderScaleHistogramOrigin = -4;
 export function getRenderScaleHistogramOffset(
   renderScale: number,
   origin: number = renderScaleHistogramOrigin,
+  binSize: number = renderScaleHistogramBinSize,
 ): number {
-  return (Math.log2(renderScale) - origin) / renderScaleHistogramBinSize;
+  return (Math.log2(renderScale) - origin) / binSize;
 }
 
 export function getRenderScaleFromHistogramOffset(
   offset: number,
   origin: number = renderScaleHistogramOrigin,
+  binSize: number = renderScaleHistogramBinSize,
 ): number {
-  return 2 ** (offset * renderScaleHistogramBinSize + origin);
+  return 2 ** (offset * binSize + origin);
 }
 
 export function trackableRenderScaleTarget(
@@ -61,10 +63,13 @@ export function trackableRenderScaleTarget(
 export class RenderScaleHistogram {
   visibility = new VisibilityPriorityAggregator();
   changed = new NullarySignal();
-  logScaleOrigin: number;
 
-  constructor(origin: number = renderScaleHistogramOrigin) {
-    this.logScaleOrigin = origin;
+  constructor(
+    readonly logScaleOrigin: number = renderScaleHistogramOrigin,
+    readonly numBins: number = numRenderScaleHistogramBins,
+    readonly binSize: number = renderScaleHistogramBinSize,
+  ) {
+    this.value = new Uint32Array(numBins * this.numHistogramRows * 2);
   }
 
   /**
@@ -84,11 +89,9 @@ export class RenderScaleHistogram {
   numHistogramRows = 1;
 
   /**
-   * Initially allocate one row.
+   * Histogram value array, stores both present and not-present counts.
    */
-  value = new Uint32Array(
-    numRenderScaleHistogramBins * this.numHistogramRows * 2,
-  );
+  value: Uint32Array;
 
   /**
    * Number of chunks that are indication only (not present in the data).
@@ -130,25 +133,23 @@ export class RenderScaleHistogram {
     }
     if (spatialScaleIndex >= numHistogramRows) {
       this.numHistogramRows = numHistogramRows *= 2;
-      const newValue = new Uint32Array(
-        numHistogramRows * numRenderScaleHistogramBins * 2,
-      );
+      const newValue = new Uint32Array(numHistogramRows * this.numBins * 2);
       newValue.set(value);
       this.value = value = newValue;
     }
     const index =
-      spatialScaleIndex * numRenderScaleHistogramBins * 2 +
+      spatialScaleIndex * this.numBins * 2 +
       Math.min(
         Math.max(
           0,
           Math.round(
-            getRenderScaleHistogramOffset(renderScale, this.logScaleOrigin),
+            getRenderScaleHistogramOffset(renderScale, this.logScaleOrigin, this.binSize),
           ),
         ),
-        numRenderScaleHistogramBins - 1,
+        this.numBins - 1,
       );
     value[index] += presentCount;
-    value[index + numRenderScaleHistogramBins] += notPresentCount;
+    value[index + this.numBins] += notPresentCount;
     if (renderOnly) {
       this.fakeChunkCount = this.fakeChunkCount + notPresentCount;
     }

--- a/src/render_scale_statistics.ts
+++ b/src/render_scale_statistics.ts
@@ -143,7 +143,11 @@ export class RenderScaleHistogram {
         Math.max(
           0,
           Math.round(
-            getRenderScaleHistogramOffset(renderScale, this.logScaleOrigin, this.binSize),
+            getRenderScaleHistogramOffset(
+              renderScale,
+              this.logScaleOrigin,
+              this.binSize,
+            ),
           ),
         ),
         this.numBins - 1,

--- a/src/widget/render_scale_widget.ts
+++ b/src/widget/render_scale_widget.ts
@@ -22,9 +22,6 @@ import type { RenderScaleHistogram } from "#src/render_scale_statistics.js";
 import {
   getRenderScaleFromHistogramOffset,
   getRenderScaleHistogramOffset,
-  numRenderScaleHistogramBins,
-  renderScaleHistogramBinSize,
-  renderScaleHistogramOrigin,
 } from "#src/render_scale_statistics.js";
 import type { TrackableValueInterface } from "#src/trackable_value.js";
 import { WatchableValue } from "#src/trackable_value.js";
@@ -73,7 +70,6 @@ export class RenderScaleWidget extends RefCounted {
   legendRenderScale = document.createElement("div");
   legendSpatialScale = document.createElement("div");
   legendChunks = document.createElement("div");
-  protected logScaleOrigin = renderScaleHistogramOrigin;
   protected unitOfTarget = "px";
   private ctx = this.canvas.getContext("2d")!;
   hoverTarget = new WatchableValue<[number, number] | undefined>(undefined);
@@ -94,11 +90,11 @@ export class RenderScaleWidget extends RefCounted {
     }
     this.hoverTarget.value = undefined;
     const logScaleMax = Math.round(
-      this.logScaleOrigin +
-        numRenderScaleHistogramBins * renderScaleHistogramBinSize,
+      this.histogram.logScaleOrigin +
+        this.histogram.numBins * this.histogram.binSize,
     );
     const targetValue = clampToInterval(
-      [2 ** this.logScaleOrigin, 2 ** (logScaleMax - 1)],
+      [2 ** this.histogram.logScaleOrigin, 2 ** (logScaleMax - 1)],
       this.target.value * 2 ** Math.sign(deltaY),
     ) as number;
     this.target.value = targetValue;
@@ -143,9 +139,8 @@ export class RenderScaleWidget extends RefCounted {
     );
 
     const getTargetValue = (event: MouseEvent) => {
-      const position =
-        (event.offsetX / canvas.width) * numRenderScaleHistogramBins;
-      return getRenderScaleFromHistogramOffset(position, this.logScaleOrigin);
+      const position = (event.offsetX / canvas.width) * this.histogram.numBins;
+      return getRenderScaleFromHistogramOffset(position, this.histogram.logScaleOrigin, this.histogram.binSize);
     };
     this.registerEventListener(canvas, "pointermove", (event: MouseEvent) => {
       this.hoverTarget.value = [getTargetValue(event), event.offsetY];
@@ -207,8 +202,10 @@ export class RenderScaleWidget extends RefCounted {
       legendRenderScale.textContent = valueString + " " + this.unitOfTarget;
     }
 
+    const { numBins } = this.histogram;
+
     function binToCanvasX(bin: number) {
-      return (bin * width) / numRenderScaleHistogramBins;
+      return (bin * width) / numBins;
     }
 
     ctx.clearRect(0, 0, width, height);
@@ -230,13 +227,12 @@ export class RenderScaleWidget extends RefCounted {
     const numRows = spatialScales.size;
     let totalPresent = 0;
     let totalNotPresent = 0;
-    for (let bin = 0; bin < numRenderScaleHistogramBins; ++bin) {
+    for (let bin = 0; bin < numBins; ++bin) {
       let count = 0;
       for (let row = 0; row < numRows; ++row) {
-        const index = row * numRenderScaleHistogramBins * 2 + bin;
+        const index = row * numBins * 2 + bin;
         const presentCount = histogramData[index];
-        const notPresentCount =
-          histogramData[index + numRenderScaleHistogramBins];
+        const notPresentCount = histogramData[index + numBins];
         totalPresent += presentCount;
         totalNotPresent += notPresentCount;
         count += presentCount + notPresentCount;
@@ -256,9 +252,9 @@ export class RenderScaleWidget extends RefCounted {
     let hoverSpatialScale: number | undefined = undefined;
     if (hoverValue !== undefined) {
       const i = Math.floor(
-        getRenderScaleHistogramOffset(hoverValue[0], this.logScaleOrigin),
+        getRenderScaleHistogramOffset(hoverValue[0], this.histogram.logScaleOrigin, this.histogram.binSize),
       );
-      if (i >= 0 && i < numRenderScaleHistogramBins) {
+      if (i >= 0 && i < numBins) {
         let sum = 0;
         const hoverY = hoverValue[1];
         for (
@@ -268,10 +264,8 @@ export class RenderScaleWidget extends RefCounted {
         ) {
           const spatialScale = sortedSpatialScales[spatialScaleIndex];
           const row = spatialScales.get(spatialScale)!;
-          const index = 2 * row * numRenderScaleHistogramBins + i;
-          const count =
-            histogramData[index] +
-            histogramData[index + numRenderScaleHistogramBins];
+          const index = 2 * row * numBins + i;
+          const count = histogramData[index] + histogramData[index + numBins];
           if (count === 0) continue;
           const yStart = Math.round(countToCanvasY(sum));
           sum += count;
@@ -287,11 +281,11 @@ export class RenderScaleWidget extends RefCounted {
       totalPresent = 0;
       totalNotPresent = 0;
       const row = spatialScales.get(hoverSpatialScale)!;
-      const baseIndex = 2 * row * numRenderScaleHistogramBins;
-      for (let bin = 0; bin < numRenderScaleHistogramBins; ++bin) {
+      const baseIndex = 2 * row * numBins;
+      for (let bin = 0; bin < numBins; ++bin) {
         const index = baseIndex + bin;
         totalPresent += histogramData[index];
-        totalNotPresent += histogramData[index + numRenderScaleHistogramBins];
+        totalNotPresent += histogramData[index + numBins];
       }
       if (Number.isFinite(hoverSpatialScale)) {
         this.legendSpatialScale.textContent = formatScaleWithUnitAsString(
@@ -325,7 +319,7 @@ export class RenderScaleWidget extends RefCounted {
       return [presentColor, notPresentColor];
     });
 
-    for (let i = 0; i < numRenderScaleHistogramBins; ++i) {
+    for (let i = 0; i < numBins; ++i) {
       let sum = 0;
       for (
         let spatialScaleIndex = numRows - 1;
@@ -334,10 +328,9 @@ export class RenderScaleWidget extends RefCounted {
       ) {
         const spatialScale = sortedSpatialScales[spatialScaleIndex];
         const row = spatialScales.get(spatialScale)!;
-        const index = row * numRenderScaleHistogramBins * 2 + i;
+        const index = row * numBins * 2 + i;
         const presentCount = histogramData[index];
-        const notPresentCount =
-          histogramData[index + numRenderScaleHistogramBins];
+        const notPresentCount = histogramData[index + numBins];
         const count = presentCount + notPresentCount;
         if (count === 0) continue;
         const xStart = Math.round(binToCanvasX(i));
@@ -357,7 +350,7 @@ export class RenderScaleWidget extends RefCounted {
       const value = targetValue;
       ctx.fillStyle = "#fff";
       const startOffset = binToCanvasX(
-        getRenderScaleHistogramOffset(value, this.logScaleOrigin),
+        getRenderScaleHistogramOffset(value, this.histogram.logScaleOrigin, this.histogram.binSize),
       );
       const lineWidth = 1;
       ctx.fillRect(Math.floor(startOffset), 0, lineWidth, height);
@@ -367,7 +360,7 @@ export class RenderScaleWidget extends RefCounted {
       const value = hoverValue[0];
       ctx.fillStyle = "#888";
       const startOffset = binToCanvasX(
-        getRenderScaleHistogramOffset(value, this.logScaleOrigin),
+        getRenderScaleHistogramOffset(value, this.histogram.logScaleOrigin, this.histogram.binSize),
       );
       const lineWidth = 1;
       ctx.fillRect(Math.floor(startOffset), 0, lineWidth, height);
@@ -377,7 +370,6 @@ export class RenderScaleWidget extends RefCounted {
 
 export class VolumeRenderingRenderScaleWidget extends RenderScaleWidget {
   protected unitOfTarget = "samples";
-  protected logScaleOrigin = 1;
 
   getWheelMoveValue(event: WheelEvent) {
     return -event.deltaY;

--- a/src/widget/render_scale_widget.ts
+++ b/src/widget/render_scale_widget.ts
@@ -140,7 +140,11 @@ export class RenderScaleWidget extends RefCounted {
 
     const getTargetValue = (event: MouseEvent) => {
       const position = (event.offsetX / canvas.width) * this.histogram.numBins;
-      return getRenderScaleFromHistogramOffset(position, this.histogram.logScaleOrigin, this.histogram.binSize);
+      return getRenderScaleFromHistogramOffset(
+        position,
+        this.histogram.logScaleOrigin,
+        this.histogram.binSize,
+      );
     };
     this.registerEventListener(canvas, "pointermove", (event: MouseEvent) => {
       this.hoverTarget.value = [getTargetValue(event), event.offsetY];
@@ -252,7 +256,11 @@ export class RenderScaleWidget extends RefCounted {
     let hoverSpatialScale: number | undefined = undefined;
     if (hoverValue !== undefined) {
       const i = Math.floor(
-        getRenderScaleHistogramOffset(hoverValue[0], this.histogram.logScaleOrigin, this.histogram.binSize),
+        getRenderScaleHistogramOffset(
+          hoverValue[0],
+          this.histogram.logScaleOrigin,
+          this.histogram.binSize,
+        ),
       );
       if (i >= 0 && i < numBins) {
         let sum = 0;
@@ -350,7 +358,11 @@ export class RenderScaleWidget extends RefCounted {
       const value = targetValue;
       ctx.fillStyle = "#fff";
       const startOffset = binToCanvasX(
-        getRenderScaleHistogramOffset(value, this.histogram.logScaleOrigin, this.histogram.binSize),
+        getRenderScaleHistogramOffset(
+          value,
+          this.histogram.logScaleOrigin,
+          this.histogram.binSize,
+        ),
       );
       const lineWidth = 1;
       ctx.fillRect(Math.floor(startOffset), 0, lineWidth, height);
@@ -360,7 +372,11 @@ export class RenderScaleWidget extends RefCounted {
       const value = hoverValue[0];
       ctx.fillStyle = "#888";
       const startOffset = binToCanvasX(
-        getRenderScaleHistogramOffset(value, this.histogram.logScaleOrigin, this.histogram.binSize),
+        getRenderScaleHistogramOffset(
+          value,
+          this.histogram.logScaleOrigin,
+          this.histogram.binSize,
+        ),
       );
       const lineWidth = 1;
       ctx.fillRect(Math.floor(startOffset), 0, lineWidth, height);


### PR DESCRIPTION
Previously these were all fixed constants. Then when volume rendering was introduced we made the origin be a constructor param to the render scale widget and the histogram stats. Here, we propose to make the bin size, number of bins and the scale origin all parts of the render scale histogram, and then have the render scale widget directly use all of these public attrs of the render scale histogram.

The intent here is to functionally change nothing. But it would allow the volume rendering origin change previously made to be cleaner. And in the future we are considering to propose a different cap on the number of volume rendering samples, and use these in #991 at which point these parameters will be adjusted for that purpose.