### PR TITLE
fix: recompute default position when dimension order changes

### DIFF
--- a/src/layer/index.spec.ts
+++ b/src/layer/index.spec.ts
@@ -1,0 +1,158 @@
+/**
+ * @license
+ * Copyright 2026 Google Inc.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it } from "vitest";
+import type { CoordinateSpace } from "#src/coordinate_transform.js";
+import {
+  emptyInvalidCoordinateSpace,
+  makeCoordinateSpace,
+} from "#src/coordinate_transform.js";
+import { UserLayer } from "#src/layer/index.js";
+import { Position } from "#src/navigation_state.js";
+import type { RenderLayerTransform } from "#src/render_coordinate_transform.js";
+import { WatchableValue } from "#src/trackable_value.js";
+
+function makeSpace(names: string[], upperBounds: number[]): CoordinateSpace {
+  return makeCoordinateSpace({
+    names,
+    ids: names.map((_, i) => i + 1),
+    units: names.map(() => "m"),
+    scales: Float64Array.from(names.map(() => 1e-9)),
+    bounds: {
+      lowerBounds: new Float64Array(names.length),
+      upperBounds: Float64Array.from(upperBounds),
+      voxelCenterAtIntegerCoordinates: names.map(() => false),
+    },
+  });
+}
+
+const globalSpace = makeSpace(["x", "y", "z"], [1000, 800, 600]);
+const globalLargerSpace = makeSpace(["x", "y", "z"], [2000, 1600, 1200]);
+const localSpace = makeSpace(["c"], [8]);
+const localLargerSpace = makeSpace(["c"], [16]);
+const GLOBAL_CENTRE = [500.5, 400.5, 300.5];
+const GLOBAL_LARGER_CENTRE = [1000.5, 800.5, 600.5];
+const LOCAL_CENTRE = [4.5];
+const LOCAL_LARGER_CENTRE = [8.5];
+
+// `setLayerPosition` only touches `this.manager.root.globalPosition` and
+// `this.localPosition`, so it can be driven against real `Position`s without
+// constructing a full layer.
+function setup() {
+  const globalCoordinateSpace = new WatchableValue<CoordinateSpace>(
+    emptyInvalidCoordinateSpace,
+  );
+  const localCoordinateSpace = new WatchableValue<CoordinateSpace>(
+    emptyInvalidCoordinateSpace,
+  );
+  const globalPosition = new Position(globalCoordinateSpace);
+  const localPosition = new Position(localCoordinateSpace);
+  globalCoordinateSpace.value = globalSpace;
+  localCoordinateSpace.value = localSpace;
+  const layer = {
+    manager: { root: { globalPosition } },
+    localPosition,
+  } as unknown as UserLayer;
+  // A rank-4 render layer: dimensions 0-2 come from the global position and
+  // dimension 3 from the local (channel) position.
+  const modelTransform = {
+    globalToRenderLayerDimensions: [0, 1, 2],
+    localToRenderLayerDimensions: [3],
+  } as unknown as RenderLayerTransform;
+  const setLayerPosition = (layerPosition: Float32Array) =>
+    UserLayer.prototype.setLayerPosition.call(
+      layer,
+      modelTransform,
+      layerPosition,
+    );
+  return {
+    globalCoordinateSpace,
+    localCoordinateSpace,
+    globalPosition,
+    localPosition,
+    setLayerPosition,
+  };
+}
+
+function reload(
+  coordinateSpace: WatchableValue<CoordinateSpace>,
+  space: CoordinateSpace,
+) {
+  coordinateSpace.value = emptyInvalidCoordinateSpace;
+  coordinateSpace.value = space;
+}
+
+describe("UserLayer.setLayerPosition", () => {
+  it("keeps global and local positions it moved", () => {
+    const {
+      globalCoordinateSpace,
+      localCoordinateSpace,
+      globalPosition,
+      localPosition,
+      setLayerPosition,
+    } = setup();
+    setLayerPosition(Float32Array.of(10, 20, 30, 2));
+    expect(Array.from(globalPosition.value)).toEqual([10, 20, 30]);
+    expect(Array.from(localPosition.value)).toEqual([2]);
+
+    reload(globalCoordinateSpace, globalLargerSpace);
+    reload(localCoordinateSpace, localLargerSpace);
+
+    expect(Array.from(globalPosition.value)).toEqual([10, 20, 30]);
+    expect(Array.from(localPosition.value)).toEqual([2]);
+    globalPosition.dispose();
+    localPosition.dispose();
+  });
+
+  it("does not count a layer position that changes nothing as a move", () => {
+    const {
+      globalCoordinateSpace,
+      localCoordinateSpace,
+      globalPosition,
+      localPosition,
+      setLayerPosition,
+    } = setup();
+    setLayerPosition(Float32Array.of(...GLOBAL_CENTRE, ...LOCAL_CENTRE));
+
+    reload(globalCoordinateSpace, globalLargerSpace);
+    reload(localCoordinateSpace, localLargerSpace);
+
+    expect(Array.from(globalPosition.value)).toEqual(GLOBAL_LARGER_CENTRE);
+    expect(Array.from(localPosition.value)).toEqual(LOCAL_LARGER_CENTRE);
+    globalPosition.dispose();
+    localPosition.dispose();
+  });
+
+  it("marks only the position that actually moved", () => {
+    const {
+      globalCoordinateSpace,
+      localCoordinateSpace,
+      globalPosition,
+      localPosition,
+      setLayerPosition,
+    } = setup();
+    // Global coordinates unchanged; only the local channel moves.
+    setLayerPosition(Float32Array.of(...GLOBAL_CENTRE, 2));
+
+    reload(globalCoordinateSpace, globalLargerSpace);
+    reload(localCoordinateSpace, localLargerSpace);
+
+    expect(Array.from(globalPosition.value)).toEqual(GLOBAL_LARGER_CENTRE);
+    expect(Array.from(localPosition.value)).toEqual([2]);
+    globalPosition.dispose();
+    localPosition.dispose();
+  });
+});

--- a/src/layer/index.ts
+++ b/src/layer/index.ts
@@ -82,7 +82,7 @@ import {
 } from "#src/ui/side_panel_location.js";
 import type { GlobalToolBinder } from "#src/ui/tool.js";
 import { LayerToolBinder, SelectedLegacyTool } from "#src/ui/tool.js";
-import { gatherUpdate } from "#src/util/array.js";
+import { arraysEqual, gatherUpdate } from "#src/util/array.js";
 import type { Borrowed, Owned } from "#src/util/disposable.js";
 import { invokeDisposers, RefCounted } from "#src/util/disposable.js";
 import {
@@ -639,16 +639,24 @@ export class UserLayer extends RefCounted {
   ) {
     const { globalPosition } = this.manager.root;
     const { localPosition } = this;
+    const previousGlobalCoordinates = Float32Array.from(globalPosition.value);
     gatherUpdate(
       globalPosition.value,
       layerPosition,
       modelTransform.globalToRenderLayerDimensions,
     );
+    if (!arraysEqual(globalPosition.value, previousGlobalCoordinates)) {
+      globalPosition.markMoved();
+    }
+    const previousLocalCoordinates = Float32Array.from(localPosition.value);
     gatherUpdate(
       localPosition.value,
       layerPosition,
       modelTransform.localToRenderLayerDimensions,
     );
+    if (!arraysEqual(localPosition.value, previousLocalCoordinates)) {
+      localPosition.markMoved();
+    }
     localPosition.changed.dispatch();
     globalPosition.changed.dispatch();
   }

--- a/src/navigation_state.spec.ts
+++ b/src/navigation_state.spec.ts
@@ -203,6 +203,27 @@ describe("Position edge cases", () => {
     position.dispose();
   });
 
+  it("re-infers when a reset leaves an inferred position behind", () => {
+    // The sequence reported in the issue: resetting the viewer state empties
+    // the position while the outgoing coordinate space is still valid, so the
+    // next render infers a position for that space.  Applying the new state
+    // then replaces the space through an invalid gap, and the position left
+    // behind must not be carried over by index.
+    const { coordinateSpace, position } = newPosition();
+    coordinateSpace.value = xyzSpace;
+    position.restoreState([1, 2, 3]);
+
+    position.reset();
+    expect(Array.from(position.value)).toEqual([125000.5, 60000.5, 2500.5]);
+
+    coordinateSpace.value = emptyInvalidCoordinateSpace;
+    coordinateSpace.value = zxySpace;
+
+    expectWithinBounds(zxySpace, position.value);
+    expect(Array.from(position.value)).toEqual([2500.5, 125000.5, 60000.5]);
+    position.dispose();
+  });
+
   it("leaves an inferred position unchanged when the same space returns", () => {
     // Reloading the same data must not make the position jump.
     const { coordinateSpace, position } = newPosition();
@@ -277,6 +298,37 @@ describe("Position edge cases", () => {
     position.dispose();
   });
 
+  it("keeps an inferred position inferred across a remap between valid spaces", () => {
+    // Matching dimensions by id is not a move, so a position that is still
+    // exactly as inferred stays that way and must be re-inferred if the
+    // coordinate space is later replaced while invalid.
+    const { coordinateSpace, position } = newPosition();
+    coordinateSpace.value = xyzSpace;
+    coordinateSpace.value = zxySpace;
+    expect(Array.from(position.value)).toEqual([2500.5, 125000.5, 60000.5]);
+
+    coordinateSpace.value = emptyInvalidCoordinateSpace;
+    coordinateSpace.value = xyzSpace;
+
+    expectWithinBounds(xyzSpace, position.value);
+    expect(Array.from(position.value)).toEqual([125000.5, 60000.5, 2500.5]);
+    position.dispose();
+  });
+
+  it("keeps an explicit position explicit across a remap between valid spaces", () => {
+    const { coordinateSpace, position } = newPosition();
+    coordinateSpace.value = xyzSpace;
+    position.restoreState([1000, 2000, 3000]);
+    coordinateSpace.value = zxySpace;
+    expect(Array.from(position.value)).toEqual([3000, 1000, 2000]);
+
+    coordinateSpace.value = emptyInvalidCoordinateSpace;
+    coordinateSpace.value = zxySpace;
+
+    expect(Array.from(position.value)).toEqual([3000, 1000, 2000]);
+    position.dispose();
+  });
+
   it("re-infers a snapped inferred position after a reorder", () => {
     const { coordinateSpace, position } = newPosition();
     coordinateSpace.value = xyzSpace;
@@ -299,6 +351,10 @@ describe("Position edge cases", () => {
 
     const target = newPosition();
     target.position.assign(source.position);
+    // Reading the value here is load-bearing: `assign` copies the source's
+    // valid coordinate space, so the target has to observe its own invalid
+    // space before the new one arrives.  Without this read the dimension-id
+    // remap path runs instead of the invalid-gap path under test.
     expect(Array.from(target.position.value)).toEqual([
       125000.5, 60000.5, 2500.5,
     ]);
@@ -380,8 +436,11 @@ describe("Position edge cases", () => {
 
     const target = newPosition();
     target.position.assign(source.position);
+    // As above, the target must observe its own invalid coordinate space
+    // first; otherwise it still holds the space copied from the source and the
+    // assignment below is a no-op that exercises nothing.
+    expect(Array.from(target.position.value)).toEqual([1, 2, 3]);
 
-    target.coordinateSpace.value = emptyInvalidCoordinateSpace;
     target.coordinateSpace.value = xyzSpace;
 
     expect(Array.from(target.position.value)).toEqual([1, 2, 3]);

--- a/src/navigation_state.spec.ts
+++ b/src/navigation_state.spec.ts
@@ -316,6 +316,63 @@ describe("Position edge cases", () => {
     target.position.dispose();
   });
 
+  it("keeps a position that was panned in place", () => {
+    // `NavigationState.translateVoxelsRelative` and the slice-view zoom move the
+    // position by writing into the array returned by `value` rather than going
+    // through the setter, so a position that started out inferred must stop
+    // counting as inferred once the user has moved it.  Such a position is kept
+    // for the same reason an explicitly restored one is: it is a location the
+    // user chose.  There is no previous valid coordinate space left to match
+    // dimension ids against, so the coordinates carry over by index, exactly as
+    // they do for a position restored from JSON.
+    const { coordinateSpace, position } = newPosition();
+    coordinateSpace.value = xyzSpace;
+
+    const voxelCoordinates = position.value;
+    voxelCoordinates[0] = 1000;
+    voxelCoordinates[1] = 2000;
+    position.changed.dispatch();
+
+    coordinateSpace.value = emptyInvalidCoordinateSpace;
+    coordinateSpace.value = zxySpace;
+
+    expect(Array.from(position.value)).toEqual([1000, 2000, 2500.5]);
+    position.dispose();
+  });
+
+  it("keeps a position with a single panned dimension", () => {
+    const { coordinateSpace, position } = newPosition();
+    coordinateSpace.value = xyzSpace;
+
+    position.value[2] = 4000;
+    position.changed.dispatch();
+
+    coordinateSpace.value = emptyInvalidCoordinateSpace;
+    coordinateSpace.value = zxySpace;
+
+    expect(Array.from(position.value)).toEqual([125000.5, 60000.5, 4000]);
+    position.dispose();
+  });
+
+  it("re-infers a position panned back onto the inferred coordinates", () => {
+    // Moving the position and then moving it back leaves it indistinguishable
+    // from a position that was never touched, so it is treated as inferred.
+    const { coordinateSpace, position } = newPosition();
+    coordinateSpace.value = xyzSpace;
+
+    position.value[0] = 1000;
+    position.changed.dispatch();
+    position.value[0] = 125000.5;
+    position.changed.dispatch();
+
+    coordinateSpace.value = emptyInvalidCoordinateSpace;
+    coordinateSpace.value = zxySpace;
+
+    expectWithinBounds(zxySpace, position.value);
+    expect(Array.from(position.value)).toEqual([2500.5, 125000.5, 60000.5]);
+    position.dispose();
+  });
+
   it("carries explicitness across assign", () => {
     const source = newPosition();
     source.coordinateSpace.value = xyzSpace;

--- a/src/navigation_state.spec.ts
+++ b/src/navigation_state.spec.ts
@@ -14,18 +14,39 @@
  * limitations under the License.
  */
 
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import type { CoordinateSpace } from "#src/coordinate_transform.js";
 import {
   emptyInvalidCoordinateSpace,
   makeCoordinateSpace,
 } from "#src/coordinate_transform.js";
