### PR TITLE
fix: single layer multi-channel setup uses omero color

### DIFF
--- a/src/layer/multi_channel_setup.ts
+++ b/src/layer/multi_channel_setup.ts
@@ -212,9 +212,9 @@ function setupLayerPostCreation(
   const shaderControlValue = shaderControlState.value;
 
   const determineColor = (): Float32Array | undefined => {
-    if (totalLocalChannels === 1) return new Float32Array([1, 1, 1]);
     if (channel?.color !== undefined && !ignoreInputMetadata)
       return channel.color;
+    if (totalLocalChannels === 1) return new Float32Array([1, 1, 1]);
     return DEFAULT_ARRAY_COLORS.get(channelIndex % DEFAULT_ARRAY_COLORS.size);
   };
 


### PR DESCRIPTION
This changes the color precedence to be omero channel color, then white if only one channel, then default color array (loops through RGBW). Previously it was mistakenly choosing white if only one channel over the color in the metadata.

Should address https://github.com/google/neuroglancer/issues/1075