### PR TITLE
feat: make the tool status be the bottom element with new messages at top

### DIFF
--- a/src/status.ts
+++ b/src/status.ts
@@ -77,14 +77,14 @@ export class StatusMessage {
       event.preventDefault();
     }
   };
-  constructor(delay: Delay = false, modal = false) {
+  constructor(delay: Delay = false, modal = false, insertAtBottom = false) {
     const element = document.createElement("li");
     this.element = element;
     element.addEventListener("mousedown", this.handleMouseDown);
     if (delay === true) {
       delay = DEFAULT_STATUS_DELAY;
     }
-    this.setModal(modal);
+    this.setModal(modal, insertAtBottom);
     if (delay !== false) {
       this.setVisible(false);
       this.timer = window.setTimeout(this.setVisible.bind(this, true), delay);
@@ -124,7 +124,16 @@ export class StatusMessage {
   setPreventFocusChangeOnMouseDown(value: boolean) {
     this.preventFocusChangeOnMouseDown = value;
   }
-  setModal(value: boolean) {
+  setModal(value: boolean, insertAtBottom: boolean = false) {
+    const insertIntoStatusContainer = () => {
+      const container = getStatusContainer();
+      if (insertAtBottom) {
+        container.appendChild(this.element);
+      } else {
+        container.prepend(this.element);
+      }
+    };
+
     if (value) {
       if (this.modalElementWrapper === undefined) {
         const modalElementWrapper = document.createElement("div");
@@ -146,9 +155,9 @@ export class StatusMessage {
       if (this.modalElementWrapper !== undefined) {
         modalStatusContainer!.removeChild(this.modalElementWrapper);
         this.modalElementWrapper = undefined;
-        getStatusContainer().appendChild(this.element);
+        insertIntoStatusContainer();
       } else if (this.element.parentElement === null) {
-        getStatusContainer().appendChild(this.element);
+        insertIntoStatusContainer();
       }
     }
   }

--- a/src/ui/tool.ts
+++ b/src/ui/tool.ts
@@ -810,7 +810,13 @@ export function makeToolButton(
 }
 
 export function makeToolActivationStatusMessage(activation: ToolActivation) {
-  const message = activation.registerDisposer(new StatusMessage(false));
+  const message = activation.registerDisposer(
+    new StatusMessage(
+      /*delay=*/ false,
+      /*modal=*/ false,
+      /*insertAtBottom=*/ true,
+    ),
+  );
   message.element.classList.add("neuroglancer-tool-status");
   const content = document.createElement("div");
   content.classList.add("neuroglancer-tool-status-content");


### PR DESCRIPTION
In #991 we use a tool which is on the screen very commonly, and the status message system to inform about edits made. The kind of thing like - if a merge is performed correctly, or if the merge fails, or if you have the wrong permissions to move a node.

When this happens the tool message visually shifts around because the status messages are getting appended to the bottom of the list. This PR aims to change this behaviour, so tools are always appended at the bottom of the element list, and messages instead get prepended and put as the first element in the list.

So while you could previously get this where the tools are in between messages, or the message shows below the tool and moves the tool up visually
<img width="1862" height="136" alt="image" src="https://github.com/user-attachments/assets/fdd43d94-37cd-457e-aae1-0de3ac42a926" />

Now you always get it like:
<img width="1868" height="123" alt="image" src="https://github.com/user-attachments/assets/ad11e73d-0672-433f-9d89-f5369bdd4cb9" />
with the tool fixed at the bottom and messages above.

I'm making this PR as a general one because I think it could be helpful for review purposes of #991 if these kind of general changes are not baked inside that PR and can be more easily discussed in smaller pieces where possible. And because if other tools are ever using the same system, it could be helpful.