### PR TITLE
chore: updating firebase deploy action to node 24.0 version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -154,7 +154,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - uses: ./.github/actions/setup-firefox
       - name: Setup tmate session
-        uses: mxschmitt/action-tmate@c0afd6f790e3a5564914980036ebf83216678101 # v3.23
+        uses: mxschmitt/action-tmate@35b54afac29c97fb54faba5b513f8fbd1882f113 # v3.24
         if: ${{ github.event_name == 'workflow_dispatch' && inputs.debug_enabled }}
       - run: uvx nox -s lint format mypy
       - name: Check for dirty working directory

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -154,7 +154,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - uses: ./.github/actions/setup-firefox
       - name: Setup tmate session
-        uses: mxschmitt/action-tmate@35b54afac29c97fb54faba5b513f8fbd1882f113 # v3.24
+        uses: mxschmitt/action-tmate@c0afd6f790e3a5564914980036ebf83216678101 # v3.23
         if: ${{ github.event_name == 'workflow_dispatch' && inputs.debug_enabled }}
       - run: uvx nox -s lint format mypy
       - name: Check for dirty working directory
@@ -300,7 +300,7 @@ jobs:
           name: python-client-static
           path: python/neuroglancer/static/client
       - name: Publish client to Firebase hosting
-        uses: FirebaseExtended/action-hosting-deploy@e2eda2e106cfa35cdbcf4ac9ddaf6c4756df2c8c # v0.10.0
+        uses: FirebaseExtended/action-hosting-deploy@500ac625ca2dd40cbd15f7659af953801858032a # v0.11.0
         with:
           firebaseServiceAccount: "${{ secrets.FIREBASE_HOSTING_SERVICE_ACCOUNT_KEY }}"
           projectId: neuroglancer-demo
@@ -311,7 +311,7 @@ jobs:
           name: docs
           path: dist/docs
       - name: Publish docs to Firebase hosting
-        uses: FirebaseExtended/action-hosting-deploy@e2eda2e106cfa35cdbcf4ac9ddaf6c4756df2c8c # v0.10.0
+        uses: FirebaseExtended/action-hosting-deploy@500ac625ca2dd40cbd15f7659af953801858032a # v0.11.0
         with:
           firebaseServiceAccount: "${{ secrets.FIREBASE_HOSTING_SERVICE_ACCOUNT_KEY }}"
           projectId: neuroglancer-demo

--- a/.github/workflows/deploy_docs_preview.yml
+++ b/.github/workflows/deploy_docs_preview.yml
@@ -45,7 +45,7 @@ jobs:
           echo "pr-id=${PR_ID}" >> $GITHUB_OUTPUT
         env:
           GH_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
-      - uses: FirebaseExtended/action-hosting-deploy@e2eda2e106cfa35cdbcf4ac9ddaf6c4756df2c8c # v0.10.0
+      - uses: FirebaseExtended/action-hosting-deploy@500ac625ca2dd40cbd15f7659af953801858032a # v0.11.0
         id: deploy
         with:
           repoToken: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/deploy_preview.yml
+++ b/.github/workflows/deploy_preview.yml
@@ -45,7 +45,7 @@ jobs:
           echo "pr-id=${PR_ID}" >> $GITHUB_OUTPUT
         env:
           GH_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
-      - uses: FirebaseExtended/action-hosting-deploy@e2eda2e106cfa35cdbcf4ac9ddaf6c4756df2c8c # v0.10.0
+      - uses: FirebaseExtended/action-hosting-deploy@500ac625ca2dd40cbd15f7659af953801858032a # v0.11.0
         id: deploy
         with:
           repoToken: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
This addresses removing the second Node 20 dependency (toward addressing #1047) from github actions by utilizing the newly released 0.11.0 (see https://github.com/FirebaseExtended/action-hosting-deploy/issues/457) and release (https://github.com/FirebaseExtended/action-hosting-deploy/releases/tag/v0.11.0). 