### PR TITLE
perf(volume_rendering): faster volume rendering depth check in fragment shader

### DIFF
--- a/python/tests/volume_rendering_test.py
+++ b/python/tests/volume_rendering_test.py
@@ -20,7 +20,7 @@ import numpy as np
 import pytest
 
 
-def _setup_viewer_with_volume_and_mesh(webdriver, orthographic):
+def _setup_viewer_with_volume_and_mesh(webdriver, orthographic, mesh_opacity=1.0):
     shape = (20, 20, 20)
 
     # Image data in the far half of the volume (high z = far from default camera,
@@ -60,6 +60,7 @@ void main() {
                 segments=[1],
                 segment_default_color="#ff0000",
                 hover_highlight=False,
+                object_alpha=mesh_opacity,
             ),
         )
         s.layout = "3d"
@@ -115,7 +116,9 @@ def test_volume_rendering_picking_does_not_occlude_mesh(webdriver, orthographic)
     depth (≈ 0) to the picking buffer, making it appear closer than any real geometry
     and stealing pick buffer entries from meshes that were geometrically in front of it.
     """
-    _setup_viewer_with_volume_and_mesh(webdriver, orthographic=orthographic)
+    _setup_viewer_with_volume_and_mesh(
+        webdriver, orthographic=orthographic, mesh_opacity=0.5
+    )
 
     # threading.Event is required because the pick callback fires on a background
     # thread (browser → Python action dispatch), not on the test's main thread.

--- a/python/tests/volume_rendering_test.py
+++ b/python/tests/volume_rendering_test.py
@@ -26,7 +26,7 @@ def _setup_viewer_with_volume_and_mesh(webdriver, orthographic):
     # Image data in the far half of the volume (high z = far from default camera,
     # which looks in the +z direction so low z is nearest).
     image_data = np.zeros(shape, dtype=np.uint8)
-    image_data[1:19, 1:19, 11:20] = 200
+    image_data[1:19, 1:19, 11:20] = 255
 
     # Segmentation cube in the near half (low z = close to default camera).
     # The cube must not touch any array boundary so that marching cubes generates
@@ -44,8 +44,13 @@ def _setup_viewer_with_volume_and_mesh(webdriver, orthographic):
                 source=neuroglancer.LocalVolume(
                     data=image_data, dimensions=s.dimensions
                 ),
-                volume_rendering_mode="On",
-                volume_rendering_gain=10.0,
+                volume_rendering_mode="Max",
+                shader="""
+#uicontrol invlerp normalized
+void main() {
+    emitRGBA(vec4(0.0, 0.0, normalized(), 1.0));
+}
+                """,
             ),
         )
         s.layers.append(
@@ -65,21 +70,25 @@ def _setup_viewer_with_volume_and_mesh(webdriver, orthographic):
 
 
 @pytest.mark.parametrize("orthographic", [False, True])
-def test_opaque_mesh_occludes_volume_rendering(webdriver, orthographic):
+def test_volume_rendering_occlusion(webdriver, orthographic):
     """Test that an opaque mesh occludes a volume rendered from an image volume.
 
     Specifically, this aims to check the harder case where the mesh sits
     inside a single image chunk, as opposed to fully being in front of the chunk.
     """
-    _setup_viewer_with_volume_and_mesh(webdriver, orthographic=True)
+    _setup_viewer_with_volume_and_mesh(webdriver, orthographic=orthographic)
 
     # The mesh should occlude the volume with default camera
     webdriver.sync()
     screenshot = webdriver.viewer.screenshot(size=[10, 10]).screenshot
-    np.testing.assert_array_equal(
-        screenshot.image_pixels,
-        np.tile(np.array([255, 0, 0, 255], dtype=np.uint8), (10, 10, 1)),
-    )
+    pixels = screenshot.image_pixels
+    # Lighting causes each color channel to vary slightly instead of saturating
+    # at 255, so check bounds rather than exact equality.
+    # Mesh is red, so the only non-zero colors should be in the red channel.
+    np.testing.assert_array_equal(pixels[..., 1], 0)
+    np.testing.assert_array_equal(pixels[..., 2], 0)
+    np.testing.assert_array_equal(pixels[..., 3], 255)
+    assert np.all(pixels[..., 0] >= 230)
 
     # On flipping the camera, a full opacity volume rendering occludes the mesh
     with webdriver.viewer.txn() as s:
@@ -89,11 +98,12 @@ def test_opaque_mesh_occludes_volume_rendering(webdriver, orthographic):
     screenshot = webdriver.viewer.screenshot(size=[10, 10]).screenshot
     np.testing.assert_array_equal(
         screenshot.image_pixels,
-        np.tile(np.array([255, 255, 255, 255], dtype=np.uint8), (10, 10, 1)),
+        np.tile(np.array([0, 0, 255, 255], dtype=np.uint8), (10, 10, 1)),
     )
 
 
-def test_volume_rendering_picking_does_not_occlude_mesh(webdriver):
+@pytest.mark.parametrize("orthographic", [False, True])
+def test_volume_rendering_picking_does_not_occlude_mesh(webdriver, orthographic):
     """Volume rendering must not steal pick buffer entries from a transparent entry in front of it.
 
     Scene: a transparent segmentation mesh occupies the near half of the volume (low z,
@@ -105,7 +115,7 @@ def test_volume_rendering_picking_does_not_occlude_mesh(webdriver):
     depth (≈ 0) to the picking buffer, making it appear closer than any real geometry
     and stealing pick buffer entries from meshes that were geometrically in front of it.
     """
-    _setup_viewer_with_volume_and_mesh(webdriver, orthographic=False)
+    _setup_viewer_with_volume_and_mesh(webdriver, orthographic=orthographic)
 
     # threading.Event is required because the pick callback fires on a background
     # thread (browser → Python action dispatch), not on the test's main thread.

--- a/python/tests/volume_rendering_test.py
+++ b/python/tests/volume_rendering_test.py
@@ -166,7 +166,7 @@ def test_volume_rendering_picking_does_not_occlude_mesh(webdriver, orthographic)
     assert action_state is not None
 
     image_pick = action_state.selected_values.get("image")
-    assert image_pick is not None, (
-        "Image volume was not picked when it is in front of the mesh"
-    )
+    assert (
+        image_pick is not None
+    ), "Image volume was not picked when it is in front of the mesh"
     # We don't assert the value because currently volume rendering reports 0

--- a/python/tests/volume_rendering_test.py
+++ b/python/tests/volume_rendering_test.py
@@ -11,12 +11,86 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Test volume rendering picking."""
+"""Test volume rendering picking and rendering."""
 
 import threading
 
 import neuroglancer
 import numpy as np
+import pytest
+
+
+def _setup_viewer_with_volume_and_mesh(webdriver, orthographic):
+    shape = (20, 20, 20)
+
+    # Image data in the far half of the volume (high z = far from default camera,
+    # which looks in the +z direction so low z is nearest).
+    image_data = np.zeros(shape, dtype=np.uint8)
+    image_data[1:19, 1:19, 11:20] = 200
+
+    # Segmentation cube in the near half (low z = close to default camera).
+    # The cube must not touch any array boundary so that marching cubes generates
+    # a fully closed mesh rather than an open plane.
+    seg_data = np.zeros(shape, dtype=np.uint64)
+    seg_data[1:19, 1:19, 1:9] = 1
+
+    with webdriver.viewer.txn() as s:
+        s.dimensions = neuroglancer.CoordinateSpace(
+            names=["x", "y", "z"], units="nm", scales=[1, 1, 1]
+        )
+        s.layers.append(
+            name="image",
+            layer=neuroglancer.ImageLayer(
+                source=neuroglancer.LocalVolume(
+                    data=image_data, dimensions=s.dimensions
+                ),
+                volume_rendering_mode="On",
+                volume_rendering_gain=10.0,
+            ),
+        )
+        s.layers.append(
+            name="seg",
+            layer=neuroglancer.SegmentationLayer(
+                source=neuroglancer.LocalVolume(data=seg_data, dimensions=s.dimensions),
+                segments=[1],
+                segment_default_color="#ff0000",
+                hover_highlight=False,
+            ),
+        )
+        s.layout = "3d"
+        s.layout.orthographic_projection = orthographic
+        s.show_axis_lines = False
+        s.position = [10, 10, 10]
+        s.projection_scale = 15
+
+
+@pytest.mark.parametrize("orthographic", [False, True])
+def test_opaque_mesh_occludes_volume_rendering(webdriver, orthographic):
+    """Test that an opaque mesh occludes a volume rendered from an image volume.
+
+    Specifically, this aims to check the harder case where the mesh sits
+    inside a single image chunk, as opposed to fully being in front of the chunk.
+    """
+    _setup_viewer_with_volume_and_mesh(webdriver, orthographic=True)
+
+    # The mesh should occlude the volume with default camera
+    webdriver.sync()
+    screenshot = webdriver.viewer.screenshot(size=[10, 10]).screenshot
+    np.testing.assert_array_equal(
+        screenshot.image_pixels,
+        np.tile(np.array([255, 0, 0, 255], dtype=np.uint8), (10, 10, 1)),
+    )
+
+    # On flipping the camera, a full opacity volume rendering occludes the mesh
+    with webdriver.viewer.txn() as s:
+        s.projection_orientation = [0, 1, 0, 0]
+
+    webdriver.sync()
+    screenshot = webdriver.viewer.screenshot(size=[10, 10]).screenshot
+    np.testing.assert_array_equal(
+        screenshot.image_pixels,
+        np.tile(np.array([255, 255, 255, 255], dtype=np.uint8), (10, 10, 1)),
+    )
 
 
 def test_volume_rendering_picking_does_not_occlude_mesh(webdriver):
@@ -31,44 +105,7 @@ def test_volume_rendering_picking_does_not_occlude_mesh(webdriver):
     depth (≈ 0) to the picking buffer, making it appear closer than any real geometry
     and stealing pick buffer entries from meshes that were geometrically in front of it.
     """
-    shape = (20, 20, 20)
-
-    # Image data in the far half of the volume (high z = far from default camera,
-    # which looks in the +z direction so low z is nearest).
-    image_data = np.zeros(shape, dtype=np.uint8)
-    image_data[:, :, 10:20] = 200
-
-    # Segmentation cube in the near half (low z = close to default camera).
-    # The cube must not touch any array boundary so that marching cubes generates
-    # a fully closed mesh rather than an open plane.
-    seg_data = np.zeros(shape, dtype=np.uint64)
-    seg_data[2:18, 2:18, 2:9] = 1
-
-    with webdriver.viewer.txn() as s:
-        s.dimensions = neuroglancer.CoordinateSpace(
-            names=["x", "y", "z"], units="nm", scales=[1, 1, 1]
-        )
-        s.layers.append(
-            name="image",
-            layer=neuroglancer.ImageLayer(
-                source=neuroglancer.LocalVolume(
-                    data=image_data, dimensions=s.dimensions
-                ),
-                volume_rendering_mode="On",
-            ),
-        )
-        s.layers.append(
-            name="seg",
-            layer=neuroglancer.SegmentationLayer(
-                source=neuroglancer.LocalVolume(data=seg_data, dimensions=s.dimensions),
-                segments=[1],
-                object_alpha=0.5,
-            ),
-        )
-        s.layout = "3d"
-        s.show_axis_lines = False
-        s.position = [10, 10, 10]
-        s.projection_scale = 30
+    _setup_viewer_with_volume_and_mesh(webdriver, orthographic=False)
 
     # threading.Event is required because the pick callback fires on a background
     # thread (browser → Python action dispatch), not on the test's main thread.
@@ -116,7 +153,7 @@ def test_volume_rendering_picking_does_not_occlude_mesh(webdriver):
     assert action_state is not None
 
     image_pick = action_state.selected_values.get("image")
-    assert (
-        image_pick is not None
-    ), "Image volume was not picked when it is in front of the mesh"
+    assert image_pick is not None, (
+        "Image volume was not picked when it is in front of the mesh"
+    )
     # We don't assert the value because currently volume rendering reports 0

--- a/src/volume_rendering/volume_render_layer.ts
+++ b/src/volume_rendering/volume_render_layer.ts
@@ -454,10 +454,6 @@ float computeDepthFromClipSpace(vec4 clipSpacePosition) {
   float NDCDepthCoord = clipSpacePosition.z / clipSpacePosition.w;
   return (NDCDepthCoord + 1.0) * 0.5;
 }
-vec2 computeUVFromClipSpace(vec4 clipSpacePosition) {
-  vec2 NDCPosition = clipSpacePosition.xy / clipSpacePosition.w;
-  return (NDCPosition + 1.0) * 0.5;
-}
 `,
           ]);
           builder.setFragmentMainFunction(`
@@ -498,16 +494,22 @@ void main() {
   int endStep = min(uMaxSteps, int(floor((intersectEnd - uNearLimitFraction) / stepSize)) + 1);
   outputColor = vec4(0, 0, 0, 0);
   revealage = 1.0;
+  vec4 clipNearPoint = uModelViewProjectionMatrix * vec4(nearPoint, 1.0);
+  vec4 clipFarPoint = uModelViewProjectionMatrix * vec4(farPoint, 1.0);
+  float depthInBuffer = texture(uDepthSampler, (normalizedPosition + 1.0) * 0.5).r;
   for (int rayStep = startStep; rayStep < endStep; ++rayStep) {
-    vec3 position = mix(nearPoint, farPoint, uNearLimitFraction + float(rayStep) * stepSize);
-    vec4 clipSpacePosition = uModelViewProjectionMatrix * vec4(position, 1.0);
+    // linearly interpolate position and clip space position along the ray
+    float rayFraction = uNearLimitFraction + float(rayStep) * stepSize;
+    vec3 position = mix(nearPoint, farPoint, rayFraction);
+    vec4 clipSpacePosition = mix(clipNearPoint, clipFarPoint, rayFraction);
+
+    // compute depth at the ray position and check if it is behind an opaque object
     depthAtRayPosition = computeDepthFromClipSpace(clipSpacePosition);
-    vec2 uv = computeUVFromClipSpace(clipSpacePosition);
-    float depthInBuffer = texture(uDepthSampler, uv).r;
     bool rayPositionBehindOpaqueObject = (1.0 - depthAtRayPosition) < depthInBuffer;
     if (rayPositionBehindOpaqueObject) {
       break;
     }
+
     curChunkPosition = position - uTranslation;
     userMain();
     ${glsl_handleMaxProjectionUpdate}


### PR DESCRIPTION
### Summary
Improves fragment shader performance of depth testing in volume rendering, adds a new test for volume rendering occlusion, and updates an existing volume rendering test to check both perspective and orthographic projections.

### Motivation
During volume rendering, we currently compute the depth along the ray at each ray march step in the fragment shader. This computed depth is compared to the depth value in the depth buffer, to see if the ray has passed behind an opaque object. This allows opaque objects to block volume rendering rays. Without this feature, you visually see an odd mixing between opaque objects and volume rendering. However, there are two parts of this which could be more efficient.

### Changes
1. **Finding the current ray sample position in clip space.**
*Previously* - Apply the `uModelViewProjectionMatrix` to the ray position at each ray march step in model space to get that position in clip space. In other words, interpolate in model space and then transform to clip space.
*Here* - Apply the `uModelViewProjectionMatrix` to the near position of the ray and the far position of ray (akin to ray entry and exit points) and then at each ray march step, interpolate along the vector in clip space to find the position of the current sample. In other words, transform the ray start and end points into clip space and then interpolate in clip space.
*Reason* - This interpolation is more efficient than a matrix multiplication each step. We can do this because `MVP·mix(near, far, t) = MVP·((1-t)·near + t·far) = (1-t)·MVP·near + t·MVP·far = mix(MVP·near, MVP·far, t)` due to additivity and homogeneity of degree 1 properties of the matrix multiplication here. This works as long as we do it before perspective divide.
2. **Extracting the depth from the buffer for the current ray sample.**
*Previously* - Map the position of the current sample in clip space to UV coordinates and then sample from the depth buffer at that UV value.
*Here* - Before starting the ray march, sample from the depth buffer once using the clip space position of the position passed from the vertex shader to the fragment shader.
*Reason* - Since positions along a ray project back to the same fragment location, we know that the UV value must be constant along the ray. So we don't need to resample from the depth buffer texture at each ray march step.