### PR TITLE
docs: fix segment selection in demo notebook

### DIFF
--- a/python/examples/jupyter-notebook-demo.ipynb
+++ b/python/examples/jupyter-notebook-demo.ipynb
@@ -167,7 +167,7 @@
    "outputs": [],
    "source": [
     "with viewer.txn() as s:\n",
-    "    s.layers['segmentation'].segments.update([1752, 88847])\n",
+    "    s.layers['segmentation'].segments |= [1752, 88847]\n",
     "    s.layers['segmentation'].visible = True"
    ]
   },


### PR DESCRIPTION
Fixes #609

**What this does**

Fixes one broken line in the Jupyter notebook demo.

**Why**

The "Select a couple segments" cell called `segments.update([...])`. That stopped working when `layer.segments` became a set-like view of the starred segments, so running the cell raised `AttributeError: 'VisibleSegments' object has no attribute 'update'`.

**What changed**

- One line: `segments.update([1752, 88847])` becomes `segments |= [1752, 88847]`, which the set view does support and which accepts any iterable.

`update` itself still exists on `StarredSegments`, if starring rather than selecting is what is wanted.

**How to see it**

Run the notebook. The cell now selects the two segments instead of raising an error. This was the only stale call in the notebook — the later `segments.add` cell is still correct.