### PR TITLE
Synchronized cross-section hover cursor + move-layers-between-panels   by dragging

### DIFF
--- a/docs/json_schema/viewer_state.yml
+++ b/docs/json_schema/viewer_state.yml
@@ -41,6 +41,12 @@ properties:
     type: boolean
     title: "Indicates whether to show the red/green/blue axis lines."
     default: true
+  showCrossSectionHoverPosition:
+    type: boolean
+    title: |
+      Indicates whether to show the position hovered in one cross-section panel
+      as a marker in the other cross-section panels.
+    default: false
   wireFrame:
     type: boolean
     title: "Indicates whether to enable wireframe rendering mode (for debugging)."

--- a/python/neuroglancer/viewer_state.py
+++ b/python/neuroglancer/viewer_state.py
@@ -1927,6 +1927,9 @@ class ViewerState(JsonObjectWrapper):
     show_axis_lines = showAxisLines = wrapped_property(
         "showAxisLines", optional(bool, True)
     )
+    show_cross_section_hover_position = showCrossSectionHoverPosition = (
+        wrapped_property("showCrossSectionHoverPosition", optional(bool, False))
+    )
     wire_frame = wireFrame = wrapped_property("wireFrame", optional(bool, False))
     enable_adaptive_downsampling = enableAdaptiveDownsampling = wrapped_property(
         "enableAdaptiveDownsampling", optional(bool, True)

--- a/src/data_panel_layout.ts
+++ b/src/data_panel_layout.ts
@@ -91,6 +91,7 @@ export interface ViewerUIState
   selectionDetailsState: TrackableDataSelectionState;
   showPerspectiveSliceViews: TrackableBoolean;
   showAxisLines: TrackableBoolean;
+  showCrossSectionHoverPosition: TrackableBoolean;
   wireFrame: TrackableBoolean;
   enableAdaptiveDownsampling: TrackableBoolean;
   showScaleBar: TrackableBoolean;
@@ -177,6 +178,7 @@ export function getCommonViewerState(viewer: ViewerUIState) {
     mouseState: viewer.mouseState,
     layerManager: viewer.layerManager,
     showAxisLines: viewer.showAxisLines,
+    showCrossSectionHoverPosition: viewer.showCrossSectionHoverPosition,
     wireFrame: viewer.wireFrame,
     enableAdaptiveDownsampling: viewer.enableAdaptiveDownsampling,
     visibleLayerRoles: viewer.visibleLayerRoles,

--- a/src/hover_position_marker.spec.ts
+++ b/src/hover_position_marker.spec.ts
@@ -1,0 +1,183 @@
+/**
+ * @license
+ * Copyright 2024 Google Inc.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, it, expect } from "vitest";
+import type { ProjectionParameters } from "#src/projection_parameters.js";
+import {
+  computeHoverMarkerMatrix,
+  crossSectionHoverMarkerAlpha,
+  shouldDrawCrossSectionHoverMarker,
+} from "#src/hover_position_marker.js";
+import { mat4 } from "#src/util/geom.js";
+
+describe("shouldDrawCrossSectionHoverMarker", () => {
+  // The marker echoes the position hovered in one panel into the *other*
+  // cross-section panels.  It is therefore drawn only in a panel that does not
+  // hold the cursor -- which never happens with a single panel, and only happens
+  // once panels are shown side by side.
+
+  it("is not drawn in a single panel (cursor always in the only panel)", () => {
+    // Single panel: whenever the cursor is active it is in this (the only)
+    // panel, so `mouseInThisPanel` is true and nothing is echoed.
+    expect(
+      shouldDrawCrossSectionHoverMarker({
+        enabled: true,
+        mouseActive: true,
+        mouseInThisPanel: true,
+      }),
+    ).toBe(false);
+  });
+
+  it("is drawn in a side-by-side panel that does not hold the cursor", () => {
+    // Two (or more) panels side by side: the panel the cursor is NOT over echoes
+    // the hovered position.
+    expect(
+      shouldDrawCrossSectionHoverMarker({
+        enabled: true,
+        mouseActive: true,
+        mouseInThisPanel: false,
+      }),
+    ).toBe(true);
+  });
+
+  it("is not drawn in the side-by-side panel that holds the cursor", () => {
+    expect(
+      shouldDrawCrossSectionHoverMarker({
+        enabled: true,
+        mouseActive: true,
+        mouseInThisPanel: true,
+      }),
+    ).toBe(false);
+  });
+
+  it("is not drawn when the feature is toggled off", () => {
+    // Even side by side with the cursor in another panel, the toggle gates it.
+    expect(
+      shouldDrawCrossSectionHoverMarker({
+        enabled: false,
+        mouseActive: true,
+        mouseInThisPanel: false,
+      }),
+    ).toBe(false);
+  });
+
+  it("is not drawn when the mouse is not active in any panel", () => {
+    expect(
+      shouldDrawCrossSectionHoverMarker({
+        enabled: true,
+        mouseActive: false,
+        mouseInThisPanel: false,
+      }),
+    ).toBe(false);
+  });
+});
+
+// Builds a minimal ProjectionParameters carrying only the fields
+// computeHoverMarkerMatrix reads.
+function makeProjectionParameters(
+  viewProjectionMat: mat4,
+  displayDimensionIndices: Int32Array,
+  canonicalVoxelFactors: Float32Array,
+): ProjectionParameters {
+  return {
+    viewProjectionMat,
+    displayDimensionRenderInfo: {
+      displayDimensionIndices,
+      canonicalVoxelFactors,
+    },
+  } as unknown as ProjectionParameters;
+}
+
+describe("computeHoverMarkerMatrix", () => {
+  it("centers the marker at the given global position", () => {
+    const projectionParameters = makeProjectionParameters(
+      mat4.identity(mat4.create()),
+      Int32Array.of(0, 1, 2),
+      Float32Array.of(1, 1, 1),
+    );
+    const position = Float32Array.of(3, -4, 5);
+    const mat = computeHoverMarkerMatrix(projectionParameters, 1, position);
+    // With an identity view-projection and unit voxel factors, the translation
+    // column of the marker matrix is exactly the hovered position.
+    expect(Array.from(mat.slice(12, 15))).toEqual([3, -4, 5]);
+  });
+
+  it("scales the marker by markerSize / canonicalVoxelFactors", () => {
+    const projectionParameters = makeProjectionParameters(
+      mat4.identity(mat4.create()),
+      Int32Array.of(0, 1, 2),
+      Float32Array.of(1, 2, 4),
+    );
+    const mat = computeHoverMarkerMatrix(
+      projectionParameters,
+      8,
+      Float32Array.of(0, 0, 0),
+    );
+    // Diagonal scale entries: markerSize / canonicalVoxelFactors[i].
+    expect(mat[0]).toBe(8 / 1);
+    expect(mat[5]).toBe(8 / 2);
+    expect(mat[10]).toBe(8 / 4);
+  });
+
+  it("ignores display dimensions mapped to -1", () => {
+    const projectionParameters = makeProjectionParameters(
+      mat4.identity(mat4.create()),
+      Int32Array.of(0, -1, 2),
+      Float32Array.of(1, 1, 1),
+    );
+    const position = Float32Array.of(3, 4, 5);
+    const mat = computeHoverMarkerMatrix(projectionParameters, 1, position);
+    // The second display dimension is unmapped, so its translation is 0.
+    expect(Array.from(mat.slice(12, 15))).toEqual([3, 0, 5]);
+  });
+});
+
+describe("crossSectionHoverMarkerAlpha", () => {
+  // Builds a marker matrix whose projected center has the given normalized
+  // device z (clip z / clip w) by setting the last column to [_, _, ndcZ, 1].
+  function markerMatWithNdcZ(ndcZ: number): mat4 {
+    const mat = mat4.identity(mat4.create());
+    mat[14] = ndcZ;
+    mat[15] = 1;
+    return mat;
+  }
+
+  it("is fully opaque on the slice plane (ndcZ == 0)", () => {
+    expect(crossSectionHoverMarkerAlpha(markerMatWithNdcZ(0))).toBe(1);
+  });
+
+  it("fades linearly with distance from the slice plane", () => {
+    expect(crossSectionHoverMarkerAlpha(markerMatWithNdcZ(0.25))).toBeCloseTo(
+      0.75,
+    );
+    expect(crossSectionHoverMarkerAlpha(markerMatWithNdcZ(-0.25))).toBeCloseTo(
+      0.75,
+    );
+  });
+
+  it("is invisible at and beyond the depth-slab edge (|ndcZ| >= 1)", () => {
+    expect(crossSectionHoverMarkerAlpha(markerMatWithNdcZ(1))).toBe(0);
+    expect(crossSectionHoverMarkerAlpha(markerMatWithNdcZ(1.5))).toBe(0);
+    expect(crossSectionHoverMarkerAlpha(markerMatWithNdcZ(-2))).toBe(0);
+  });
+
+  it("treats a zero clip w as on-plane", () => {
+    const mat = mat4.identity(mat4.create());
+    mat[14] = 5;
+    mat[15] = 0;
+    expect(crossSectionHoverMarkerAlpha(mat)).toBe(1);
+  });
+});

--- a/src/hover_position_marker.ts
+++ b/src/hover_position_marker.ts
@@ -1,0 +1,123 @@
+/**
+ * @license
+ * Copyright 2024 Google Inc.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @file Draws a small reticle marker at the mouse-hover position within a
+ * cross-section slice panel.  Used to display the position currently hovered in
+ * one panel as a marker in the other panels (see
+ * `showCrossSectionHoverPosition`).
+ */
+
+import type { ProjectionParameters } from "#src/projection_parameters.js";
+import { RefCounted } from "#src/util/disposable.js";
+import { mat4, type vec4 } from "#src/util/geom.js";
+import { GLBuffer } from "#src/webgl/buffer.js";
+import type { GL } from "#src/webgl/context.js";
+import type { ShaderProgram } from "#src/webgl/shader.js";
+import { trivialUniformColorShader } from "#src/webgl/trivial_shaders.js";
+
+const tempMat = mat4.create();
+
+/**
+ * Computes the transform that places a fixed-size marker centered at the
+ * specified global `position`, projected into the viewport described by
+ * `projectionParameters`.  This mirrors `computeAxisLineMatrix` but uses an
+ * arbitrary position (the mouse-hover position) rather than the navigation
+ * center.
+ */
+export function computeHoverMarkerMatrix(
+  projectionParameters: ProjectionParameters,
+  markerSize: number,
+  position: Float32Array,
+) {
+  const mat = mat4.identity(tempMat);
+  const {
+    displayDimensionRenderInfo: {
+      canonicalVoxelFactors,
+      displayDimensionIndices,
+    },
+  } = projectionParameters;
+  for (let i = 0; i < 3; ++i) {
+    const globalDim = displayDimensionIndices[i];
+    mat[12 + i] =
+      globalDim === -1 || globalDim >= position.length
+        ? 0
+        : position[globalDim];
+    mat[5 * i] = markerSize / canonicalVoxelFactors[i];
+  }
+  mat4.multiply(mat, projectionParameters.viewProjectionMat, mat);
+  return mat;
+}
+
+export class HoverPositionMarker extends RefCounted {
+  vertexBuffer: GLBuffer;
+  shader: ShaderProgram;
+
+  constructor(public gl: GL) {
+    super();
+    // Two line segments forming a "+" reticle in the local X/Y plane.
+    this.vertexBuffer = this.registerDisposer(
+      GLBuffer.fromData(
+        gl,
+        new Float32Array([
+          -1,
+          0,
+          0,
+          1, //
+          1,
+          0,
+          0,
+          1, //
+          0,
+          -1,
+          0,
+          1, //
+          0,
+          1,
+          0,
+          1, //
+        ]),
+        gl.ARRAY_BUFFER,
+        gl.STATIC_DRAW,
+      ),
+    );
+    this.shader = trivialUniformColorShader(gl);
+  }
+
+  static get(gl: GL) {
+    return gl.memoize.get(
+      "SliceViewPanel:HoverPositionMarker",
+      () => new HoverPositionMarker(gl),
+    );
+  }
+
+  draw(mat: mat4, color: vec4) {
+    const { shader, gl } = this;
+    shader.bind();
+    gl.uniformMatrix4fv(shader.uniform("uProjectionMatrix"), false, mat);
+    gl.uniform4fv(shader.uniform("uColor"), color);
+    const aVertexPosition = shader.attribute("aVertexPosition");
+    this.vertexBuffer.bindToVertexAttrib(aVertexPosition, 4);
+
+    gl.enable(gl.BLEND);
+    gl.blendFunc(gl.SRC_ALPHA, gl.ONE_MINUS_SRC_ALPHA);
+    gl.lineWidth(1);
+    gl.drawArrays(gl.LINES, 0, 4);
+    gl.disable(gl.BLEND);
+
+    gl.disableVertexAttribArray(aVertexPosition);
+  }
+}

--- a/src/hover_position_marker.ts
+++ b/src/hover_position_marker.ts
@@ -15,19 +15,15 @@
  */
 
 /**
- * @file Draws a small reticle marker at the mouse-hover position within a
- * cross-section slice panel.  Used to display the position currently hovered in
- * one panel as a marker in the other panels (see
- * `showCrossSectionHoverPosition`).
+ * @file Geometry and visibility logic for the cross-section hover marker: a
+ * small reticle drawn at the mouse-hover position of one cross-section slice
+ * panel and echoed into the other panels (see `showCrossSectionHoverPosition`).
+ * The WebGL rendering lives in `./hover_position_marker_renderer.js`; this module
+ * is kept free of WebGL dependencies so the logic can be unit-tested.
  */
 
 import type { ProjectionParameters } from "#src/projection_parameters.js";
-import { RefCounted } from "#src/util/disposable.js";
-import { mat4, type vec4 } from "#src/util/geom.js";
-import { GLBuffer } from "#src/webgl/buffer.js";
-import type { GL } from "#src/webgl/context.js";
-import type { ShaderProgram } from "#src/webgl/shader.js";
-import { trivialUniformColorShader } from "#src/webgl/trivial_shaders.js";
+import { mat4 } from "#src/util/geom.js";
 
 const tempMat = mat4.create();
 
@@ -62,62 +58,40 @@ export function computeHoverMarkerMatrix(
   return mat;
 }
 
-export class HoverPositionMarker extends RefCounted {
-  vertexBuffer: GLBuffer;
-  shader: ShaderProgram;
+/**
+ * Determines whether the cross-section hover marker should be drawn in a given
+ * cross-section slice panel.
+ *
+ * The marker echoes the position hovered in one panel into the *other* panels,
+ * so it is only drawn in a panel that does not currently contain the mouse
+ * cursor.  With a single cross-section panel (no side-by-side layout) the active
+ * cursor is always within that one panel, so the marker is never drawn; it only
+ * appears once two or more panels are shown side by side and the cursor is in a
+ * different panel than this one.
+ */
+export function shouldDrawCrossSectionHoverMarker(options: {
+  // The `showCrossSectionHoverPosition` viewer toggle.
+  enabled: boolean;
+  // Whether the shared mouse cursor is currently active in some panel.
+  mouseActive: boolean;
+  // Whether the mouse cursor is within this panel (i.e. `mouseX >= 0`).
+  mouseInThisPanel: boolean;
+}): boolean {
+  const { enabled, mouseActive, mouseInThisPanel } = options;
+  return enabled && mouseActive && !mouseInThisPanel;
+}
 
-  constructor(public gl: GL) {
-    super();
-    // Two line segments forming a "+" reticle in the local X/Y plane.
-    this.vertexBuffer = this.registerDisposer(
-      GLBuffer.fromData(
-        gl,
-        new Float32Array([
-          -1,
-          0,
-          0,
-          1, //
-          1,
-          0,
-          0,
-          1, //
-          0,
-          -1,
-          0,
-          1, //
-          0,
-          1,
-          0,
-          1, //
-        ]),
-        gl.ARRAY_BUFFER,
-        gl.STATIC_DRAW,
-      ),
-    );
-    this.shader = trivialUniformColorShader(gl);
-  }
-
-  static get(gl: GL) {
-    return gl.memoize.get(
-      "SliceViewPanel:HoverPositionMarker",
-      () => new HoverPositionMarker(gl),
-    );
-  }
-
-  draw(mat: mat4, color: vec4) {
-    const { shader, gl } = this;
-    shader.bind();
-    gl.uniformMatrix4fv(shader.uniform("uProjectionMatrix"), false, mat);
-    gl.uniform4fv(shader.uniform("uColor"), color);
-    const aVertexPosition = shader.attribute("aVertexPosition");
-    this.vertexBuffer.bindToVertexAttrib(aVertexPosition, 4);
-
-    gl.enable(gl.BLEND);
-    gl.blendFunc(gl.SRC_ALPHA, gl.ONE_MINUS_SRC_ALPHA);
-    gl.lineWidth(1);
-    gl.drawArrays(gl.LINES, 0, 4);
-    gl.disable(gl.BLEND);
-
-    gl.disableVertexAttribArray(aVertexPosition);
-  }
+/**
+ * Computes the opacity of the hover marker from its projected depth, so that the
+ * marker fades with distance from this panel's slice plane.  `markerMat` is the
+ * result of {@link computeHoverMarkerMatrix}; its last column is the marker
+ * center in clip space.  The normalized device z (`z/w`) is the signed distance
+ * from the slice plane, reaching magnitude 1 at the edge of the visible depth
+ * slab, so the marker is fully opaque on the plane and invisible at/beyond the
+ * slab edge.
+ */
+export function crossSectionHoverMarkerAlpha(markerMat: mat4): number {
+  const clipW = markerMat[15];
+  const ndcZ = clipW !== 0 ? markerMat[14] / clipW : 0;
+  return Math.max(0, 1 - Math.abs(ndcZ));
 }

--- a/src/hover_position_marker_renderer.ts
+++ b/src/hover_position_marker_renderer.ts
@@ -1,0 +1,75 @@
+/**
+ * @license
+ * Copyright 2024 Google Inc.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @file WebGL rendering for the cross-section hover marker.  The geometry and
+ * visibility logic lives in `./hover_position_marker.js`.
+ */
+
+import { RefCounted } from "#src/util/disposable.js";
+import type { mat4, vec4 } from "#src/util/geom.js";
+import { GLBuffer } from "#src/webgl/buffer.js";
+import type { GL } from "#src/webgl/context.js";
+import type { ShaderProgram } from "#src/webgl/shader.js";
+import { trivialUniformColorShader } from "#src/webgl/trivial_shaders.js";
+
+export class HoverPositionMarker extends RefCounted {
+  vertexBuffer: GLBuffer;
+  shader: ShaderProgram;
+
+  constructor(public gl: GL) {
+    super();
+    // Two line segments forming a "+" reticle in the local X/Y plane.
+    this.vertexBuffer = this.registerDisposer(
+      GLBuffer.fromData(
+        gl,
+        new Float32Array([
+          -1, 0, 0, 1, //
+          1, 0, 0, 1, //
+          0, -1, 0, 1, //
+          0, 1, 0, 1, //
+        ]),
+        gl.ARRAY_BUFFER,
+        gl.STATIC_DRAW,
+      ),
+    );
+    this.shader = trivialUniformColorShader(gl);
+  }
+
+  static get(gl: GL) {
+    return gl.memoize.get(
+      "SliceViewPanel:HoverPositionMarker",
+      () => new HoverPositionMarker(gl),
+    );
+  }
+
+  draw(mat: mat4, color: vec4) {
+    const { shader, gl } = this;
+    shader.bind();
+    gl.uniformMatrix4fv(shader.uniform("uProjectionMatrix"), false, mat);
+    gl.uniform4fv(shader.uniform("uColor"), color);
+    const aVertexPosition = shader.attribute("aVertexPosition");
+    this.vertexBuffer.bindToVertexAttrib(aVertexPosition, 4);
+
+    gl.enable(gl.BLEND);
+    gl.blendFunc(gl.SRC_ALPHA, gl.ONE_MINUS_SRC_ALPHA);
+    gl.lineWidth(1);
+    gl.drawArrays(gl.LINES, 0, 4);
+    gl.disable(gl.BLEND);
+
+    gl.disableVertexAttribArray(aVertexPosition);
+  }
+}

--- a/src/layer_group_viewer.ts
+++ b/src/layer_group_viewer.ts
@@ -27,6 +27,7 @@ import type {
   LayerListSpecification,
   MouseSelectionState,
   SelectedLayerState,
+  UserLayer,
 } from "#src/layer/index.js";
 import { LayerSubsetSpecification } from "#src/layer/index.js";
 import type {
@@ -51,6 +52,7 @@ import {
   WatchableDisplayDimensionRenderInfo,
 } from "#src/navigation_state.js";
 import type { RenderLayerRole } from "#src/renderlayer.js";
+import { StatusMessage } from "#src/status.js";
 import { TrackableBoolean } from "#src/trackable_boolean.js";
 import type {
   TrackableValue,
@@ -70,6 +72,7 @@ import type { Borrowed, Owned } from "#src/util/disposable.js";
 import { RefCounted } from "#src/util/disposable.js";
 import { removeChildren } from "#src/util/dom.js";
 import { getDropEffectFromModifiers } from "#src/util/drag_and_drop.js";
+import type { ActionEvent } from "#src/util/event_action_map.js";
 import {
   dispatchEventAction,
   registerActionListener,
@@ -477,10 +480,35 @@ export class LayerGroupViewer extends RefCounted {
     this.makeUI();
   }
 
-  bindAction(action: string, handler: () => void) {
+  bindAction(
+    action: string,
+    handler: (event: ActionEvent<MouseEvent>) => void,
+  ) {
     this.registerDisposer(
       registerActionListener(this.element, action, handler),
     );
+  }
+
+  // Returns the layer shown in this group that should receive an annotation
+  // click.  Prefers the globally-selected layer when it is shown in this group
+  // and has an active tool; otherwise the first layer in this group that has
+  // one.  Returns undefined when no layer in this group has an active tool, so a
+  // click in this panel never annotates a layer shown only in another panel.
+  private getAnnotationToolLayer(): UserLayer | undefined {
+    const selected = this.selectedLayer.layer;
+    if (selected !== undefined && this.layerManager.has(selected)) {
+      const userLayer = selected.layer;
+      if (userLayer !== null && userLayer.tool.value !== undefined) {
+        return userLayer;
+      }
+    }
+    for (const managedLayer of this.layerManager.managedLayers) {
+      const userLayer = managedLayer.layer;
+      if (userLayer !== null && userLayer.tool.value !== undefined) {
+        return userLayer;
+      }
+    }
+    return undefined;
   }
 
   private registerActionBindings() {
@@ -494,6 +522,31 @@ export class LayerGroupViewer extends RefCounted {
     });
     this.bindAction("t+", () => {
       this.navigationState.pose.translateNonDisplayDimension(0, +1);
+    });
+
+    // Scope segment/annotation click actions to the layer group under the
+    // cursor, so a click acts on the layers shown in the panel where the
+    // (original) cursor is -- not on the globally-selected layer, which may be
+    // displayed in a different panel.  stopPropagation prevents the root
+    // Viewer's global bindings (which use the root layer manager / global
+    // selected layer) from also handling the event.
+    for (const action of ["select", "star"]) {
+      this.bindAction(action, (event) => {
+        event.stopPropagation();
+        this.mouseState.updateUnconditionally();
+        this.layerManager.invokeAction(action);
+      });
+    }
+    this.bindAction("annotate", (event) => {
+      event.stopPropagation();
+      const userLayer = this.getAnnotationToolLayer();
+      if (userLayer === undefined) {
+        StatusMessage.showTemporaryMessage(
+          "No layer with an active annotation tool is shown in this panel.",
+        );
+        return;
+      }
+      userLayer.tool.value!.trigger(this.mouseState);
     });
   }
 

--- a/src/layer_group_viewer.ts
+++ b/src/layer_group_viewer.ts
@@ -27,7 +27,6 @@ import type {
   LayerListSpecification,
   MouseSelectionState,
   SelectedLayerState,
-  UserLayer,
 } from "#src/layer/index.js";
 import { LayerSubsetSpecification } from "#src/layer/index.js";
 import type {
@@ -52,7 +51,6 @@ import {
   WatchableDisplayDimensionRenderInfo,
 } from "#src/navigation_state.js";
 import type { RenderLayerRole } from "#src/renderlayer.js";
-import { StatusMessage } from "#src/status.js";
 import { TrackableBoolean } from "#src/trackable_boolean.js";
 import type {
   TrackableValue,
@@ -72,7 +70,6 @@ import type { Borrowed, Owned } from "#src/util/disposable.js";
 import { RefCounted } from "#src/util/disposable.js";
 import { removeChildren } from "#src/util/dom.js";
 import { getDropEffectFromModifiers } from "#src/util/drag_and_drop.js";
-import type { ActionEvent } from "#src/util/event_action_map.js";
 import {
   dispatchEventAction,
   registerActionListener,
@@ -480,35 +477,10 @@ export class LayerGroupViewer extends RefCounted {
     this.makeUI();
   }
 
-  bindAction(
-    action: string,
-    handler: (event: ActionEvent<MouseEvent>) => void,
-  ) {
+  bindAction(action: string, handler: () => void) {
     this.registerDisposer(
       registerActionListener(this.element, action, handler),
     );
-  }
-
-  // Returns the layer shown in this group that should receive an annotation
-  // click.  Prefers the globally-selected layer when it is shown in this group
-  // and has an active tool; otherwise the first layer in this group that has
-  // one.  Returns undefined when no layer in this group has an active tool, so a
-  // click in this panel never annotates a layer shown only in another panel.
-  private getAnnotationToolLayer(): UserLayer | undefined {
-    const selected = this.selectedLayer.layer;
-    if (selected !== undefined && this.layerManager.has(selected)) {
-      const userLayer = selected.layer;
-      if (userLayer !== null && userLayer.tool.value !== undefined) {
-        return userLayer;
-      }
-    }
-    for (const managedLayer of this.layerManager.managedLayers) {
-      const userLayer = managedLayer.layer;
-      if (userLayer !== null && userLayer.tool.value !== undefined) {
-        return userLayer;
-      }
-    }
-    return undefined;
   }
 
   private registerActionBindings() {
@@ -522,31 +494,6 @@ export class LayerGroupViewer extends RefCounted {
     });
     this.bindAction("t+", () => {
       this.navigationState.pose.translateNonDisplayDimension(0, +1);
-    });
-
-    // Scope segment/annotation click actions to the layer group under the
-    // cursor, so a click acts on the layers shown in the panel where the
-    // (original) cursor is -- not on the globally-selected layer, which may be
-    // displayed in a different panel.  stopPropagation prevents the root
-    // Viewer's global bindings (which use the root layer manager / global
-    // selected layer) from also handling the event.
-    for (const action of ["select", "star"]) {
-      this.bindAction(action, (event) => {
-        event.stopPropagation();
-        this.mouseState.updateUnconditionally();
-        this.layerManager.invokeAction(action);
-      });
-    }
-    this.bindAction("annotate", (event) => {
-      event.stopPropagation();
-      const userLayer = this.getAnnotationToolLayer();
-      if (userLayer === undefined) {
-        StatusMessage.showTemporaryMessage(
-          "No layer with an active annotation tool is shown in this panel.",
-        );
-        return;
-      }
-      userLayer.tool.value!.trigger(this.mouseState);
     });
   }
 

--- a/src/layer_group_viewer.ts
+++ b/src/layer_group_viewer.ts
@@ -91,6 +91,7 @@ export interface LayerGroupViewerState {
   velocity: Owned<CoordinateSpacePlaybackVelocity>;
   mouseState: MouseSelectionState;
   showAxisLines: TrackableBoolean;
+  showCrossSectionHoverPosition: TrackableBoolean;
   wireFrame: TrackableBoolean;
   enableAdaptiveDownsampling: TrackableBoolean;
   showScaleBar: TrackableBoolean;
@@ -354,6 +355,9 @@ export class LayerGroupViewer extends RefCounted {
   }
   get showAxisLines() {
     return this.viewerState.showAxisLines;
+  }
+  get showCrossSectionHoverPosition() {
+    return this.viewerState.showCrossSectionHoverPosition;
   }
   get wireFrame() {
     return this.viewerState.wireFrame;

--- a/src/layer_groups_layout.ts
+++ b/src/layer_groups_layout.ts
@@ -406,6 +406,7 @@ function getCommonViewerState(viewer: Viewer) {
   return {
     mouseState: viewer.mouseState,
     showAxisLines: viewer.showAxisLines,
+    showCrossSectionHoverPosition: viewer.showCrossSectionHoverPosition,
     wireFrame: viewer.wireFrame,
     enableAdaptiveDownsampling: viewer.enableAdaptiveDownsampling,
     showScaleBar: viewer.showScaleBar,

--- a/src/sliceview/panel.ts
+++ b/src/sliceview/panel.ts
@@ -18,8 +18,10 @@ import { AxesLineHelper, computeAxisLineMatrix } from "#src/axes_lines.js";
 import type { DisplayContext } from "#src/display_context.js";
 import {
   computeHoverMarkerMatrix,
-  HoverPositionMarker,
+  crossSectionHoverMarkerAlpha,
+  shouldDrawCrossSectionHoverMarker,
 } from "#src/hover_position_marker.js";
+import { HoverPositionMarker } from "#src/hover_position_marker_renderer.js";
 import type { VisibleRenderLayerTracker } from "#src/layer/index.js";
 import { makeRenderedPanelVisibleLayerTracker } from "#src/layer/index.js";
 import { PickIDManager } from "#src/object_picking.js";
@@ -425,10 +427,11 @@ export class SliceViewPanel extends RenderedDataPanel {
     // Draw the hover position coming from another panel, but not in the panel
     // the mouse is currently over (`mouseX >= 0`), where the real cursor is
     // already visible.
-    const showHoverMarker =
-      this.viewer.showCrossSectionHoverPosition.value &&
-      mouseState.active &&
-      this.mouseX < 0;
+    const showHoverMarker = shouldDrawCrossSectionHoverMarker({
+      enabled: this.viewer.showCrossSectionHoverPosition.value,
+      mouseActive: mouseState.active,
+      mouseInThisPanel: this.mouseX >= 0,
+    });
     if (
       this.viewer.showAxisLines.value ||
       this.viewer.showScaleBar.value ||
@@ -459,12 +462,8 @@ export class SliceViewPanel extends RenderedDataPanel {
           HOVER_MARKER_SIZE * zoom,
           mouseState.position,
         );
-        // The last column of `markerMat` is the marker center projected into
-        // clip space; its normalized z gives the signed distance from this
-        // panel's slice plane (|z| == 1 at the edge of the visible depth slab).
-        const clipW = markerMat[15];
-        const ndcZ = clipW !== 0 ? markerMat[14] / clipW : 0;
-        const alpha = Math.max(0, 1 - Math.abs(ndcZ));
+        // Fade the marker with distance from this panel's slice plane.
+        const alpha = crossSectionHoverMarkerAlpha(markerMat);
         if (alpha > 0) {
           vec4.set(tempHoverColor, 1, 0.85, 0, alpha);
           this.hoverMarker.draw(disableZProjection(markerMat), tempHoverColor);

--- a/src/sliceview/panel.ts
+++ b/src/sliceview/panel.ts
@@ -16,6 +16,10 @@
 
 import { AxesLineHelper, computeAxisLineMatrix } from "#src/axes_lines.js";
 import type { DisplayContext } from "#src/display_context.js";
+import {
+  computeHoverMarkerMatrix,
+  HoverPositionMarker,
+} from "#src/hover_position_marker.js";
 import type { VisibleRenderLayerTracker } from "#src/layer/index.js";
 import { makeRenderedPanelVisibleLayerTracker } from "#src/layer/index.js";
 import { PickIDManager } from "#src/object_picking.js";
@@ -98,12 +102,18 @@ void emit(vec4 color, highp uint pickId) {
 const tempVec3 = vec3.create();
 const tempVec3b = vec3.create();
 const tempVec4 = vec4.create();
+const tempHoverColor = vec4.create();
+
+// Half-length, in logical pixels, of the "+" reticle drawn at the hover
+// position that is synchronized across cross-section panels.
+const HOVER_MARKER_SIZE = 8;
 
 export class SliceViewPanel extends RenderedDataPanel {
   declare viewer: SliceViewerState;
   private sliceViewRenderHelper;
 
   private axesLineHelper = this.registerDisposer(AxesLineHelper.get(this.gl));
+  private hoverMarker = this.registerDisposer(HoverPositionMarker.get(this.gl));
 
   private colorFactor = vec4.fromValues(1, 1, 1, 1);
   private pickIDs = new PickIDManager();
@@ -261,6 +271,20 @@ export class SliceViewPanel extends RenderedDataPanel {
         }
       }),
     );
+    this.registerDisposer(
+      viewer.showCrossSectionHoverPosition.changed.add(() => {
+        if (this.visible) {
+          this.scheduleRedraw();
+        }
+      }),
+    );
+    this.registerDisposer(
+      viewer.mouseState.changed.add(() => {
+        if (this.visible && viewer.showCrossSectionHoverPosition.value) {
+          this.scheduleRedraw();
+        }
+      }),
+    );
 
     this.registerDisposer(
       viewer.showScaleBar.changed.add(() => {
@@ -397,7 +421,19 @@ export class SliceViewPanel extends RenderedDataPanel {
       renderLayer.draw(renderContext, attachment);
     }
     gl.disable(WebGL2RenderingContext.BLEND);
-    if (this.viewer.showAxisLines.value || this.viewer.showScaleBar.value) {
+    const { mouseState } = this.viewer;
+    // Draw the hover position coming from another panel, but not in the panel
+    // the mouse is currently over (`mouseX >= 0`), where the real cursor is
+    // already visible.
+    const showHoverMarker =
+      this.viewer.showCrossSectionHoverPosition.value &&
+      mouseState.active &&
+      this.mouseX < 0;
+    if (
+      this.viewer.showAxisLines.value ||
+      this.viewer.showScaleBar.value ||
+      showHoverMarker
+    ) {
       this.offscreenFramebuffer.bindSingle(OffscreenTextures.COLOR);
       if (this.viewer.showAxisLines.value) {
         const axisLength =
@@ -415,6 +451,24 @@ export class SliceViewPanel extends RenderedDataPanel {
             computeAxisLineMatrix(projectionParameters, axisLength * zoom),
           ),
         );
+      }
+      if (showHoverMarker) {
+        const { value: zoom } = this.viewer.navigationState.zoomFactor;
+        const markerMat = computeHoverMarkerMatrix(
+          projectionParameters,
+          HOVER_MARKER_SIZE * zoom,
+          mouseState.position,
+        );
+        // The last column of `markerMat` is the marker center projected into
+        // clip space; its normalized z gives the signed distance from this
+        // panel's slice plane (|z| == 1 at the edge of the visible depth slab).
+        const clipW = markerMat[15];
+        const ndcZ = clipW !== 0 ? markerMat[14] / clipW : 0;
+        const alpha = Math.max(0, 1 - Math.abs(ndcZ));
+        if (alpha > 0) {
+          vec4.set(tempHoverColor, 1, 0.85, 0, alpha);
+          this.hoverMarker.draw(disableZProjection(markerMat), tempHoverColor);
+        }
       }
       if (this.viewer.showScaleBar.value) {
         gl.enable(WebGL2RenderingContext.BLEND);

--- a/src/ui/default_input_event_bindings.ts
+++ b/src/ui/default_input_event_bindings.ts
@@ -28,6 +28,7 @@ export function getDefaultGlobalBindings() {
     map.set("keyb", "toggle-scale-bar");
     map.set("keyv", "toggle-default-annotations");
     map.set("keya", "toggle-axis-lines");
+    map.set("keyc", "toggle-cross-section-hover-position");
     map.set("keyo", "toggle-orthographic-projection");
 
     for (let i = 1; i <= 9; ++i) {

--- a/src/ui/layer_bar.ts
+++ b/src/ui/layer_bar.ts
@@ -17,15 +17,11 @@
 import "#src/noselect.css";
 import "#src/ui/layer_bar.css";
 import svg_plus from "ikonate/icons/plus.svg?raw";
-import type {
-  LayerSubsetSpecification,
-  ManagedUserLayer,
-} from "#src/layer/index.js";
+import type { ManagedUserLayer } from "#src/layer/index.js";
 import { addNewLayer, deleteLayer, makeLayer } from "#src/layer/index.js";
 import type { LayerGroupViewer } from "#src/layer_group_viewer.js";
 import { NavigationLinkType } from "#src/navigation_state.js";
 import type { WatchableValueInterface } from "#src/trackable_value.js";
-import { ContextMenu } from "#src/ui/context_menu.js";
 import type { DropLayers } from "#src/ui/layer_drag_and_drop.js";
 import {
   registerLayerBarDragLeaveHandler,
@@ -39,64 +35,12 @@ import {
   useWhiteBackground,
 } from "#src/util/color.js";
 import { RefCounted } from "#src/util/disposable.js";
-import { removeChildren, removeFromParent } from "#src/util/dom.js";
+import { removeFromParent } from "#src/util/dom.js";
 import { preventDrag } from "#src/util/drag_and_drop.js";
 import { makeCloseButton } from "#src/widget/close_button.js";
 import { makeDeleteButton } from "#src/widget/delete_button.js";
 import { makeIcon } from "#src/widget/icon.js";
 import { PositionWidget } from "#src/widget/position_widget.js";
-
-// Removes `layer` from the layer group displayed by `panel`.  If the layer is
-// also displayed in another layer group, it is simply removed from this one;
-// otherwise (it is the only group showing it) the layer is archived.  This
-// mirrors the behavior of the layer tab's close (×) button.
-function removeLayerFromPanel(panel: LayerBar, layer: ManagedUserLayer) {
-  if (panel.layerManager === panel.manager.rootLayers) {
-    // The layer bar corresponds to a TopLevelLayerListSpecification.  That means
-    // there is just a single layer group, archive the layer unconditionally.
-    layer.setArchived(true);
-  } else if (layer.containers.size > 2) {
-    // Layer is contained in at least one other layer group (root + this group +
-    // another), just remove it from this layer group.
-    panel.layerManager.removeManagedLayer(layer);
-  } else {
-    // Layer is not contained in any other layer group.  Archive it.
-    layer.setArchived(true);
-  }
-}
-
-// Returns the layer subsets (other than `panel`'s) belonging to the same root,
-// split into those that currently contain `layer` and those that do not.
-function getOtherPanels(panel: LayerBar, layer: ManagedUserLayer) {
-  const withLayer: LayerSubsetSpecification[] = [];
-  const withoutLayer: LayerSubsetSpecification[] = [];
-  for (const subset of panel.manager.root.subsets) {
-    if (subset.layerManager === panel.layerManager) continue;
-    (subset.layerManager.has(layer) ? withLayer : withoutLayer).push(subset);
-  }
-  return { withLayer, withoutLayer };
-}
-
-// Removes `layer` from every layer group other than `panel`'s, so it is shown
-// only in `panel`.
-function showLayerOnlyInPanel(panel: LayerBar, layer: ManagedUserLayer) {
-  for (const subset of getOtherPanels(panel, layer).withLayer) {
-    subset.layerManager.removeManagedLayer(layer);
-  }
-}
-
-// Moves `layer` from `panel` into the single other layer group, adding it there
-// if necessary.
-function moveLayerToOtherPanel(panel: LayerBar, layer: ManagedUserLayer) {
-  const { withLayer, withoutLayer } = getOtherPanels(panel, layer);
-  const others = [...withLayer, ...withoutLayer];
-  if (others.length !== 1) return;
-  const other = others[0];
-  if (!other.layerManager.has(layer)) {
-    other.layerManager.addManagedLayer(layer.addRef());
-  }
-  removeLayerFromPanel(panel, layer);
-}
 
 class LayerWidget extends RefCounted {
   element = document.createElement("div");
@@ -110,7 +54,6 @@ class LayerWidget extends RefCounted {
   maxLength = 0;
   prevValueText = "";
   private colorChangeDisposer: () => void = () => {};
-  private contextMenu = this.registerDisposer(new ContextMenu());
 
   constructor(
     public layer: ManagedUserLayer,
@@ -150,7 +93,22 @@ class LayerWidget extends RefCounted {
     const closeElement = makeCloseButton();
     closeElement.title = "Remove layer from this layer group";
     closeElement.addEventListener("click", (event: MouseEvent) => {
-      removeLayerFromPanel(this.panel, this.layer);
+      if (this.panel.layerManager === this.panel.manager.rootLayers) {
+        // The layer bar corresponds to a TopLevelLayerListSpecification.  That means there is just
+        // a single layer group, archive the layer unconditionally.
+        this.layer.setArchived(true);
+      } else {
+        // The layer bar corresponds to a LayerSubsetSpecification.  The layer is always contained
+        // in the root LayerManager, as well as the LayerManager for each LayerSubsetSpecification.
+        if (this.layer.containers.size > 2) {
+          // Layer is contained in at least one other layer group, just remove it from this layer
+          // group.
+          this.panel.layerManager.removeManagedLayer(this.layer);
+        } else {
+          // Layer is not contained in any other layer group.  Archive it.
+          this.layer.setArchived(true);
+        }
+      }
       event.stopPropagation();
     });
     const deleteElement = makeDeleteButton();
@@ -211,7 +169,8 @@ class LayerWidget extends RefCounted {
     });
 
     element.addEventListener("contextmenu", (event: MouseEvent) => {
-      this.showContextMenu(event);
+      panel.selectedLayer.layer = layer;
+      panel.selectedLayer.visible = true;
       event.stopPropagation();
       event.preventDefault();
     });
@@ -219,44 +178,6 @@ class LayerWidget extends RefCounted {
       getLayoutSpec: () => panel.getLayoutSpecForDrag(),
     });
     registerLayerBarDropHandlers(this.panel, element, this.layer);
-  }
-
-  private showContextMenu(event: MouseEvent) {
-    const { contextMenu, layer, panel } = this;
-    // The context menu only offers actions that move a layer between layer
-    // groups, so it is only shown when the screen is split into multiple layer
-    // groups (i.e. this bar corresponds to a subset, not the single top-level
-    // group).  With a single panel, right-clicking does nothing.
-    if (panel.layerManager === panel.manager.rootLayers) {
-      return;
-    }
-    const menu = contextMenu.element;
-    removeChildren(menu);
-    const addItem = (text: string, action: () => void) => {
-      const button = document.createElement("button");
-      button.textContent = text;
-      button.addEventListener("click", () => {
-        action();
-        contextMenu.hide();
-      });
-      menu.appendChild(button);
-    };
-    addItem("Layer controls", () => {
-      panel.selectedLayer.layer = layer;
-      panel.selectedLayer.visible = true;
-    });
-    const { withLayer, withoutLayer } = getOtherPanels(panel, layer);
-    const numPanels = withLayer.length + withoutLayer.length + 1;
-    if (numPanels === 2 && withoutLayer.length === 1) {
-      addItem("Move to other panel", () => moveLayerToOtherPanel(panel, layer));
-    }
-    if (withLayer.length > 0) {
-      addItem("Show only in this panel", () =>
-        showLayerOnlyInPanel(panel, layer),
-      );
-    }
-    addItem("Remove from this panel", () => removeLayerFromPanel(panel, layer));
-    contextMenu.show(event);
   }
 
   setColor() {

--- a/src/ui/layer_bar.ts
+++ b/src/ui/layer_bar.ts
@@ -17,11 +17,15 @@
 import "#src/noselect.css";
 import "#src/ui/layer_bar.css";
 import svg_plus from "ikonate/icons/plus.svg?raw";
-import type { ManagedUserLayer } from "#src/layer/index.js";
+import type {
+  LayerSubsetSpecification,
+  ManagedUserLayer,
+} from "#src/layer/index.js";
 import { addNewLayer, deleteLayer, makeLayer } from "#src/layer/index.js";
 import type { LayerGroupViewer } from "#src/layer_group_viewer.js";
 import { NavigationLinkType } from "#src/navigation_state.js";
 import type { WatchableValueInterface } from "#src/trackable_value.js";
+import { ContextMenu } from "#src/ui/context_menu.js";
 import type { DropLayers } from "#src/ui/layer_drag_and_drop.js";
 import {
   registerLayerBarDragLeaveHandler,
@@ -35,12 +39,64 @@ import {
   useWhiteBackground,
 } from "#src/util/color.js";
 import { RefCounted } from "#src/util/disposable.js";
-import { removeFromParent } from "#src/util/dom.js";
+import { removeChildren, removeFromParent } from "#src/util/dom.js";
 import { preventDrag } from "#src/util/drag_and_drop.js";
 import { makeCloseButton } from "#src/widget/close_button.js";
 import { makeDeleteButton } from "#src/widget/delete_button.js";
 import { makeIcon } from "#src/widget/icon.js";
 import { PositionWidget } from "#src/widget/position_widget.js";
+
+// Removes `layer` from the layer group displayed by `panel`.  If the layer is
+// also displayed in another layer group, it is simply removed from this one;
+// otherwise (it is the only group showing it) the layer is archived.  This
+// mirrors the behavior of the layer tab's close (×) button.
+function removeLayerFromPanel(panel: LayerBar, layer: ManagedUserLayer) {
+  if (panel.layerManager === panel.manager.rootLayers) {
+    // The layer bar corresponds to a TopLevelLayerListSpecification.  That means
+    // there is just a single layer group, archive the layer unconditionally.
+    layer.setArchived(true);
+  } else if (layer.containers.size > 2) {
+    // Layer is contained in at least one other layer group (root + this group +
+    // another), just remove it from this layer group.
+    panel.layerManager.removeManagedLayer(layer);
+  } else {
+    // Layer is not contained in any other layer group.  Archive it.
+    layer.setArchived(true);
+  }
+}
+
+// Returns the layer subsets (other than `panel`'s) belonging to the same root,
+// split into those that currently contain `layer` and those that do not.
+function getOtherPanels(panel: LayerBar, layer: ManagedUserLayer) {
+  const withLayer: LayerSubsetSpecification[] = [];
+  const withoutLayer: LayerSubsetSpecification[] = [];
+  for (const subset of panel.manager.root.subsets) {
+    if (subset.layerManager === panel.layerManager) continue;
+    (subset.layerManager.has(layer) ? withLayer : withoutLayer).push(subset);
+  }
+  return { withLayer, withoutLayer };
+}
+
+// Removes `layer` from every layer group other than `panel`'s, so it is shown
+// only in `panel`.
+function showLayerOnlyInPanel(panel: LayerBar, layer: ManagedUserLayer) {
+  for (const subset of getOtherPanels(panel, layer).withLayer) {
+    subset.layerManager.removeManagedLayer(layer);
+  }
+}
+
+// Moves `layer` from `panel` into the single other layer group, adding it there
+// if necessary.
+function moveLayerToOtherPanel(panel: LayerBar, layer: ManagedUserLayer) {
+  const { withLayer, withoutLayer } = getOtherPanels(panel, layer);
+  const others = [...withLayer, ...withoutLayer];
+  if (others.length !== 1) return;
+  const other = others[0];
+  if (!other.layerManager.has(layer)) {
+    other.layerManager.addManagedLayer(layer.addRef());
+  }
+  removeLayerFromPanel(panel, layer);
+}
 
 class LayerWidget extends RefCounted {
   element = document.createElement("div");
@@ -54,6 +110,7 @@ class LayerWidget extends RefCounted {
   maxLength = 0;
   prevValueText = "";
   private colorChangeDisposer: () => void = () => {};
+  private contextMenu = this.registerDisposer(new ContextMenu());
 
   constructor(
     public layer: ManagedUserLayer,
@@ -93,22 +150,7 @@ class LayerWidget extends RefCounted {
     const closeElement = makeCloseButton();
     closeElement.title = "Remove layer from this layer group";
     closeElement.addEventListener("click", (event: MouseEvent) => {
-      if (this.panel.layerManager === this.panel.manager.rootLayers) {
-        // The layer bar corresponds to a TopLevelLayerListSpecification.  That means there is just
-        // a single layer group, archive the layer unconditionally.
-        this.layer.setArchived(true);
-      } else {
-        // The layer bar corresponds to a LayerSubsetSpecification.  The layer is always contained
-        // in the root LayerManager, as well as the LayerManager for each LayerSubsetSpecification.
-        if (this.layer.containers.size > 2) {
-          // Layer is contained in at least one other layer group, just remove it from this layer
-          // group.
-          this.panel.layerManager.removeManagedLayer(this.layer);
-        } else {
-          // Layer is not contained in any other layer group.  Archive it.
-          this.layer.setArchived(true);
-        }
-      }
+      removeLayerFromPanel(this.panel, this.layer);
       event.stopPropagation();
     });
     const deleteElement = makeDeleteButton();
@@ -169,8 +211,7 @@ class LayerWidget extends RefCounted {
     });
 
     element.addEventListener("contextmenu", (event: MouseEvent) => {
-      panel.selectedLayer.layer = layer;
-      panel.selectedLayer.visible = true;
+      this.showContextMenu(event);
       event.stopPropagation();
       event.preventDefault();
     });
@@ -178,6 +219,44 @@ class LayerWidget extends RefCounted {
       getLayoutSpec: () => panel.getLayoutSpecForDrag(),
     });
     registerLayerBarDropHandlers(this.panel, element, this.layer);
+  }
+
+  private showContextMenu(event: MouseEvent) {
+    const { contextMenu, layer, panel } = this;
+    // The context menu only offers actions that move a layer between layer
+    // groups, so it is only shown when the screen is split into multiple layer
+    // groups (i.e. this bar corresponds to a subset, not the single top-level
+    // group).  With a single panel, right-clicking does nothing.
+    if (panel.layerManager === panel.manager.rootLayers) {
+      return;
+    }
+    const menu = contextMenu.element;
+    removeChildren(menu);
+    const addItem = (text: string, action: () => void) => {
+      const button = document.createElement("button");
+      button.textContent = text;
+      button.addEventListener("click", () => {
+        action();
+        contextMenu.hide();
+      });
+      menu.appendChild(button);
+    };
+    addItem("Layer controls", () => {
+      panel.selectedLayer.layer = layer;
+      panel.selectedLayer.visible = true;
+    });
+    const { withLayer, withoutLayer } = getOtherPanels(panel, layer);
+    const numPanels = withLayer.length + withoutLayer.length + 1;
+    if (numPanels === 2 && withoutLayer.length === 1) {
+      addItem("Move to other panel", () => moveLayerToOtherPanel(panel, layer));
+    }
+    if (withLayer.length > 0) {
+      addItem("Show only in this panel", () =>
+        showLayerOnlyInPanel(panel, layer),
+      );
+    }
+    addItem("Remove from this panel", () => removeLayerFromPanel(panel, layer));
+    contextMenu.show(event);
   }
 
   setColor() {

--- a/src/ui/layer_drag_and_drop.ts
+++ b/src/ui/layer_drag_and_drop.ts
@@ -104,6 +104,21 @@ export function endLayerDrag(dropEffect = "none") {
       dragSource.manager.layerManager.filter(
         (x: ManagedUserLayer) => !removedLayers.has(x),
       );
+      // After removal from the source panel, a layer that is no longer shown in
+      // any layer group would be garbage-collected from the master layer list
+      // (the master LayerManager collects layers with a single reference).
+      // Archive it instead so it stays available in the master layer list --
+      // this matches the layer tab's close button and makes dragging a layer
+      // back onto the master layer list ("main parent") behave like closing it
+      // from its last group.  `containers` holds the master LayerManager plus one
+      // entry per group showing the layer, so size <= 1 means it is no longer in
+      // any group.  When moved to another group instead, that group keeps it
+      // (size >= 2) and it is not archived.
+      for (const layer of dragSource.layers) {
+        if (!layer.archived && layer.containers.size <= 1) {
+          layer.setArchived(true);
+        }
+      }
     }
     dragSource.disposer();
   }
@@ -233,6 +248,34 @@ export class DropLayers {
 
 type LayerDropEffect = "none" | "move" | "copy" | "link";
 
+// Drop effect for dragging a layer between two different panels of the same
+// window (group -> other group, or group -> master layer list).  The default is
+// *move* (remove the layer from the panel it came from); hold Ctrl to link (show
+// it in both panels) or Shift to copy (duplicate it).  This differs from the
+// shared `getDropEffectFromModifiers`, which maps Ctrl to "move".
+function getLayerCrossPanelDropEffect(event: DragEvent): {
+  dropEffect: LayerDropEffect;
+  dropEffectMessage: string;
+} {
+  let dropEffect: LayerDropEffect;
+  if (event.shiftKey) {
+    dropEffect = "copy";
+  } else if (event.ctrlKey) {
+    dropEffect = "link";
+  } else {
+    dropEffect = "move";
+  }
+  let message = "";
+  const addMessage = (msg: string) => {
+    if (message !== "") message += ", ";
+    message += msg;
+  };
+  if (dropEffect !== "move") addMessage("release modifiers to move");
+  if (dropEffect !== "link") addMessage("hold CONTROL to link");
+  if (dropEffect !== "copy") addMessage("hold SHIFT to copy");
+  return { dropEffect, dropEffectMessage: message };
+}
+
 export function getLayerDropEffect(
   event: DragEvent,
   manager: Borrowed<LayerListSpecification>,
@@ -244,29 +287,28 @@ export function getLayerDropEffect(
   let defaultDropEffect: LayerDropEffect;
   if (source === undefined) {
     defaultDropEffect = "copy";
-  } else {
-    if (newTarget) {
-      // We cannot "move" layers out of the layer list panel.
-      if (!source.isLayerListPanel) {
-        moveAllowed = true;
-      }
-      defaultDropEffect = "link";
-    } else {
-      if (
-        source.manager === manager &&
-        source.isLayerListPanel === targetIsLayerListPanel
-      ) {
-        defaultDropEffect = "move";
-        moveAllowed = true;
-      } else if (targetIsLayerListPanel) {
-        defaultDropEffect = "none";
-      } else if (source.isLayerListPanel) {
-        defaultDropEffect = "link";
-      } else {
-        moveAllowed = true;
-        defaultDropEffect = "link";
-      }
+  } else if (newTarget) {
+    // We cannot "move" layers out of the layer list panel.
+    if (!source.isLayerListPanel) {
+      moveAllowed = true;
     }
+    defaultDropEffect = "link";
+  } else if (
+    source.manager === manager &&
+    source.isLayerListPanel === targetIsLayerListPanel
+  ) {
+    // Reordering within the same panel.
+    defaultDropEffect = "move";
+    moveAllowed = true;
+  } else if (source.isLayerListPanel) {
+    // Dragging from the master layer list into a group panel: link only.  A
+    // layer cannot be moved *out* of the master list (that would delete it); it
+    // is only shown/hidden in individual groups.
+    defaultDropEffect = "link";
+  } else {
+    // Dragging a layer from a group panel to a different panel: another group,
+    // or back onto the master layer list (the "main parent").  Default to move.
+    return getLayerCrossPanelDropEffect(event);
   }
   return getDropEffectFromModifiers(event, defaultDropEffect, moveAllowed);
 }
@@ -518,10 +560,15 @@ export function registerLayerBarDropHandlers(
       return;
     }
     const { dropLayers, dropEffect, dropEffectMessage } = updateResult;
-    const numLayers = dropLayers.layers.size;
     let message = "";
     const maybePlural = dropLayers.numSourceLayers === 1 ? "" : "s";
     const numSourceLayers = dropLayers.numSourceLayers;
+    // For a move, every source layer is removed from its origin panel, even if
+    // some are already present in the target (e.g. dropping onto the master
+    // layer list, which already contains every layer), so report the source
+    // count rather than the number of layers added to the target.
+    const numLayers =
+      dropEffect === "move" ? numSourceLayers : dropLayers.layers.size;
     if (dropEffect === "none") {
       message = `Cannot link dragged layer${maybePlural} here`;
     } else {

--- a/src/ui/viewer_settings.ts
+++ b/src/ui/viewer_settings.ts
@@ -116,6 +116,10 @@ export class ViewerSettingsPanel extends SidePanel {
       scroll.appendChild(labelElement);
     };
     addCheckbox("Show axis lines", viewer.showAxisLines);
+    addCheckbox(
+      "Show hover position in all cross-sections",
+      viewer.showCrossSectionHoverPosition,
+    );
     addCheckbox("Show scale bar", viewer.showScaleBar);
     addCheckbox("Show cross sections in 3-d", viewer.showPerspectiveSliceViews);
     addCheckbox(

--- a/src/viewer.ts
+++ b/src/viewer.ts
@@ -265,6 +265,10 @@ class TrackableViewerState extends CompoundTrackable {
     this.add("projectionDepth", viewer.projectionDepthRange);
     this.add("layers", viewer.layerSpecification);
     this.add("showAxisLines", viewer.showAxisLines);
+    this.add(
+      "showCrossSectionHoverPosition",
+      viewer.showCrossSectionHoverPosition,
+    );
     this.add("wireFrame", viewer.wireFrame);
     this.add("enableAdaptiveDownsampling", viewer.enableAdaptiveDownsampling);
     this.add("showScaleBar", viewer.showScaleBar);
@@ -439,6 +443,7 @@ export class Viewer extends RefCounted implements ViewerState {
     new SelectedLayerState(this.layerManager.addRef()),
   );
   showAxisLines = new TrackableBoolean(true, true);
+  showCrossSectionHoverPosition = new TrackableBoolean(false, false);
   wireFrame = new TrackableBoolean(false, false);
   enableAdaptiveDownsampling = new TrackableBoolean(true, true);
   showScaleBar = new TrackableBoolean(true, true);
@@ -1155,6 +1160,9 @@ export class Viewer extends RefCounted implements ViewerState {
     });
 
     this.bindAction("toggle-axis-lines", () => this.showAxisLines.toggle());
+    this.bindAction("toggle-cross-section-hover-position", () =>
+      this.showCrossSectionHoverPosition.toggle(),
+    );
     this.bindAction("toggle-scale-bar", () => this.showScaleBar.toggle());
     this.bindAction("toggle-default-annotations", () =>
       this.showDefaultAnnotations.toggle(),

--- a/src/viewer_state.ts
+++ b/src/viewer_state.ts
@@ -33,6 +33,7 @@ export interface ViewerState extends VisibilityPrioritySpecification {
   navigationState: NavigationState;
   mouseState: MouseSelectionState;
   showAxisLines: TrackableBoolean;
+  showCrossSectionHoverPosition: TrackableBoolean;
   layerManager: LayerManager;
   selectedLayer: SelectedLayerState;
   selectionDetailsState: TrackableDataSelectionState;


### PR DESCRIPTION
## Summary

This branch adds two independent cross-section cursor / layer-panel usability features plus some unit tests. I implemented them as part of the same PR because for the cross-section cursor I had a hard time moving an existing layer under a different root. Initially when I it kept the layer in both section which was confusing when IU under both roots which moved it kept 2 copies which for me created a lot of confusion especially if I had to adjust the rendering controls for the layer. I played with a layer-tab context menu but I found dragging more intuitive.


## 1. Synchronized cross-section hover cursor

A toggle (`showCrossSectionHoverPosition`) that echoes the mouse-hover position from the cross-section panel. I found this feature useful when I check registered images - sometime is more convenient being able to hover over the fixed and moving images simultaneously  instead of toggling the corresponding layers on/off.

- Bound to the **`c`** key and exposed in the viewer settings dialog.
- Only has an effect when two or more cross-section panels are shown side by side; a single panel never draws it (the active cursor is always in that panel).
- Serialized in the viewer state, the Python API, and the JSON schema.

## 2. Move layers between panels (and back to the master layer list) by dragging

- Fixes drag-and-drop of layer tabs across split (multi layer-group) layouts:

- Dragging a layer tab from one group panel to another now **moves** it (removes it from the panel it came from) by default, instead of linking it into both. Hold **Ctrl** to link (show in both panels), **Shift** to copy.
- Dragging a layer from a group panel onto the master **Layer List** side panel is now allowed and removes it from its source group — mirroring the layer tab's
    × close button: it is archived if it was its last group, and left untouched in any other groups that still show it. Previously this was silently a no-op / disallowed.
