### PR TITLE
fix(drag_and_drop): Fix drag and drop issues under Wayland

### DIFF
--- a/src/util/drag_and_drop.ts
+++ b/src/util/drag_and_drop.ts
@@ -81,6 +81,29 @@ export function decodeParametersFromDragTypeList(
 
 let savedDropEffect: DataTransfer["dropEffect"] | undefined;
 
+// Chrome on Wayland seems to report an `effectAllowed` of `copyMove` regardless
+// of what the dragstart handler sets.  Convert the actual drop effect to an
+// allowed value to avoid Chrome rejecting the drop.  The actual drop effect is
+// still stored separately by `setDropEffect` to ensure the correct drop action
+// is performed.
+function getAllowedDropEffect(
+  effectAllowed: string,
+  dropEffect: string,
+): string {
+  if (effectAllowed == dropEffect) return dropEffect;
+  switch (effectAllowed) {
+    case "all":
+      return dropEffect;
+    case "copyMove":
+      return dropEffect == "copy" || dropEffect == "move" ? dropEffect : "copy";
+    case "copyLink":
+      return dropEffect == "copy" || dropEffect == "link" ? dropEffect : "copy";
+    case "linkMove":
+      return dropEffect == "link" || dropEffect == "move" ? dropEffect : "link";
+  }
+  return effectAllowed;
+}
+
 /**
  * On Chrome 62, the dataTransfer.dropEffect property is reset to 'none' when the 'drop' event is
  * dispatched.  As a workaround, we store it in a global variable.
@@ -93,7 +116,10 @@ export function setDropEffect<T extends DataTransfer["dropEffect"]>(
   event: DragEvent,
   dropEffect: T,
 ) {
-  event.dataTransfer!.dropEffect = dropEffect;
+  event.dataTransfer!.dropEffect = getAllowedDropEffect(
+    event.dataTransfer!.effectAllowed,
+    dropEffect,
+  ) as any;
   savedDropEffect = dropEffect;
   return dropEffect;
 }
@@ -110,28 +136,112 @@ export function preventDrag(element: HTMLElement) {
   });
 }
 
+// False except on Wayland.
+let mustRestartDragToChangeModifiers = false;
+
+// When `modifiersReportedDuringDrag == false`, this stores the initial
+// modifiers reported to the `dragstart` handler.
+let savedModifiers:
+  | {
+      shiftKey: boolean;
+      ctrlKey: boolean;
+      altKey: boolean;
+      metaKey: boolean;
+    }
+  | undefined = undefined;
+
+// Apply Linux Wayland-specific workarounds.
+if (
+  navigator.platform.startsWith("Linux ") &&
+  !navigator.userAgent.includes("CrOs") &&
+  !navigator.userAgent.includes("Android") &&
+  // On Wayland, screenX and screenY are always reported as 0.  However, this
+  // does not definitively rule out X11.
+  window.screenX === 0 &&
+  window.screenY === 0
+) {
+  // On Linux under Wayland, Chrome does not report any modifier keys after the
+  // initial `dragstart` event, while Firefox saves the modifier keys that were
+  // held during `dragstart` and continues to report them on all drag-related
+  // events, even if the user releases the modifiers.
+  //
+  // We will emulate the and Firefox do not report modifier keys
+  // during drag operations due to Wayland limitations, only on the initial
+  // dragstart event.  There is no way to directly detect Wayland vs X11 but we
+  // on Chrome can check if any modifiers have been observed in drag events other than
+  // `dragstart`.
+  mustRestartDragToChangeModifiers = true;
+
+  if (navigator.userAgent.includes("Chrome")) {
+    // Under Chrome, effectively emulate the Firefox behavior by storing the
+    // modifiers that are reported to `dragstart` and make them available.
+    //
+    // Additionally, if any modifier is reported to a drag event other than
+    // `dragstart`, the platform must not be Wayland and the workaround and
+    // warning can be disabled.
+    const eventTypes = [
+      "dragstart",
+      "dragend",
+      "drag",
+      "dragenter",
+      "dragover",
+      "dragleave",
+    ];
+    function dragHandler(event: DragEvent) {
+      if (event.type == "dragstart") {
+        savedModifiers = {
+          shiftKey: event.shiftKey,
+          altKey: event.altKey,
+          ctrlKey: event.ctrlKey,
+          metaKey: event.metaKey,
+        };
+      } else if (event.type == "dragend") {
+        savedModifiers = undefined;
+      } else if (
+        event.ctrlKey ||
+        event.altKey ||
+        event.shiftKey ||
+        event.metaKey
+      ) {
+        // Non-Wayland platform detected, disable workaround.
+        savedModifiers = undefined;
+        mustRestartDragToChangeModifiers = false;
+        for (const eventType of eventTypes) {
+          window.removeEventListener(eventType, dragHandler, { capture: true });
+        }
+      }
+    }
+    for (const eventType of eventTypes) {
+      window.addEventListener(eventType, dragHandler, { capture: true });
+    }
+  }
+}
+
 export function getDropEffectFromModifiers<DropEffect extends string>(
   event: DragEvent,
   defaultDropEffect: DropEffect,
   moveAllowed: boolean,
 ): { dropEffect: DropEffect | "move" | "copy"; dropEffectMessage: string } {
+  const modifiers = savedModifiers ?? event;
   let dropEffect: DropEffect | "move" | "copy";
-  if (event.shiftKey) {
+  if (modifiers.shiftKey) {
     dropEffect = "copy";
-  } else if (event.ctrlKey && moveAllowed) {
+  } else if (modifiers.ctrlKey && moveAllowed) {
     dropEffect = "move";
   } else {
     dropEffect = defaultDropEffect;
   }
   let message = "";
   const addMessage = (msg: string) => {
-    if (message !== "") {
+    if (message === "" && mustRestartDragToChangeModifiers) {
+      message = "restart drag and ";
+    } else if (message !== "") {
       message += ", ";
     }
     message += msg;
   };
   if (defaultDropEffect !== "none" && dropEffect !== defaultDropEffect) {
-    if (event.shiftKey) {
+    if (modifiers.shiftKey) {
       addMessage(`release SHIFT to ${defaultDropEffect}`);
     } else {
       addMessage(`release CONTROL to ${defaultDropEffect}`);
@@ -142,6 +252,11 @@ export function getDropEffectFromModifiers<DropEffect extends string>(
   }
   if (dropEffect !== "move" && moveAllowed && defaultDropEffect !== "move") {
     addMessage("hold CONTROL to move");
+  }
+
+  if (message !== "" && mustRestartDragToChangeModifiers) {
+    message +=
+      "; due to Wayland limitation, modifier keys cannot be changed during drag";
   }
   return { dropEffect, dropEffectMessage: message };
 }


### PR DESCRIPTION
Under Wayland, neither Firefox nor Chrome report changes to modifier keys during
drag events.  Chrome reports modifiers for the initial `dragstart` event and no
modifiers for the subsequent events (https://issues.chromium.org/issues/40138974).
Firefox saves the modifiers that were pressed during the initial `dragstart` and
continues to report the same modifiers for all subsequent events.

Previously, Neuroglancer determined the drop effect based on the modifier keys
reported to the `dragover` event, and under Linux Wayland on Chrome no modifiers
are ever reported.  With this change, the Firefox behavior under Wayland is
essentially emulated on Chrome: the modifiers reported to `dragstart` are saved
and apply throughout the drag event (even if the user later releases them).

This commit also updates the drag status message to indicate the
Wayland-specific limitations when Wayland is detected.

Additionally, Chrome under Wayland sets `effectAllowed` to `copyMove` rather
than `all` by default.  Previously, in cases such as dropping a layer onto a
drop zone in order to create a new layer group, Neuroglancer selected a default
dropEffect of `link`, which led to the drop being rejected by Chrome.  This
commit fixes that problem by reporting a fake dropEffect, if necessary, to
ensure it is one of the values allowed by `effectAllowed`.  Regardless of the
reported drop effect, the correct drop operation is still performed.