### PR TITLE
fix: protect against empty table causing endless while loop in hash map query

### DIFF
--- a/src/segmentation_display_state/property_map.ts
+++ b/src/segmentation_display_state/property_map.ts
@@ -150,6 +150,7 @@ function queryUint64PermutationHashMap(
   values: BigUint64Array,
   x: bigint,
 ): number {
+  if (table.length === 0) return -1;
   let hashCode = murmurHash3_x86_32Hash64Bits_Bigint(/*seed=*/ 0, x);
   const mask = table.length - 1;
   while (true) {


### PR DESCRIPTION
Currently `queryUint64PermutationHashMap` will go into an endless while loop if the passed `table` has no entries. This PR aims to guard against that.

While this shouldn't come up in most cases, we did run into it in #991 as we didn't know we wouldn't just get a -1 as a result with an empty table. If possible, I'd like to include that protection here within `queryUint64PermutationHashMap` to return `-1`, which is the result indicating not found.