-import { Position } from "#src/navigation_state.js";
+import {
+  CoordinateSpacePlaybackVelocity,
+  DisplayPose,
+  OrientationState,
+  PlaybackManager,
+  Position,
+  TrackableDisplayDimensions,
+  TrackableRelativeDisplayScales,
+  VelocityBoundaryBehavior,
+  WatchableDisplayDimensionRenderInfo,
+} from "#src/navigation_state.js";
 import { WatchableValue } from "#src/trackable_value.js";
+import { vec3 } from "#src/util/geom.js";
+import { NullarySignal } from "#src/util/signal.js";
 
 // Stable per-name dimension ids, so that a space listing the same dimensions in
 // a different order still refers to the same dimensions.
-const dimensionIds: { [name: string]: number } = { x: 1, y: 2, z: 3, c: 4 };
+const dimensionIds: { [name: string]: number } = {
+  x: 1,
+  y: 2,
+  z: 3,
+  c: 4,
+  t: 5,
+  u: 6,
+  v: 7,
+  w: 8,
+};
 
 function makeSpace(
   names: string[],
@@ -65,6 +86,31 @@ const zxySpace = makeSpace(
   [4e-8, 4e-9, 4e-9],
   [5000, 250000, 120000],
 );
+// The same dimensions in the same order over a larger extent, as happens when a
+// second layer widens the combined coordinate space.  Its centre differs from
+// `xyzSpace`'s, so a position inferred for `xyzSpace` and carried over is no
+// longer the centre of the bounds.
+const xyzLargerSpace = makeSpace(
+  ["x", "y", "z"],
+  [4e-9, 4e-9, 4e-8],
+  [500000, 240000, 10000],
+);
+
+// A higher-rank volume, e.g. spatial dimensions plus channel and time, to
+// check that the bookkeeping does not depend on the typical rank of 3.
+const highRankNames = ["x", "y", "z", "c", "t", "u", "v", "w"];
+const highRankSpace = makeSpace(
+  highRankNames,
+  highRankNames.map(() => 1e-9),
+  [10, 20, 30, 40, 50, 60, 70, 80],
+);
+const highRankLargerSpace = makeSpace(
+  highRankNames,
+  highRankNames.map(() => 1e-9),
+  [20, 40, 60, 80, 100, 120, 140, 160],
+);
+const highRankCentre = [5.5, 10.5, 15.5, 20.5, 25.5, 30.5, 35.5, 40.5];
+const highRankLargerCentre = [10.5, 20.5, 30.5, 40.5, 50.5, 60.5, 70.5, 80.5];
 
 function expectWithinBounds(space: CoordinateSpace, coordinates: Float32Array) {
   const { lowerBounds, upperBounds } = space.bounds;
@@ -372,15 +418,14 @@ describe("Position edge cases", () => {
     target.position.dispose();
   });
 
-  it("keeps a position that was panned in place", () => {
-    // `NavigationState.translateVoxelsRelative` and the slice-view zoom move the
-    // position by writing into the array returned by `value` rather than going
-    // through the setter, so a position that started out inferred must stop
-    // counting as inferred once the user has moved it.  Such a position is kept
-    // for the same reason an explicitly restored one is: it is a location the
-    // user chose.  There is no previous valid coordinate space left to match
-    // dimension ids against, so the coordinates carry over by index, exactly as
-    // they do for a position restored from JSON.
+  it("keeps a position moved in place without a `markMoved` call", () => {
+    // The navigation callers report their moves through `Position.markMoved`,
+    // but a caller that does not is still detected, because the coordinates no
+    // longer match the copy taken when they were inferred.  Such a position is
+    // kept for the same reason an explicitly restored one is: it is a location
+    // the user chose.  There is no previous valid coordinate space left to
+    // match dimension ids against, so the coordinates carry over by index,
+    // exactly as they do for a position restored from JSON.
     const { coordinateSpace, position } = newPosition();
     coordinateSpace.value = xyzSpace;
 
@@ -397,6 +442,11 @@ describe("Position edge cases", () => {
   });
 
   it("keeps a position with a single panned dimension", () => {
+    // Carrying over by index means a moved position can land outside the bounds
+    // of a space whose dimensions are ordered differently: `z` ends up at
+    // 125000.5 here, against an upper bound of 5000.  That behaviour predates
+    // this change -- matching dimensions by id across the invalid gap would be
+    // needed to fix it -- and is asserted only to pin what happens today.
     const { coordinateSpace, position } = newPosition();
     coordinateSpace.value = xyzSpace;
 
@@ -410,22 +460,73 @@ describe("Position edge cases", () => {
     position.dispose();
   });
 
-  it("re-infers a position panned back onto the inferred coordinates", () => {
-    // Moving the position and then moving it back leaves it indistinguishable
-    // from a position that was never touched, so it is treated as inferred.
+  it("keeps a position moved away and back by `addOffset`", () => {
+    // A linked position is driven by `Position.addOffset`, which writes into the
+    // target's live coordinate array.  Following a peer away and back must not
+    // make the target count as inferred again.
+    const source = newPosition();
+    source.coordinateSpace.value = xyzSpace;
+    source.position.restoreState([0, 0, 0]);
+
+    const target = newPosition();
+    target.coordinateSpace.value = xyzSpace;
+    const inferred = Array.from(target.position.value);
+    expect(inferred).toEqual([125000.5, 60000.5, 2500.5]);
+
+    Position.addOffset(
+      target.position,
+      source.position,
+      Float32Array.from(inferred),
+    );
+    expect(Array.from(target.position.value)).toEqual(inferred);
+
+    // The peer moves, dragging the target with it, and then moves back.
+    source.position.value = Float32Array.of(100, 0, 0);
+    Position.addOffset(
+      target.position,
+      source.position,
+      Float32Array.from(inferred),
+    );
+    expect(Array.from(target.position.value)).toEqual([
+      125100.5, 60000.5, 2500.5,
+    ]);
+    source.position.value = Float32Array.of(0, 0, 0);
+    Position.addOffset(
+      target.position,
+      source.position,
+      Float32Array.from(inferred),
+    );
+    expect(Array.from(target.position.value)).toEqual(inferred);
+
+    target.coordinateSpace.value = emptyInvalidCoordinateSpace;
+    target.coordinateSpace.value = zxySpace;
+
+    expect(Array.from(target.position.value)).toEqual(inferred);
+    source.position.dispose();
+    target.position.dispose();
+  });
+
+  it("keeps a position that `snapToVoxel` moved away and back", () => {
+    // Snapping a position that is already on a voxel centre changes nothing, so
+    // it stays inferred; snapping one that is not is a move.
     const { coordinateSpace, position } = newPosition();
     coordinateSpace.value = xyzSpace;
+    const inferred = Array.from(position.value);
 
-    position.value[0] = 1000;
+    position.snapToVoxel();
+    expect(Array.from(position.value)).toEqual(inferred);
+
+    // Move off the voxel centre in place, as the slice-view zoom does, and then
+    // snap back onto the inferred coordinates.
+    position.value[0] = 125000.2;
     position.changed.dispatch();
-    position.value[0] = 125000.5;
-    position.changed.dispatch();
+    position.snapToVoxel();
+    expect(Array.from(position.value)).toEqual(inferred);
 
     coordinateSpace.value = emptyInvalidCoordinateSpace;
     coordinateSpace.value = zxySpace;
 
-    expectWithinBounds(zxySpace, position.value);
-    expect(Array.from(position.value)).toEqual([2500.5, 125000.5, 60000.5]);
+    expect(Array.from(position.value)).toEqual(inferred);
     position.dispose();
   });
 
@@ -446,5 +547,367 @@ describe("Position edge cases", () => {
     expect(Array.from(target.position.value)).toEqual([1, 2, 3]);
     source.position.dispose();
     target.position.dispose();
+  });
+});
+
+describe("Position moved through the navigation callers", () => {
+  // `DisplayPose` moves the position by writing into the array returned by
+  // `Position.value` and dispatching `changed` itself, rather than going
+  // through the setter.  These tests drive those callers directly, so that the
+  // bookkeeping which distinguishes an inferred position from one the user
+  // chose is exercised the way it is in the application.
+  function newPose() {
+    const coordinateSpace = new WatchableValue<CoordinateSpace>(
+      emptyInvalidCoordinateSpace,
+    );
+    const position = new Position(coordinateSpace);
+    const pose = new DisplayPose(
+      position,
+      new WatchableDisplayDimensionRenderInfo(
+        new TrackableRelativeDisplayScales(coordinateSpace),
+        new TrackableDisplayDimensions(coordinateSpace),
+      ),
+      new OrientationState(),
+    );
+    return { coordinateSpace, position, pose };
+  }
+
+  it("keeps a position the user stepped away from and back to", () => {
+    const { coordinateSpace, position, pose } = newPose();
+    coordinateSpace.value = xyzSpace;
+    coordinateSpace.value = xyzLargerSpace;
+
+    // Carried over from `xyzSpace`, so no longer the centre of the bounds.
+    const chosen = [125000.5, 60000.5, 2500.5];
+    expect(Array.from(position.value)).toEqual(chosen);
+
+    // The user steps a dimension away and back, landing on exactly the
+    // coordinates that were inferred.
+    pose.translateDimensionRelative(0, 100);
+    expect(Array.from(position.value)).toEqual([125100.5, 60000.5, 2500.5]);
+    pose.translateDimensionRelative(0, -100);
+    expect(Array.from(position.value)).toEqual(chosen);
+
+    coordinateSpace.value = emptyInvalidCoordinateSpace;
+    coordinateSpace.value = xyzLargerSpace;
+
+    // The position was chosen by the user, so it must not be recomputed as the
+    // centre of the new bounds.
+    expect(Array.from(position.value)).toEqual(chosen);
+    pose.dispose();
+  });
+
+  it("keeps a position the user panned away from and back to", () => {
+    const { coordinateSpace, position, pose } = newPose();
+    coordinateSpace.value = xyzSpace;
+    coordinateSpace.value = xyzLargerSpace;
+
+    const chosen = [125000.5, 60000.5, 2500.5];
+    pose.translateVoxelsRelative(vec3.fromValues(10, 0, 0));
+    expect(Array.from(position.value)).toEqual([125010.5, 60000.5, 2500.5]);
+    pose.translateVoxelsRelative(vec3.fromValues(-10, 0, 0));
+    expect(Array.from(position.value)).toEqual(chosen);
+
+    coordinateSpace.value = emptyInvalidCoordinateSpace;
+    coordinateSpace.value = xyzLargerSpace;
+
+    expect(Array.from(position.value)).toEqual(chosen);
+    pose.dispose();
+  });
+
+  it("does not count a step that rounds back onto the same voxel as a move", () => {
+    // Arrow-key stepping rounds to the voxel centre, so a sub-voxel adjustment
+    // leaves the coordinates untouched.  Nothing moved, so the position is
+    // still the inferred one and must be recomputed for the new bounds.
+    const { coordinateSpace, position, pose } = newPose();
+    coordinateSpace.value = xyzSpace;
+    coordinateSpace.value = xyzLargerSpace;
+    expect(Array.from(position.value)).toEqual([125000.5, 60000.5, 2500.5]);
+
+    pose.translateDimensionRelative(0, 0.1);
+    expect(Array.from(position.value)).toEqual([125000.5, 60000.5, 2500.5]);
+
+    coordinateSpace.value = emptyInvalidCoordinateSpace;
+    coordinateSpace.value = xyzLargerSpace;
+
+    expect(Array.from(position.value)).toEqual([250000.5, 120000.5, 5000.5]);
+    pose.dispose();
+  });
+
+  it("still re-infers a position the user never moved", () => {
+    const { coordinateSpace, position, pose } = newPose();
+    coordinateSpace.value = xyzSpace;
+    coordinateSpace.value = xyzLargerSpace;
+    expect(Array.from(position.value)).toEqual([125000.5, 60000.5, 2500.5]);
+
+    coordinateSpace.value = emptyInvalidCoordinateSpace;
+    coordinateSpace.value = xyzLargerSpace;
+
+    // Nothing moved the position, so it is recomputed for the new bounds.
+    expect(Array.from(position.value)).toEqual([250000.5, 120000.5, 5000.5]);
+    pose.dispose();
+  });
+
+  it("keeps a position that a clamped step moved to the boundary", () => {
+    const { coordinateSpace, position, pose } = newPose();
+    coordinateSpace.value = xyzSpace;
+
+    // Stepping far past the upper bound clamps to the last voxel centre.
+    pose.translateDimensionRelative(2, 1e9);
+    expect(Array.from(position.value)).toEqual([125000.5, 60000.5, 4999.5]);
+
+    coordinateSpace.value = emptyInvalidCoordinateSpace;
+    coordinateSpace.value = xyzLargerSpace;
+
+    // The clamped step still moved the position, so it is kept.
+    expect(Array.from(position.value)).toEqual([125000.5, 60000.5, 4999.5]);
+    pose.dispose();
+  });
+
+  it("does not count a step clamped back onto the same voxel as a move", () => {
+    // A space so shallow in `z` that the centre voxel is also the last one:
+    // the clamp puts the stepped coordinate right back where it started.
+    const shallowSpace = makeSpace(
+      ["x", "y", "z"],
+      [4e-9, 4e-9, 4e-8],
+      [1000, 800, 2],
+    );
+    const { coordinateSpace, position, pose } = newPose();
+    coordinateSpace.value = shallowSpace;
+    expect(Array.from(position.value)).toEqual([500.5, 400.5, 1.5]);
+
+    pose.translateDimensionRelative(2, 5);
+    expect(Array.from(position.value)).toEqual([500.5, 400.5, 1.5]);
+
+    coordinateSpace.value = emptyInvalidCoordinateSpace;
+    coordinateSpace.value = xyzLargerSpace;
+
+    // Nothing actually moved, so the position is recomputed for the new bounds.
+    expect(Array.from(position.value)).toEqual([250000.5, 120000.5, 5000.5]);
+    pose.dispose();
+  });
+
+  it("does not count a rotation about the current position as a move", () => {
+    const { coordinateSpace, position, pose } = newPose();
+    coordinateSpace.value = xyzSpace;
+    const fixedPoint = Float32Array.from(position.value);
+
+    pose.rotateAbsolute(vec3.fromValues(0, 0, 1), Math.PI / 2, fixedPoint);
+    expect(Array.from(position.value)).toEqual([125000.5, 60000.5, 2500.5]);
+
+    coordinateSpace.value = emptyInvalidCoordinateSpace;
+    coordinateSpace.value = xyzLargerSpace;
+
+    expect(Array.from(position.value)).toEqual([250000.5, 120000.5, 5000.5]);
+    pose.dispose();
+  });
+
+  it("keeps a position rotated about another point", () => {
+    const { coordinateSpace, position, pose } = newPose();
+    coordinateSpace.value = xyzSpace;
+    const fixedPoint = Float32Array.from(position.value);
+    fixedPoint[0] += 10;
+
+    // A half turn about `fixedPoint` reflects the position through it.
+    pose.rotateAbsolute(vec3.fromValues(0, 0, 1), Math.PI, fixedPoint);
+    expect(Array.from(position.value)).toEqual([125020.5, 60000.5, 2500.5]);
+
+    coordinateSpace.value = emptyInvalidCoordinateSpace;
+    coordinateSpace.value = xyzSpace;
+
+    expect(Array.from(position.value)).toEqual([125020.5, 60000.5, 2500.5]);
+    pose.dispose();
+  });
+
+  it("keeps a position moved away and back through updateDisplayPosition", () => {
+    const { coordinateSpace, position, pose } = newPose();
+    coordinateSpace.value = xyzSpace;
+
+    expect(
+      pose.updateDisplayPosition((pos) => {
+        pos[0] += 10;
+      }),
+    ).toBe(true);
+    expect(Array.from(position.value)).toEqual([125010.5, 60000.5, 2500.5]);
+    expect(
+      pose.updateDisplayPosition((pos) => {
+        pos[0] -= 10;
+      }),
+    ).toBe(true);
+    expect(Array.from(position.value)).toEqual([125000.5, 60000.5, 2500.5]);
+
+    coordinateSpace.value = emptyInvalidCoordinateSpace;
+    coordinateSpace.value = xyzLargerSpace;
+
+    expect(Array.from(position.value)).toEqual([125000.5, 60000.5, 2500.5]);
+    pose.dispose();
+  });
+
+  it("does not count an updateDisplayPosition that changes nothing as a move", () => {
+    const { coordinateSpace, position, pose } = newPose();
+    coordinateSpace.value = xyzSpace;
+
+    expect(pose.updateDisplayPosition(() => {})).toBe(true);
+
+    coordinateSpace.value = emptyInvalidCoordinateSpace;
+    coordinateSpace.value = xyzLargerSpace;
+
+    expect(Array.from(position.value)).toEqual([250000.5, 120000.5, 5000.5]);
+    pose.dispose();
+  });
+
+  it("keeps a position after repeated away-and-back cycles", () => {
+    const { coordinateSpace, position, pose } = newPose();
+    coordinateSpace.value = xyzSpace;
+
+    for (let i = 0; i < 5; ++i) {
+      pose.translateDimensionRelative(0, 100);
+      pose.translateDimensionRelative(0, -100);
+      pose.translateVoxelsRelative(vec3.fromValues(0, 7, 0));
+      pose.translateVoxelsRelative(vec3.fromValues(0, -7, 0));
+    }
+    expect(Array.from(position.value)).toEqual([125000.5, 60000.5, 2500.5]);
+
+    coordinateSpace.value = emptyInvalidCoordinateSpace;
+    coordinateSpace.value = xyzLargerSpace;
+
+    expect(Array.from(position.value)).toEqual([125000.5, 60000.5, 2500.5]);
+    pose.dispose();
+  });
+
+  it("re-infers an untouched rank-8 position", () => {
+    const { coordinateSpace, position, pose } = newPose();
+    coordinateSpace.value = highRankSpace;
+    expect(Array.from(position.value)).toEqual(highRankCentre);
+
+    coordinateSpace.value = emptyInvalidCoordinateSpace;
+    coordinateSpace.value = highRankLargerSpace;
+
+    expect(Array.from(position.value)).toEqual(highRankLargerCentre);
+    pose.dispose();
+  });
+
+  it("keeps a rank-8 position stepped away and back on every dimension", () => {
+    const { coordinateSpace, position, pose } = newPose();
+    coordinateSpace.value = highRankSpace;
+
+    // Many alternating steps across all dimensions, netting out to zero.
+    for (let round = 0; round < 625; ++round) {
+      for (let dim = 0; dim < 8; ++dim) {
+        pose.translateDimensionRelative(dim, 1);
+        pose.translateDimensionRelative(dim, -1);
+      }
+    }
+    expect(Array.from(position.value)).toEqual(highRankCentre);
+
+    coordinateSpace.value = emptyInvalidCoordinateSpace;
+    coordinateSpace.value = highRankLargerSpace;
+
+    expect(Array.from(position.value)).toEqual(highRankCentre);
+    pose.dispose();
+  });
+});
+
+describe("Position moved by playback", () => {
+  function newPlayback() {
+    const coordinateSpace = new WatchableValue<CoordinateSpace>(
+      emptyInvalidCoordinateSpace,
+    );
+    const position = new Position(coordinateSpace);
+    coordinateSpace.value = xyzSpace;
+    const velocity = new CoordinateSpacePlaybackVelocity(coordinateSpace);
+    const display = {
+      updateStarted: new NullarySignal(),
+      scheduleRedraw() {},
+    };
+    const playback = new PlaybackManager(display, position, velocity);
+    return { coordinateSpace, position, velocity, display, playback };
+  }
+
+  it("keeps a position that playback moved", () => {
+    vi.useFakeTimers();
+    try {
+      const { coordinateSpace, position, velocity, display, playback } =
+        newPlayback();
+      velocity.value = [
+        undefined,
+        undefined,
+        {
+          velocity: 1000,
+          atBoundary: VelocityBoundaryBehavior.STOP,
+          paused: false,
+        },
+      ];
+      vi.advanceTimersByTime(500);
+      display.updateStarted.dispatch();
+      expect(Array.from(position.value)).toEqual([125000.5, 60000.5, 3000.5]);
+
+      coordinateSpace.value = emptyInvalidCoordinateSpace;
+      coordinateSpace.value = xyzLargerSpace;
+
+      // Playback moved the position, so it is kept.
+      expect(Array.from(position.value)).toEqual([125000.5, 60000.5, 3000.5]);
+      playback.dispose();
+      velocity.dispose();
+      position.dispose();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("does not count a playback tick too small to change the coordinate as a move", () => {
+    vi.useFakeTimers();
+    try {
+      const { coordinateSpace, position, velocity, display, playback } =
+        newPlayback();
+      velocity.value = [
+        undefined,
+        undefined,
+        {
+          velocity: 1e-6,
+          atBoundary: VelocityBoundaryBehavior.STOP,
+          paused: false,
+        },
+      ];
+      vi.advanceTimersByTime(1);
+      display.updateStarted.dispatch();
+      // The delta is far below Float32 precision at this coordinate, so the
+      // stored value is unchanged even though a change was dispatched.
+      expect(Array.from(position.value)).toEqual([125000.5, 60000.5, 2500.5]);
+
+      coordinateSpace.value = emptyInvalidCoordinateSpace;
+      coordinateSpace.value = xyzLargerSpace;
+
+      expect(Array.from(position.value)).toEqual([250000.5, 120000.5, 5000.5]);
+      playback.dispose();
+      velocity.dispose();
+      position.dispose();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});
+
+describe("Position synchronised by addOffset", () => {
+  it("does not count a sync that recomputes the same coordinates as a move", () => {
+    const coordinateSpace = new WatchableValue<CoordinateSpace>(
+      emptyInvalidCoordinateSpace,
+    );
+    const source = new Position(coordinateSpace);
+    const target = new Position(coordinateSpace);
+    coordinateSpace.value = xyzSpace;
+    const offset = Position.getOffset(target, source);
+
+    Position.addOffset(target, source, offset);
+    expect(Array.from(target.value)).toEqual([125000.5, 60000.5, 2500.5]);
+
+    coordinateSpace.value = emptyInvalidCoordinateSpace;
+    coordinateSpace.value = xyzLargerSpace;
+
+    // The sync rewrote identical coordinates, so the position is still the
+    // inferred one and is recomputed for the new bounds.
+    expect(Array.from(target.value)).toEqual([250000.5, 120000.5, 5000.5]);
+    source.dispose();
+    target.dispose();
   });
 });

--- a/src/navigation_state.spec.ts
+++ b/src/navigation_state.spec.ts
@@ -25,23 +25,30 @@ import { WatchableValue } from "#src/trackable_value.js";
 
 // Stable per-name dimension ids, so that a space listing the same dimensions in
 // a different order still refers to the same dimensions.
-const dimensionIds: { [name: string]: number } = { x: 1, y: 2, z: 3 };
+const dimensionIds: { [name: string]: number } = { x: 1, y: 2, z: 3, c: 4 };
 
 function makeSpace(
   names: string[],
   scales: number[],
   upperBounds: number[],
+  options: {
+    lowerBounds?: number[];
+    voxelCenterAtIntegerCoordinates?: boolean[];
+  } = {},
 ): CoordinateSpace {
-  const rank = names.length;
+  const {
+    lowerBounds = names.map(() => 0),
+    voxelCenterAtIntegerCoordinates = names.map(() => false),
+  } = options;
   return makeCoordinateSpace({
     names,
     ids: names.map((name) => dimensionIds[name]),
     units: names.map(() => "m"),
     scales: Float64Array.from(scales),
     bounds: {
-      lowerBounds: new Float64Array(rank),
+      lowerBounds: Float64Array.from(lowerBounds),
       upperBounds: Float64Array.from(upperBounds),
-      voxelCenterAtIntegerCoordinates: names.map(() => false),
+      voxelCenterAtIntegerCoordinates,
     },
   });
 }
@@ -140,5 +147,188 @@ describe("Position", () => {
     coordinateSpace.value = xyzSpace;
     expect(Array.from(position.value)).toEqual([10, 20, 30]);
     position.dispose();
+  });
+});
+
+describe("Position edge cases", () => {
+  function newPosition(): {
+    coordinateSpace: WatchableValue<CoordinateSpace>;
+    position: Position;
+  } {
+    const coordinateSpace = new WatchableValue<CoordinateSpace>(
+      emptyInvalidCoordinateSpace,
+    );
+    return { coordinateSpace, position: new Position(coordinateSpace) };
+  }
+
+  it("re-infers the position when the rank changes as well as the order", () => {
+    const { coordinateSpace, position } = newPosition();
+    coordinateSpace.value = xyzSpace;
+    expect(Array.from(position.value)).toEqual([125000.5, 60000.5, 2500.5]);
+
+    // A channel dimension appears, so the rank no longer matches.
+    const zxycSpace = makeSpace(
+      ["z", "x", "y", "c"],
+      [4e-8, 4e-9, 4e-9, 1],
+      [5000, 250000, 120000, 10],
+    );
+    coordinateSpace.value = emptyInvalidCoordinateSpace;
+    coordinateSpace.value = zxycSpace;
+
+    expectWithinBounds(zxycSpace, position.value);
+    expect(Array.from(position.value)).toEqual([
+      2500.5, 125000.5, 60000.5, 5.5,
+    ]);
+    position.dispose();
+  });
+
+  it("re-infers after several consecutive invalid coordinate spaces", () => {
+    const { coordinateSpace, position } = newPosition();
+    coordinateSpace.value = xyzSpace;
+    expect(Array.from(position.value)).toEqual([125000.5, 60000.5, 2500.5]);
+
+    const otherInvalidSpace = makeCoordinateSpace({
+      valid: false,
+      names: [],
+      units: [],
+      scales: new Float64Array(0),
+      boundingBoxes: [],
+    });
+    coordinateSpace.value = emptyInvalidCoordinateSpace;
+    coordinateSpace.value = otherInvalidSpace;
+    coordinateSpace.value = zxySpace;
+
+    expectWithinBounds(zxySpace, position.value);
+    expect(Array.from(position.value)).toEqual([2500.5, 125000.5, 60000.5]);
+    position.dispose();
+  });
+
+  it("leaves an inferred position unchanged when the same space returns", () => {
+    // Reloading the same data must not make the position jump.
+    const { coordinateSpace, position } = newPosition();
+    coordinateSpace.value = xyzSpace;
+    const before = Array.from(position.value);
+
+    coordinateSpace.value = emptyInvalidCoordinateSpace;
+    coordinateSpace.value = xyzSpace;
+
+    expect(Array.from(position.value)).toEqual(before);
+    position.dispose();
+  });
+
+  it("keeps an explicitly restored position that lies outside the bounds", () => {
+    // Navigating deliberately outside the volume is allowed; only inferred
+    // positions are recomputed.
+    const { coordinateSpace, position } = newPosition();
+    coordinateSpace.value = xyzSpace;
+    position.restoreState([999999, 0, 0]);
+
+    coordinateSpace.value = emptyInvalidCoordinateSpace;
+    coordinateSpace.value = xyzSpace;
+
+    expect(Array.from(position.value)).toEqual([999999, 0, 0]);
+    position.dispose();
+  });
+
+  it("infers a finite position for unbounded dimensions", () => {
+    const { coordinateSpace, position } = newPosition();
+    const unboundedSpace = makeSpace(
+      ["x", "y", "z"],
+      [1, 1, 1],
+      [
+        Number.POSITIVE_INFINITY,
+        Number.POSITIVE_INFINITY,
+        Number.POSITIVE_INFINITY,
+      ],
+      {
+        lowerBounds: [Number.NEGATIVE_INFINITY, Number.NEGATIVE_INFINITY, 0],
+      },
+    );
+    coordinateSpace.value = unboundedSpace;
+
+    for (const coordinate of position.value) {
+      expect(Number.isFinite(coordinate)).toBe(true);
+    }
+    expect(Array.from(position.value)).toEqual([0.5, 0.5, 0.5]);
+    position.dispose();
+  });
+
+  it("rounds to integer coordinates where the voxel centre is integral", () => {
+    const { coordinateSpace, position } = newPosition();
+    const mixedSpace = makeSpace(["x", "y", "z"], [1, 1, 1], [100, 100, 100], {
+      voxelCenterAtIntegerCoordinates: [true, false, true],
+    });
+    coordinateSpace.value = mixedSpace;
+    expect(Array.from(position.value)).toEqual([50, 50.5, 50]);
+    position.dispose();
+  });
+
+  it("still matches dimensions by id when the previous space stays valid", () => {
+    // The reordering path that never goes through an invalid space is
+    // unaffected: coordinates are remapped by dimension id.
+    const { coordinateSpace, position } = newPosition();
+    coordinateSpace.value = xyzSpace;
+    expect(Array.from(position.value)).toEqual([125000.5, 60000.5, 2500.5]);
+
+    coordinateSpace.value = zxySpace;
+
+    expectWithinBounds(zxySpace, position.value);
+    expect(Array.from(position.value)).toEqual([2500.5, 125000.5, 60000.5]);
+    position.dispose();
+  });
+
+  it("re-infers a snapped inferred position after a reorder", () => {
+    const { coordinateSpace, position } = newPosition();
+    coordinateSpace.value = xyzSpace;
+    position.snapToVoxel();
+
+    coordinateSpace.value = emptyInvalidCoordinateSpace;
+    coordinateSpace.value = zxySpace;
+
+    expectWithinBounds(zxySpace, position.value);
+    expect(Array.from(position.value)).toEqual([2500.5, 125000.5, 60000.5]);
+    position.dispose();
+  });
+
+  it("carries inferred-ness across assign", () => {
+    const source = newPosition();
+    source.coordinateSpace.value = xyzSpace;
+    expect(Array.from(source.position.value)).toEqual([
+      125000.5, 60000.5, 2500.5,
+    ]);
+
+    const target = newPosition();
+    target.position.assign(source.position);
+    expect(Array.from(target.position.value)).toEqual([
+      125000.5, 60000.5, 2500.5,
+    ]);
+
+    // The copied position was inferred, so it must be recomputed rather than
+    // reused when the target's space is replaced while invalid.
+    target.coordinateSpace.value = emptyInvalidCoordinateSpace;
+    target.coordinateSpace.value = zxySpace;
+
+    expectWithinBounds(zxySpace, target.position.value);
+    expect(Array.from(target.position.value)).toEqual([
+      2500.5, 125000.5, 60000.5,
+    ]);
+    source.position.dispose();
+    target.position.dispose();
+  });
+
+  it("carries explicitness across assign", () => {
+    const source = newPosition();
+    source.coordinateSpace.value = xyzSpace;
+    source.position.restoreState([1, 2, 3]);
+
+    const target = newPosition();
+    target.position.assign(source.position);
+
+    target.coordinateSpace.value = emptyInvalidCoordinateSpace;
+    target.coordinateSpace.value = xyzSpace;
+
+    expect(Array.from(target.position.value)).toEqual([1, 2, 3]);
+    source.position.dispose();
+    target.position.dispose();
   });
 });

--- a/src/navigation_state.spec.ts
+++ b/src/navigation_state.spec.ts
@@ -1,0 +1,144 @@
+/**
+ * @license
+ * Copyright 2026 Google Inc.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it } from "vitest";
+import type { CoordinateSpace } from "#src/coordinate_transform.js";
+import {
+  emptyInvalidCoordinateSpace,
+  makeCoordinateSpace,
+} from "#src/coordinate_transform.js";
+import { Position } from "#src/navigation_state.js";
+import { WatchableValue } from "#src/trackable_value.js";
+
+// Stable per-name dimension ids, so that a space listing the same dimensions in
+// a different order still refers to the same dimensions.
+const dimensionIds: { [name: string]: number } = { x: 1, y: 2, z: 3 };
+
+function makeSpace(
+  names: string[],
+  scales: number[],
+  upperBounds: number[],
+): CoordinateSpace {
+  const rank = names.length;
+  return makeCoordinateSpace({
+    names,
+    ids: names.map((name) => dimensionIds[name]),
+    units: names.map(() => "m"),
+    scales: Float64Array.from(scales),
+    bounds: {
+      lowerBounds: new Float64Array(rank),
+      upperBounds: Float64Array.from(upperBounds),
+      voxelCenterAtIntegerCoordinates: names.map(() => false),
+    },
+  });
+}
+
+// Bounds shaped like a typical EM volume: `x` and `y` are large, `z` is small.
+// The same volume, described with dimensions listed in two different orders.
+const xyzSpace = makeSpace(
+  ["x", "y", "z"],
+  [4e-9, 4e-9, 4e-8],
+  [250000, 120000, 5000],
+);
+const zxySpace = makeSpace(
+  ["z", "x", "y"],
+  [4e-8, 4e-9, 4e-9],
+  [5000, 250000, 120000],
+);
+
+function expectWithinBounds(space: CoordinateSpace, coordinates: Float32Array) {
+  const { lowerBounds, upperBounds } = space.bounds;
+  for (let i = 0; i < coordinates.length; ++i) {
+    expect(
+      coordinates[i],
+      `dimension ${space.names[i]} (index ${i}) out of bounds`,
+    ).toBeGreaterThanOrEqual(lowerBounds[i]);
+    expect(
+      coordinates[i],
+      `dimension ${space.names[i]} (index ${i}) out of bounds`,
+    ).toBeLessThanOrEqual(upperBounds[i]);
+  }
+}
+
+describe("Position", () => {
+  it("infers the default position as the centre of the bounds", () => {
+    const coordinateSpace = new WatchableValue<CoordinateSpace>(
+      emptyInvalidCoordinateSpace,
+    );
+    const position = new Position(coordinateSpace);
+    coordinateSpace.value = xyzSpace;
+    expect(Array.from(position.value)).toEqual([125000.5, 60000.5, 2500.5]);
+    position.dispose();
+  });
+
+  it("re-infers the default position when the coordinate space becomes valid again with a different dimension order", () => {
+    const coordinateSpace = new WatchableValue<CoordinateSpace>(
+      emptyInvalidCoordinateSpace,
+    );
+    const position = new Position(coordinateSpace);
+
+    // Initial load: the position is inferred as the centre of the bounds.
+    coordinateSpace.value = xyzSpace;
+    expect(Array.from(position.value)).toEqual([125000.5, 60000.5, 2500.5]);
+
+    // Resetting the viewer state leaves the coordinate space invalid while the
+    // data source is reloaded.
+    coordinateSpace.value = emptyInvalidCoordinateSpace;
+
+    // The same state is applied again, but this time the dimensions are listed
+    // in `z`, `x`, `y` order.  The previously inferred position refers to the
+    // old ordering and must not be carried over unchanged.
+    coordinateSpace.value = zxySpace;
+
+    expectWithinBounds(zxySpace, position.value);
+    expect(Array.from(position.value)).toEqual([2500.5, 125000.5, 60000.5]);
+    position.dispose();
+  });
+
+  it("keeps a position that was explicitly restored from JSON", () => {
+    const coordinateSpace = new WatchableValue<CoordinateSpace>(
+      emptyInvalidCoordinateSpace,
+    );
+    const position = new Position(coordinateSpace);
+    coordinateSpace.value = xyzSpace;
+
+    position.restoreState([1, 2, 3]);
+    expect(Array.from(position.value)).toEqual([1, 2, 3]);
+
+    // An explicit position must survive the coordinate space going invalid and
+    // valid again.
+    coordinateSpace.value = emptyInvalidCoordinateSpace;
+    coordinateSpace.value = xyzSpace;
+    expect(Array.from(position.value)).toEqual([1, 2, 3]);
+    position.dispose();
+  });
+
+  it("keeps a position that was explicitly assigned", () => {
+    const coordinateSpace = new WatchableValue<CoordinateSpace>(
+      emptyInvalidCoordinateSpace,
+    );
+    const position = new Position(coordinateSpace);
+    coordinateSpace.value = xyzSpace;
+
+    position.value = Float32Array.of(10, 20, 30);
+    expect(Array.from(position.value)).toEqual([10, 20, 30]);
+
+    coordinateSpace.value = emptyInvalidCoordinateSpace;
+    coordinateSpace.value = xyzSpace;
+    expect(Array.from(position.value)).toEqual([10, 20, 30]);
+    position.dispose();
+  });
+});

--- a/src/navigation_state.ts
+++ b/src/navigation_state.ts
@@ -169,12 +169,18 @@ function makeSimpleLinked<T extends RefCounted & { changed: NullarySignal }>(
 export class Position extends RefCounted {
   private coordinates_: Float32Array = vector.kEmptyFloat32Vec;
   private curCoordinateSpace: CoordinateSpace | undefined;
-  // Indicates that `coordinates_` was inferred from the bounds of
-  // `curCoordinateSpace` rather than specified explicitly.  Inferred
+  // The coordinates that were inferred from the bounds of `curCoordinateSpace`,
+  // or `undefined` if the coordinates were specified explicitly.  Inferred
   // coordinates are only meaningful for the coordinate space they were computed
   // from, and must be recomputed rather than reused if the coordinate space is
   // replaced while invalid.
-  private coordinatesAreDefault_ = false;
+  //
+  // This is a copy of the coordinates rather than a boolean flag because
+  // several callers, such as `NavigationState.translateVoxelsRelative`, move
+  // the position by writing into the array returned by `value` instead of going
+  // through the setter.  Comparing against the copy detects those moves as
+  // well.
+  private inferredCoordinates_: Float32Array | undefined;
   changed = new NullarySignal();
   constructor(
     public coordinateSpace: WatchableValueInterface<CoordinateSpace>,
@@ -202,8 +208,18 @@ export class Position extends RefCounted {
   reset() {
     this.curCoordinateSpace = undefined;
     this.coordinates_ = vector.kEmptyFloat32Vec;
-    this.coordinatesAreDefault_ = false;
+    this.inferredCoordinates_ = undefined;
     this.changed.dispatch();
+  }
+
+  // Returns `true` if the coordinates are still exactly the ones that were
+  // inferred from the bounds, i.e. the position has not been moved since.
+  private get coordinatesAreInferred() {
+    const { inferredCoordinates_ } = this;
+    return (
+      inferredCoordinates_ !== undefined &&
+      arraysEqual(inferredCoordinates_, this.coordinates_)
+    );
   }
 
   set value(coordinates: Float32Array) {
@@ -217,7 +233,7 @@ export class Position extends RefCounted {
     }
     const { coordinates_ } = this;
     coordinates_.set(coordinates);
-    this.coordinatesAreDefault_ = false;
+    this.inferredCoordinates_ = undefined;
     this.changed.dispatch();
   }
 
@@ -233,13 +249,13 @@ export class Position extends RefCounted {
       if (
         coordinates_ !== undefined &&
         coordinates_.length === rank &&
-        !this.coordinatesAreDefault_
+        !this.coordinatesAreInferred
       ) {
         // Use the existing voxel coordinates if they were specified explicitly
-        // and the rank is the same.  Otherwise, ignore.  Previously inferred
-        // coordinates cannot be reused, since the dimensions of the new
-        // coordinate space may be ordered differently, which would leave the
-        // position outside the bounds.
+        // and the rank is the same.  Otherwise, ignore.  Coordinates that are
+        // still exactly as inferred cannot be reused, since the dimensions of
+        // the new coordinate space may be ordered differently, which would
+        // leave the position outside the bounds.
       } else {
         coordinates_ = this.coordinates_ = new Float32Array(rank);
         getBoundingBoxCenter(coordinates_, coordinateSpace.bounds);
@@ -251,12 +267,13 @@ export class Position extends RefCounted {
             coordinates_[i] = Math.floor(coordinates_[i]) + 0.5;
           }
         }
-        this.coordinatesAreDefault_ = true;
+        this.inferredCoordinates_ = Float32Array.from(coordinates_);
       }
       this.changed.dispatch();
       return;
     }
     // Match dimensions by ID.
+    const wasInferred = this.coordinatesAreInferred;
     const newCoordinates = new Float32Array(rank);
     const prevCoordinates = this.coordinates_;
     const { ids, scales: newScales } = coordinateSpace;
@@ -275,6 +292,11 @@ export class Position extends RefCounted {
       }
     }
     this.coordinates_ = newCoordinates;
+    // Remapping does not count as moving the position, so coordinates that were
+    // still exactly as inferred remain so for the new coordinate space.
+    this.inferredCoordinates_ = wasInferred
+      ? Float32Array.from(newCoordinates)
+      : undefined;
     this.changed.dispatch();
   }
 
@@ -293,7 +315,7 @@ export class Position extends RefCounted {
     }
     this.curCoordinateSpace = undefined;
     this.coordinates_ = Float32Array.from(parseArray(obj, verifyFiniteFloat));
-    this.coordinatesAreDefault_ = false;
+    this.inferredCoordinates_ = undefined;
     this.handleCoordinateSpaceChanged();
     this.changed.dispatch();
   }
@@ -317,10 +339,13 @@ export class Position extends RefCounted {
 
   assign(other: Borrowed<Position>) {
     other.handleCoordinateSpaceChanged();
-    const { curCoordinateSpace, coordinates_, coordinatesAreDefault_ } = other;
+    const { curCoordinateSpace, coordinates_, inferredCoordinates_ } = other;
     this.curCoordinateSpace = curCoordinateSpace;
     this.coordinates_ = Float32Array.from(coordinates_);
-    this.coordinatesAreDefault_ = coordinatesAreDefault_;
+    this.inferredCoordinates_ =
+      inferredCoordinates_ === undefined
+        ? undefined
+        : Float32Array.from(inferredCoordinates_);
     this.changed.dispatch();
   }
 

--- a/src/navigation_state.ts
+++ b/src/navigation_state.ts
@@ -169,6 +169,12 @@ function makeSimpleLinked<T extends RefCounted & { changed: NullarySignal }>(
 export class Position extends RefCounted {
   private coordinates_: Float32Array = vector.kEmptyFloat32Vec;
   private curCoordinateSpace: CoordinateSpace | undefined;
+  // Indicates that `coordinates_` was inferred from the bounds of
+  // `curCoordinateSpace` rather than specified explicitly.  Inferred
+  // coordinates are only meaningful for the coordinate space they were computed
+  // from, and must be recomputed rather than reused if the coordinate space is
+  // replaced while invalid.
+  private coordinatesAreDefault_ = false;
   changed = new NullarySignal();
   constructor(
     public coordinateSpace: WatchableValueInterface<CoordinateSpace>,
@@ -196,6 +202,7 @@ export class Position extends RefCounted {
   reset() {
     this.curCoordinateSpace = undefined;
     this.coordinates_ = vector.kEmptyFloat32Vec;
+    this.coordinatesAreDefault_ = false;
     this.changed.dispatch();
   }
 
@@ -210,6 +217,7 @@ export class Position extends RefCounted {
     }
     const { coordinates_ } = this;
     coordinates_.set(coordinates);
+    this.coordinatesAreDefault_ = false;
     this.changed.dispatch();
   }
 
@@ -222,8 +230,16 @@ export class Position extends RefCounted {
     if (!coordinateSpace.valid) return;
     if (prevCoordinateSpace === undefined || !prevCoordinateSpace.valid) {
       let { coordinates_ } = this;
-      if (coordinates_ !== undefined && coordinates_.length === rank) {
-        // Use the existing voxel coordinates if rank is the same.  Otherwise, ignore.
+      if (
+        coordinates_ !== undefined &&
+        coordinates_.length === rank &&
+        !this.coordinatesAreDefault_
+      ) {
+        // Use the existing voxel coordinates if they were specified explicitly
+        // and the rank is the same.  Otherwise, ignore.  Previously inferred
+        // coordinates cannot be reused, since the dimensions of the new
+        // coordinate space may be ordered differently, which would leave the
+        // position outside the bounds.
       } else {
         coordinates_ = this.coordinates_ = new Float32Array(rank);
         getBoundingBoxCenter(coordinates_, coordinateSpace.bounds);
@@ -235,6 +251,7 @@ export class Position extends RefCounted {
             coordinates_[i] = Math.floor(coordinates_[i]) + 0.5;
           }
         }
+        this.coordinatesAreDefault_ = true;
       }
       this.changed.dispatch();
       return;
@@ -276,6 +293,7 @@ export class Position extends RefCounted {
     }
     this.curCoordinateSpace = undefined;
     this.coordinates_ = Float32Array.from(parseArray(obj, verifyFiniteFloat));
+    this.coordinatesAreDefault_ = false;
     this.handleCoordinateSpaceChanged();
     this.changed.dispatch();
   }
@@ -299,9 +317,10 @@ export class Position extends RefCounted {
 
   assign(other: Borrowed<Position>) {
     other.handleCoordinateSpaceChanged();
-    const { curCoordinateSpace, coordinates_ } = other;
+    const { curCoordinateSpace, coordinates_, coordinatesAreDefault_ } = other;
     this.curCoordinateSpace = curCoordinateSpace;
     this.coordinates_ = Float32Array.from(coordinates_);
+    this.coordinatesAreDefault_ = coordinatesAreDefault_;
     this.changed.dispatch();
   }
 

--- a/src/navigation_state.ts
+++ b/src/navigation_state.ts
@@ -176,10 +176,11 @@ export class Position extends RefCounted {
   // replaced while invalid.
   //
   // This is a copy of the coordinates rather than a boolean flag because
-  // several callers, such as `NavigationState.translateVoxelsRelative`, move
-  // the position by writing into the array returned by `value` instead of going
-  // through the setter.  Comparing against the copy detects those moves as
-  // well.
+  // several callers move the position by writing into the array returned by
+  // `value` instead of going through the setter.  Those callers report the move
+  // via `markMoved`, but comparing against the copy means that a caller which
+  // does not report one is still detected, and errs towards keeping the
+  // position rather than discarding it.
   private inferredCoordinates_: Float32Array | undefined;
   changed = new NullarySignal();
   constructor(
@@ -210,6 +211,17 @@ export class Position extends RefCounted {
     this.coordinates_ = vector.kEmptyFloat32Vec;
     this.inferredCoordinates_ = undefined;
     this.changed.dispatch();
+  }
+
+  /**
+   * Records that the position has been moved by a caller that writes into the
+   * array returned by `value` rather than going through the setter, so that a
+   * move which happens to land back on the inferred coordinates is still
+   * treated as a position the user chose.  Call this only when a coordinate
+   * actually changed.
+   */
+  markMoved() {
+    this.inferredCoordinates_ = undefined;
   }
 
   // Returns `true` if the coordinates are still exactly the ones that were
@@ -327,13 +339,17 @@ export class Position extends RefCounted {
     } = this.coordinateSpace.value;
     const { coordinates_ } = this;
     const rank = coordinates_.length;
+    let moved = false;
     for (let i = 0; i < rank; ++i) {
+      const previousCoordinate = coordinates_[i];
       if (voxelCenterAtIntegerCoordinates[i]) {
         coordinates_[i] = Math.round(coordinates_[i]);
       } else {
         coordinates_[i] = Math.floor(coordinates_[i]) + 0.5;
       }
+      if (coordinates_[i] !== previousCoordinate) moved = true;
     }
+    if (moved) this.markMoved();
     this.changed.dispatch();
   }
 
@@ -374,7 +390,15 @@ export class Position extends RefCounted {
     target.handleCoordinateSpaceChanged();
     const { value: sourceCoordinates } = source;
     if (offset !== undefined && sourceCoordinates.length === offset.length) {
-      vector.scaleAndAdd(target.value, sourceCoordinates, offset, scale);
+      const targetCoordinates = target.value;
+      const rank = targetCoordinates.length;
+      let moved = false;
+      for (let i = 0; i < rank; ++i) {
+        const previousCoordinate = targetCoordinates[i];
+        targetCoordinates[i] = sourceCoordinates[i] + offset[i] * scale;
+        if (targetCoordinates[i] !== previousCoordinate) moved = true;
+      }
+      if (moved) target.markMoved();
       target.changed.dispatch();
     }
   }
@@ -857,6 +881,7 @@ export class PlaybackManager extends RefCounted {
     const ids = coordinateSpace.ids;
     const positionVector = this.position.value;
     let positionChanged = false;
+    let positionMoved = false;
     let velocityChanged = false;
     const curTime = Date.now();
     const velocities = this.velocity.value;
@@ -914,12 +939,17 @@ export class PlaybackManager extends RefCounted {
             break;
         }
       }
+      const previousCoordinate = positionVector[dimensionIndex];
       positionVector[dimensionIndex] = newCoordinate;
+      if (positionVector[dimensionIndex] !== previousCoordinate) {
+        positionMoved = true;
+      }
       dimensionState.prevCoordinate = positionVector[dimensionIndex];
       dimensionState.prevTime = curTime;
       positionChanged = true;
     }
     if (positionChanged) {
+      if (positionMoved) this.position.markMoved();
       this.position.changed.dispatch();
     }
     if (velocityChanged) {
@@ -1793,10 +1823,14 @@ export class DisplayPose extends RefCounted {
       temp[i] = voxelCoordinates[dim];
     }
     if (fun(temp) !== false) {
+      let moved = false;
       for (let i = 0; i < displayRank; ++i) {
         const dim = displayDimensionIndices[i];
+        const prevCoordinate = voxelCoordinates[dim];
         voxelCoordinates[dim] = temp[i];
+        if (voxelCoordinates[dim] !== prevCoordinate) moved = true;
       }
+      if (moved) this.position.markMoved();
       this.position.changed.dispatch();
       return true;
     }
@@ -1848,11 +1882,15 @@ export class DisplayPose extends RefCounted {
     const { position } = this;
     const { value: voxelCoordinates } = position;
     const { bounds } = position.coordinateSpace.value;
+    const prevCoordinate = voxelCoordinates[dimensionIndex];
     voxelCoordinates[dimensionIndex] = clampAndRoundCoordinateToVoxelCenter(
       bounds,
       dimensionIndex,
-      voxelCoordinates[dimensionIndex] + adjustment,
+      prevCoordinate + adjustment,
     );
+    if (voxelCoordinates[dimensionIndex] !== prevCoordinate) {
+      position.markMoved();
+    }
     position.changed.dispatch();
   }
 
@@ -1870,16 +1908,20 @@ export class DisplayPose extends RefCounted {
     const { displayDimensionIndices, displayRank } =
       this.displayDimensions.value;
     const { bounds } = position.coordinateSpace.value;
+    let moved = false;
     for (let i = 0; i < displayRank; ++i) {
       const dim = displayDimensionIndices[i];
       const adjustment = temp[i];
       if (adjustment === 0) continue;
+      const prevCoordinate = voxelCoordinates[dim];
       voxelCoordinates[dim] = clampAndRoundCoordinateToVoxelCenter(
         bounds,
         dim,
-        voxelCoordinates[dim] + adjustment,
+        prevCoordinate + adjustment,
       );
+      if (voxelCoordinates[dim] !== prevCoordinate) moved = true;
     }
+    if (moved) this.position.markMoved();
     this.position.changed.dispatch();
   }
 
@@ -1934,12 +1976,16 @@ export class DisplayPose extends RefCounted {
     quat.multiply(orientation, temp, orientation);
     vec3.transformQuat(fixedPointLocal, fixedPointLocal, orientation);
 
+    let moved = false;
     for (let i = 0; i < displayRank; ++i) {
       const dim = displayDimensionIndices[i];
+      const prevCoordinate = voxelCoordinates[dim];
       voxelCoordinates[dim] =
         fixedPoint[dim] -
         fixedPointLocal[i] / (scales[dim] * relativeDisplayScales[dim]);
+      if (voxelCoordinates[dim] !== prevCoordinate) moved = true;
     }
+    if (moved) this.position.markMoved();
     this.position.changed.dispatch();
     this.orientation.changed.dispatch();
   }

--- a/src/sliceview/panel.ts
+++ b/src/sliceview/panel.ts
@@ -557,11 +557,15 @@ export class SliceViewPanel extends RenderedDataPanel {
     // invViewMatrixLinear * factor * [mouseX, mouseY, 0]^T + [newX, newY, newZ]^T
 
     const position = this.navigationState.position.value;
+    let moved = false;
     for (let i = 0; i < displayRank; ++i) {
       const dim = displayDimensionIndices[i];
       const f = invViewMatrix[i] * mouseX + invViewMatrix[4 + i] * mouseY;
+      const previousCoordinate = position[dim];
       position[dim] += f * (1 - factor);
+      if (position[dim] !== previousCoordinate) moved = true;
     }
+    if (moved) this.navigationState.position.markMoved();
     this.navigationState.position.changed.dispatch();
     navigationState.zoomBy(factor);
   }

--- a/src/ui/position_drag_and_drop.spec.ts
+++ b/src/ui/position_drag_and_drop.spec.ts
@@ -1,0 +1,130 @@
+/**
+ * @license
+ * Copyright 2026 Google Inc.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it } from "vitest";
+import type { CoordinateSpace } from "#src/coordinate_transform.js";
+import {
+  emptyInvalidCoordinateSpace,
+  makeCoordinateSpace,
+} from "#src/coordinate_transform.js";
+import { Position } from "#src/navigation_state.js";
+import { WatchableValue } from "#src/trackable_value.js";
+import { setupPositionDropHandlers } from "#src/ui/position_drag_and_drop.js";
+import { positionDragType } from "#src/widget/position_widget.js";
+
+function makeSpace(names: string[], upperBounds: number[]): CoordinateSpace {
+  return makeCoordinateSpace({
+    names,
+    ids: names.map((_, i) => i + 1),
+    units: names.map(() => "m"),
+    scales: Float64Array.from(names.map(() => 1e-9)),
+    bounds: {
+      lowerBounds: new Float64Array(names.length),
+      upperBounds: Float64Array.from(upperBounds),
+      voxelCenterAtIntegerCoordinates: names.map(() => false),
+    },
+  });
+}
+
+const xyzSpace = makeSpace(["x", "y", "z"], [1000, 800, 600]);
+const xyzLargerSpace = makeSpace(["x", "y", "z"], [2000, 1600, 1200]);
+const XYZ_CENTRE = [500.5, 400.5, 300.5];
+const XYZ_LARGER_CENTRE = [1000.5, 800.5, 600.5];
+
+function setup() {
+  const coordinateSpace = new WatchableValue<CoordinateSpace>(
+    emptyInvalidCoordinateSpace,
+  );
+  const position = new Position(coordinateSpace);
+  coordinateSpace.value = xyzSpace;
+  const target = new EventTarget();
+  const disposer = setupPositionDropHandlers(target, position);
+  return { coordinateSpace, position, target, disposer };
+}
+
+// Dispatches a "drop" event carrying a position payload, the way dragging a
+// position link onto a viewer does.
+function dropPosition(
+  target: EventTarget,
+  dimensions: string[],
+  coordinates: number[],
+) {
+  const event = Object.assign(new Event("drop", { cancelable: true }), {
+    dataTransfer: {
+      types: [positionDragType],
+      getData: (type: string) =>
+        type === positionDragType
+          ? JSON.stringify({ dimensions, position: coordinates })
+          : "",
+    },
+  });
+  target.dispatchEvent(event);
+}
+
+describe("position drag-and-drop", () => {
+  it("applies a dropped position and keeps it", () => {
+    const { coordinateSpace, position, target, disposer } = setup();
+    dropPosition(target, ["x", "y", "z"], [111, 222, 333]);
+    expect(Array.from(position.value)).toEqual([111, 222, 333]);
+
+    coordinateSpace.value = emptyInvalidCoordinateSpace;
+    coordinateSpace.value = xyzLargerSpace;
+
+    expect(Array.from(position.value)).toEqual([111, 222, 333]);
+    disposer();
+    position.dispose();
+  });
+
+  it("keeps a position dropped away and back onto the inferred coordinates", () => {
+    const { coordinateSpace, position, target, disposer } = setup();
+    dropPosition(target, ["x", "y", "z"], [111, 222, 333]);
+    dropPosition(target, ["x", "y", "z"], XYZ_CENTRE);
+    expect(Array.from(position.value)).toEqual(XYZ_CENTRE);
+
+    coordinateSpace.value = emptyInvalidCoordinateSpace;
+    coordinateSpace.value = xyzLargerSpace;
+
+    // The user chose the position, even though it matches the inferred one.
+    expect(Array.from(position.value)).toEqual(XYZ_CENTRE);
+    disposer();
+    position.dispose();
+  });
+
+  it("does not count a drop that changes nothing as a move", () => {
+    const { coordinateSpace, position, target, disposer } = setup();
+    dropPosition(target, ["x", "y", "z"], XYZ_CENTRE);
+
+    coordinateSpace.value = emptyInvalidCoordinateSpace;
+    coordinateSpace.value = xyzLargerSpace;
+
+    expect(Array.from(position.value)).toEqual(XYZ_LARGER_CENTRE);
+    disposer();
+    position.dispose();
+  });
+
+  it("applies only the dimensions present in the coordinate space", () => {
+    const { coordinateSpace, position, target, disposer } = setup();
+    dropPosition(target, ["q", "z"], [7, 42]);
+    expect(Array.from(position.value)).toEqual([500.5, 400.5, 42]);
+
+    coordinateSpace.value = emptyInvalidCoordinateSpace;
+    coordinateSpace.value = xyzLargerSpace;
+
+    expect(Array.from(position.value)).toEqual([500.5, 400.5, 42]);
+    disposer();
+    position.dispose();
+  });
+});

--- a/src/ui/position_drag_and_drop.ts
+++ b/src/ui/position_drag_and_drop.ts
@@ -60,11 +60,15 @@ export function setupPositionDropHandlers(
           },
           value: coordinates,
         } = position;
+        let moved = false;
         for (let i = 0; i < rank; ++i) {
           const dim = names.indexOf(dimensions[i]);
           if (dim === -1) continue;
+          const previousCoordinate = coordinates[dim];
           coordinates[dim] = positionVec[i];
+          if (coordinates[dim] !== previousCoordinate) moved = true;
         }
+        if (moved) position.markMoved();
         position.changed.dispatch();
       }
     },

--- a/src/widget/layer_control_channel_invlerp.ts
+++ b/src/widget/layer_control_channel_invlerp.ts
@@ -78,8 +78,9 @@ export function channelInvlerpLayerControl<LayerType extends UserLayer>(
           const value = position.value;
           const params = watchableValue.value;
           if (!arraysEqual(value, params.channel)) {
-            value.set(params.channel);
-            position.changed.dispatch();
+            // Assign through the setter so that the coordinates count as
+            // explicitly specified.
+            position.value = Float32Array.from(params.channel);
           }
         };
         updatePosition();

--- a/src/widget/transfer_function.ts
+++ b/src/widget/transfer_function.ts
@@ -1978,8 +1978,9 @@ export function transferFunctionLayerControl<LayerType extends UserLayer>(
           const value = position.value;
           const params = watchableValue.value;
           if (!arraysEqual(params.channel, value)) {
-            value.set(params.channel);
-            position.changed.dispatch();
+            // Assign through the setter so that the coordinates count as
+            // explicitly specified.
+            position.value = Float32Array.from(params.channel);
           }
         };
         updatePosition();


### PR DESCRIPTION
### What this does

When you load a saved view that has no position saved in it, Neuroglancer picks a sensible starting point for you — the middle of the data. This makes sure it works that out fresh for the view you're actually loading, instead of reusing the one it picked for the previous view.

### Why

If the new view lists its dimensions in a different order than the old one (say `z, x, y` instead of `x, y, z`), the old starting point gets applied to the wrong axes. You end up far outside the data, looking at an empty screen. That's what #885 reports — it shows up the second time you press apply in the JSON state editor, because the first apply leaves a position behind.

### What changed


<img width="1485" height="812" alt="01-master-apply1-loading" src="https://github.com/user-attachments/assets/a9cc1ee4-e2f2-4c26-a8c6-98a0e79e1e1c" />
<img width="1485" height="812" alt="02-master-apply1-CORRECT" src="https://github.com/user-attachments/assets/76a72b76-70df-426e-9e3d-33cfe20ad436" />
<img width="1485" height="812" alt="03-master-apply2-BROKEN-z-out-of-bounds" src="https://github.com/user-attachments/assets/ede95371-6a9d-4056-b609-2658465cfc10" />
<img width="1538" height="784" alt="04-fixed-apply1-loading" src="https://github.com/user-attachments/assets/3c324fcd-793c-46ce-96bc-08a6bf833f49" />
<img width="1538" height="784" alt="05-fixed-apply1-CORRECT" src="https://github.com/user-attachments/assets/63bfec74-3c68-4bf8-a422-7030a3d3ab11" />
<img width="1538" height="784" alt="06-fixed-apply2-STILL-CORRECT" src="https://github.com/user-attachments/assets/6ad21cf9-ecb9-49fc-8a9e-905f38bd6faa" />



- Neuroglancer now keeps track of which starting points it worked out for you, versus which ones you chose yourself — by saving them in a link, or by panning and zooming.
- Positions you chose are always kept, exactly as before, including ones deliberately outside the data.
- Only the automatically-chosen ones get recalculated when a view is reloaded.
- Added 17 tests: the reported case, plus edge cases for reordering, rank changes, panning, unbounded dimensions, and rounding.

### How to see it

Run `npm run dev-server`, open the viewer, and in the browser console apply the state from #885 twice:

```javascript
viewer.state.restoreState(state);              // loads correctly
viewer.state.reset(); viewer.state.restoreState(state);   // the second apply
```

Checked against the dataset in the issue (`fafb_v14`, bounds `z: 7063`, `x: 248832`, `y: 134144`):

- **Before:** position `[124416.5, 67072.5, 3531.5]` — `z` is `124416.5` against a `z` limit of `7063`. Outside the data, blank panels.
- **After:** position `[3531.5, 124416.5, 67072.5]` — inside the data.

### Note for reviewers

This tracks a *copy* of the inferred coordinates rather than a boolean flag, because several callers move the position by writing into the array returned by `position.value` and dispatching `changed` directly, never going through the setter — `NavigationState.translateVoxelsRelative` and the slice-view zoom-at-mouse handler in `src/sliceview/panel.ts`. A flag would go stale on pan or zoom and silently discard the move.

There is a plausible alternative I'd be glad to switch to if you prefer it: remember the last *valid* coordinate space and remap by dimension id across the invalid gap. That would carry a panned position through a reorder rather than re-centring it.

Fixes #885
