### PR TITLE
fix(github/deploy): pin node to 24.18.0 to pull in node-fetch fix used by firebase deployment

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -291,6 +291,9 @@ jobs:
       - "docs"
     steps:
       - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "24.18.0"
       - uses: actions/download-artifact@v8
         with:
           name: client

--- a/.github/workflows/deploy_docs_preview.yml
+++ b/.github/workflows/deploy_docs_preview.yml
@@ -31,6 +31,9 @@ jobs:
                 target_url: `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
             });
       - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "24.18.0"
       - uses: actions/download-artifact@v8
         with:
           name: docs

--- a/.github/workflows/deploy_preview.yml
+++ b/.github/workflows/deploy_preview.yml
@@ -31,6 +31,9 @@ jobs:
                 target_url: `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
             });
       - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "24.18.0"
       - uses: actions/download-artifact@v8
         with:
           name: client


### PR DESCRIPTION
https://redirect.github.com/firebase/firebase-tools/issues/10716#issuecomment-4799324669