### PR TITLE
fix typo in url

### DIFF
--- a/src/ui/annotations.ts
+++ b/src/ui/annotations.ts
@@ -510,7 +510,7 @@ export class AnnotationLayerView extends Tab {
       title:
         "The left icons allow you to select the type of the annotation. Color and other display settings are available in the 'Rendering' tab. Click for documentation.",
       svg: svg_help,
-      href: "https://neuroglancer-docs.web.app/user-guide/annotation.html",
+      href: "https://neuroglancer-docs.web.app/user-guide/annotations.html",
     });
     helpIcon.style.marginLeft = "auto";
     mutableControls.appendChild(helpIcon);


### PR DESCRIPTION
I made a mistake in linking to the new documentation, the page was plural.