### PR TITLE
Cross section hover cursor

### DIFF
--- a/docs/json_schema/viewer_state.yml
+++ b/docs/json_schema/viewer_state.yml
@@ -41,6 +41,12 @@ properties:
     type: boolean
     title: "Indicates whether to show the red/green/blue axis lines."
     default: true
+  showCrossSectionHoverPosition:
+    type: boolean
+    title: |
+      Indicates whether to show the position hovered in one cross-section panel
+      as a marker in the other cross-section panels.
+    default: false
   wireFrame:
     type: boolean
     title: "Indicates whether to enable wireframe rendering mode (for debugging)."

--- a/python/neuroglancer/viewer_state.py
+++ b/python/neuroglancer/viewer_state.py
@@ -1927,6 +1927,9 @@ class ViewerState(JsonObjectWrapper):
     show_axis_lines = showAxisLines = wrapped_property(
         "showAxisLines", optional(bool, True)
     )
+    show_cross_section_hover_position = showCrossSectionHoverPosition = (
+        wrapped_property("showCrossSectionHoverPosition", optional(bool, False))
+    )
     wire_frame = wireFrame = wrapped_property("wireFrame", optional(bool, False))
     enable_adaptive_downsampling = enableAdaptiveDownsampling = wrapped_property(
         "enableAdaptiveDownsampling", optional(bool, True)

--- a/python/tests/volume_rendering_test.py
+++ b/python/tests/volume_rendering_test.py
@@ -11,38 +11,28 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Test volume rendering picking."""
+"""Test volume rendering picking and rendering."""
 
 import threading
 
 import neuroglancer
 import numpy as np
+import pytest
 
 
-def test_volume_rendering_picking_does_not_occlude_mesh(webdriver):
-    """Volume rendering must not steal pick buffer entries from a transparent entry in front of it.
-
-    Scene: a transparent segmentation mesh occupies the near half of the volume (low z,
-    close to the default camera which looks in the +z direction), and an image volume
-    occupies the far half (high z).  Clicking the centre of the 3-D view should pick
-    the mesh, not the image.
-
-    The regression being guarded: before the fix, volume rendering wrote the near-plane
-    depth (≈ 0) to the picking buffer, making it appear closer than any real geometry
-    and stealing pick buffer entries from meshes that were geometrically in front of it.
-    """
+def _setup_viewer_with_volume_and_mesh(webdriver, orthographic, mesh_opacity=1.0):
     shape = (20, 20, 20)
 
     # Image data in the far half of the volume (high z = far from default camera,
     # which looks in the +z direction so low z is nearest).
     image_data = np.zeros(shape, dtype=np.uint8)
-    image_data[:, :, 10:20] = 200
+    image_data[1:19, 1:19, 11:20] = 255
 
     # Segmentation cube in the near half (low z = close to default camera).
     # The cube must not touch any array boundary so that marching cubes generates
     # a fully closed mesh rather than an open plane.
     seg_data = np.zeros(shape, dtype=np.uint64)
-    seg_data[2:18, 2:18, 2:9] = 1
+    seg_data[1:19, 1:19, 1:9] = 1
 
     with webdriver.viewer.txn() as s:
         s.dimensions = neuroglancer.CoordinateSpace(
@@ -54,7 +44,13 @@ def test_volume_rendering_picking_does_not_occlude_mesh(webdriver):
                 source=neuroglancer.LocalVolume(
                     data=image_data, dimensions=s.dimensions
                 ),
-                volume_rendering_mode="On",
+                volume_rendering_mode="Max",
+                shader="""
+#uicontrol invlerp normalized
+void main() {
+    emitRGBA(vec4(0.0, 0.0, normalized(), 1.0));
+}
+                """,
             ),
         )
         s.layers.append(
@@ -62,13 +58,67 @@ def test_volume_rendering_picking_does_not_occlude_mesh(webdriver):
             layer=neuroglancer.SegmentationLayer(
                 source=neuroglancer.LocalVolume(data=seg_data, dimensions=s.dimensions),
                 segments=[1],
-                object_alpha=0.5,
+                segment_default_color="#ff0000",
+                hover_highlight=False,
+                object_alpha=mesh_opacity,
             ),
         )
         s.layout = "3d"
+        s.layout.orthographic_projection = orthographic
         s.show_axis_lines = False
         s.position = [10, 10, 10]
-        s.projection_scale = 30
+        s.projection_scale = 15
+
+
+@pytest.mark.parametrize("orthographic", [False, True])
+def test_volume_rendering_occlusion(webdriver, orthographic):
+    """Test that an opaque mesh occludes a volume rendered from an image volume.
+
+    Specifically, this aims to check the harder case where the mesh sits
+    inside a single image chunk, as opposed to fully being in front of the chunk.
+    """
+    _setup_viewer_with_volume_and_mesh(webdriver, orthographic=orthographic)
+
+    # The mesh should occlude the volume with default camera
+    webdriver.sync()
+    screenshot = webdriver.viewer.screenshot(size=[10, 10]).screenshot
+    pixels = screenshot.image_pixels
+    # Lighting causes each color channel to vary slightly instead of saturating
+    # at 255, so check bounds rather than exact equality.
+    # Mesh is red, so the only non-zero colors should be in the red channel.
+    np.testing.assert_array_equal(pixels[..., 1], 0)
+    np.testing.assert_array_equal(pixels[..., 2], 0)
+    np.testing.assert_array_equal(pixels[..., 3], 255)
+    assert np.all(pixels[..., 0] >= 230)
+
+    # On flipping the camera, a full opacity volume rendering occludes the mesh
+    with webdriver.viewer.txn() as s:
+        s.projection_orientation = [0, 1, 0, 0]
+
+    webdriver.sync()
+    screenshot = webdriver.viewer.screenshot(size=[10, 10]).screenshot
+    np.testing.assert_array_equal(
+        screenshot.image_pixels,
+        np.tile(np.array([0, 0, 255, 255], dtype=np.uint8), (10, 10, 1)),
+    )
+
+
+@pytest.mark.parametrize("orthographic", [False, True])
+def test_volume_rendering_picking_does_not_occlude_mesh(webdriver, orthographic):
+    """Volume rendering must not steal pick buffer entries from a transparent entry in front of it.
+
+    Scene: a transparent segmentation mesh occupies the near half of the volume (low z,
+    close to the default camera which looks in the +z direction), and an image volume
+    occupies the far half (high z).  Clicking the centre of the 3-D view should pick
+    the mesh, not the image.
+
+    The regression being guarded: before the fix, volume rendering wrote the near-plane
+    depth (≈ 0) to the picking buffer, making it appear closer than any real geometry
+    and stealing pick buffer entries from meshes that were geometrically in front of it.
+    """
+    _setup_viewer_with_volume_and_mesh(
+        webdriver, orthographic=orthographic, mesh_opacity=0.5
+    )
 
     # threading.Event is required because the pick callback fires on a background
     # thread (browser → Python action dispatch), not on the test's main thread.

--- a/src/data_panel_layout.ts
+++ b/src/data_panel_layout.ts
@@ -91,6 +91,7 @@ export interface ViewerUIState
   selectionDetailsState: TrackableDataSelectionState;
   showPerspectiveSliceViews: TrackableBoolean;
   showAxisLines: TrackableBoolean;
+  showCrossSectionHoverPosition: TrackableBoolean;
   wireFrame: TrackableBoolean;
   enableAdaptiveDownsampling: TrackableBoolean;
   showScaleBar: TrackableBoolean;
@@ -177,6 +178,7 @@ export function getCommonViewerState(viewer: ViewerUIState) {
     mouseState: viewer.mouseState,
     layerManager: viewer.layerManager,
     showAxisLines: viewer.showAxisLines,
+    showCrossSectionHoverPosition: viewer.showCrossSectionHoverPosition,
     wireFrame: viewer.wireFrame,
     enableAdaptiveDownsampling: viewer.enableAdaptiveDownsampling,
     visibleLayerRoles: viewer.visibleLayerRoles,

--- a/src/hover_position_marker.spec.ts
+++ b/src/hover_position_marker.spec.ts
@@ -1,0 +1,183 @@
+/**
+ * @license
+ * Copyright 2024 Google Inc.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, it, expect } from "vitest";
+import type { ProjectionParameters } from "#src/projection_parameters.js";
+import {
+  computeHoverMarkerMatrix,
+  crossSectionHoverMarkerAlpha,
+  shouldDrawCrossSectionHoverMarker,
+} from "#src/hover_position_marker.js";
+import { mat4 } from "#src/util/geom.js";
+
+describe("shouldDrawCrossSectionHoverMarker", () => {
+  // The marker echoes the position hovered in one panel into the *other*
+  // cross-section panels.  It is therefore drawn only in a panel that does not
+  // hold the cursor -- which never happens with a single panel, and only happens
+  // once panels are shown side by side.
+
+  it("is not drawn in a single panel (cursor always in the only panel)", () => {
+    // Single panel: whenever the cursor is active it is in this (the only)
+    // panel, so `mouseInThisPanel` is true and nothing is echoed.
+    expect(
+      shouldDrawCrossSectionHoverMarker({
+        enabled: true,
+        mouseActive: true,
+        mouseInThisPanel: true,
+      }),
+    ).toBe(false);
+  });
+
+  it("is drawn in a side-by-side panel that does not hold the cursor", () => {
+    // Two (or more) panels side by side: the panel the cursor is NOT over echoes
+    // the hovered position.
+    expect(
+      shouldDrawCrossSectionHoverMarker({
+        enabled: true,
+        mouseActive: true,
+        mouseInThisPanel: false,
+      }),
+    ).toBe(true);
+  });
+
+  it("is not drawn in the side-by-side panel that holds the cursor", () => {
+    expect(
+      shouldDrawCrossSectionHoverMarker({
+        enabled: true,
+        mouseActive: true,
+        mouseInThisPanel: true,
+      }),
+    ).toBe(false);
+  });
+
+  it("is not drawn when the feature is toggled off", () => {
+    // Even side by side with the cursor in another panel, the toggle gates it.
+    expect(
+      shouldDrawCrossSectionHoverMarker({
+        enabled: false,
+        mouseActive: true,
+        mouseInThisPanel: false,
+      }),
+    ).toBe(false);
+  });
+
+  it("is not drawn when the mouse is not active in any panel", () => {
+    expect(
+      shouldDrawCrossSectionHoverMarker({
+        enabled: true,
+        mouseActive: false,
+        mouseInThisPanel: false,
+      }),
+    ).toBe(false);
+  });
+});
+
+// Builds a minimal ProjectionParameters carrying only the fields
+// computeHoverMarkerMatrix reads.
+function makeProjectionParameters(
+  viewProjectionMat: mat4,
+  displayDimensionIndices: Int32Array,
+  canonicalVoxelFactors: Float32Array,
+): ProjectionParameters {
+  return {
+    viewProjectionMat,
+    displayDimensionRenderInfo: {
+      displayDimensionIndices,
+      canonicalVoxelFactors,
+    },
+  } as unknown as ProjectionParameters;
+}
+
+describe("computeHoverMarkerMatrix", () => {
+  it("centers the marker at the given global position", () => {
+    const projectionParameters = makeProjectionParameters(
+      mat4.identity(mat4.create()),
+      Int32Array.of(0, 1, 2),
+      Float32Array.of(1, 1, 1),
+    );
+    const position = Float32Array.of(3, -4, 5);
+    const mat = computeHoverMarkerMatrix(projectionParameters, 1, position);
+    // With an identity view-projection and unit voxel factors, the translation
+    // column of the marker matrix is exactly the hovered position.
+    expect(Array.from(mat.slice(12, 15))).toEqual([3, -4, 5]);
+  });
+
+  it("scales the marker by markerSize / canonicalVoxelFactors", () => {
+    const projectionParameters = makeProjectionParameters(
+      mat4.identity(mat4.create()),
+      Int32Array.of(0, 1, 2),
+      Float32Array.of(1, 2, 4),
+    );
+    const mat = computeHoverMarkerMatrix(
+      projectionParameters,
+      8,
+      Float32Array.of(0, 0, 0),
+    );
+    // Diagonal scale entries: markerSize / canonicalVoxelFactors[i].
+    expect(mat[0]).toBe(8 / 1);
+    expect(mat[5]).toBe(8 / 2);
+    expect(mat[10]).toBe(8 / 4);
+  });
+
+  it("ignores display dimensions mapped to -1", () => {
+    const projectionParameters = makeProjectionParameters(
+      mat4.identity(mat4.create()),
+      Int32Array.of(0, -1, 2),
+      Float32Array.of(1, 1, 1),
+    );
+    const position = Float32Array.of(3, 4, 5);
+    const mat = computeHoverMarkerMatrix(projectionParameters, 1, position);
+    // The second display dimension is unmapped, so its translation is 0.
+    expect(Array.from(mat.slice(12, 15))).toEqual([3, 0, 5]);
+  });
+});
+
+describe("crossSectionHoverMarkerAlpha", () => {
+  // Builds a marker matrix whose projected center has the given normalized
+  // device z (clip z / clip w) by setting the last column to [_, _, ndcZ, 1].
+  function markerMatWithNdcZ(ndcZ: number): mat4 {
+    const mat = mat4.identity(mat4.create());
+    mat[14] = ndcZ;
+    mat[15] = 1;
+    return mat;
+  }
+
+  it("is fully opaque on the slice plane (ndcZ == 0)", () => {
+    expect(crossSectionHoverMarkerAlpha(markerMatWithNdcZ(0))).toBe(1);
+  });
+
+  it("fades linearly with distance from the slice plane", () => {
+    expect(crossSectionHoverMarkerAlpha(markerMatWithNdcZ(0.25))).toBeCloseTo(
+      0.75,
+    );
+    expect(crossSectionHoverMarkerAlpha(markerMatWithNdcZ(-0.25))).toBeCloseTo(
+      0.75,
+    );
+  });
+
+  it("is invisible at and beyond the depth-slab edge (|ndcZ| >= 1)", () => {
+    expect(crossSectionHoverMarkerAlpha(markerMatWithNdcZ(1))).toBe(0);
+    expect(crossSectionHoverMarkerAlpha(markerMatWithNdcZ(1.5))).toBe(0);
+    expect(crossSectionHoverMarkerAlpha(markerMatWithNdcZ(-2))).toBe(0);
+  });
+
+  it("treats a zero clip w as on-plane", () => {
+    const mat = mat4.identity(mat4.create());
+    mat[14] = 5;
+    mat[15] = 0;
+    expect(crossSectionHoverMarkerAlpha(mat)).toBe(1);
+  });
+});

--- a/src/hover_position_marker.spec.ts
+++ b/src/hover_position_marker.spec.ts
@@ -87,61 +87,114 @@ describe("shouldDrawCrossSectionHoverMarker", () => {
 
 // Builds a minimal ProjectionParameters carrying only the fields
 // computeHoverMarkerMatrix reads.
-function makeProjectionParameters(
-  viewProjectionMat: mat4,
-  displayDimensionIndices: Int32Array,
-  canonicalVoxelFactors: Float32Array,
-): ProjectionParameters {
+function makeProjectionParameters(options: {
+  viewProjectionMat: mat4;
+  displayDimensionIndices: Int32Array;
+  logicalWidth: number;
+  logicalHeight: number;
+}): ProjectionParameters {
+  const {
+    viewProjectionMat,
+    displayDimensionIndices,
+    logicalWidth,
+    logicalHeight,
+  } = options;
   return {
     viewProjectionMat,
+    logicalWidth,
+    logicalHeight,
     displayDimensionRenderInfo: {
       displayDimensionIndices,
-      canonicalVoxelFactors,
     },
   } as unknown as ProjectionParameters;
 }
 
 describe("computeHoverMarkerMatrix", () => {
-  it("centers the marker at the given global position", () => {
-    const projectionParameters = makeProjectionParameters(
-      mat4.identity(mat4.create()),
-      Int32Array.of(0, 1, 2),
-      Float32Array.of(1, 1, 1),
-    );
-    const position = Float32Array.of(3, -4, 5);
+  it("centers the reticle at the projected hover position", () => {
+    const projectionParameters = makeProjectionParameters({
+      viewProjectionMat: mat4.identity(mat4.create()),
+      displayDimensionIndices: Int32Array.of(0, 1, 2),
+      logicalWidth: 100,
+      logicalHeight: 100,
+    });
+    const position = Float32Array.of(0.3, -0.4, 0.5);
     const mat = computeHoverMarkerMatrix(projectionParameters, 1, position);
-    // With an identity view-projection and unit voxel factors, the translation
-    // column of the marker matrix is exactly the hovered position.
-    expect(Array.from(mat.slice(12, 15))).toEqual([3, -4, 5]);
+    // With an identity view-projection (w = 1) the reticle center is the hovered
+    // position in normalized device coordinates.
+    expect(mat[12]).toBeCloseTo(0.3);
+    expect(mat[13]).toBeCloseTo(-0.4);
+    expect(mat[14]).toBeCloseTo(0.5);
+    expect(mat[15]).toBe(1);
   });
 
-  it("scales the marker by markerSize / canonicalVoxelFactors", () => {
-    const projectionParameters = makeProjectionParameters(
-      mat4.identity(mat4.create()),
-      Int32Array.of(0, 1, 2),
-      Float32Array.of(1, 2, 4),
-    );
+  it("sizes the reticle in screen space (pixels -> NDC via viewport)", () => {
+    const projectionParameters = makeProjectionParameters({
+      viewProjectionMat: mat4.identity(mat4.create()),
+      displayDimensionIndices: Int32Array.of(0, 1, 2),
+      logicalWidth: 200,
+      logicalHeight: 100,
+    });
     const mat = computeHoverMarkerMatrix(
       projectionParameters,
-      8,
+      10,
       Float32Array.of(0, 0, 0),
     );
-    // Diagonal scale entries: markerSize / canonicalVoxelFactors[i].
-    expect(mat[0]).toBe(8 / 1);
-    expect(mat[5]).toBe(8 / 2);
-    expect(mat[10]).toBe(8 / 4);
+    // Half-extent in NDC = 2 * pixels / logicalSize; independent of the world.
+    expect(mat[0]).toBeCloseTo((2 * 10) / 200); // x arm: 0.1
+    expect(mat[5]).toBeCloseTo((2 * 10) / 100); // y arm: 0.2
+    // The reticle lies in the screen plane; no local-z contribution.
+    expect(mat[10]).toBe(0);
   });
 
   it("ignores display dimensions mapped to -1", () => {
-    const projectionParameters = makeProjectionParameters(
-      mat4.identity(mat4.create()),
-      Int32Array.of(0, -1, 2),
-      Float32Array.of(1, 1, 1),
-    );
-    const position = Float32Array.of(3, 4, 5);
+    const projectionParameters = makeProjectionParameters({
+      viewProjectionMat: mat4.identity(mat4.create()),
+      displayDimensionIndices: Int32Array.of(0, -1, 2),
+      logicalWidth: 100,
+      logicalHeight: 100,
+    });
+    const position = Float32Array.of(0.3, 0.4, 0.5);
     const mat = computeHoverMarkerMatrix(projectionParameters, 1, position);
-    // The second display dimension is unmapped, so its translation is 0.
-    expect(Array.from(mat.slice(12, 15))).toEqual([3, 0, 5]);
+    // The second display dimension is unmapped, so its coordinate is 0.
+    expect(mat[12]).toBeCloseTo(0.3);
+    expect(mat[13]).toBe(0);
+    expect(mat[14]).toBeCloseTo(0.5);
+  });
+
+  it("draws an identically-shaped crosshair regardless of panel orientation", () => {
+    // The core of the fix: in every orthoview the reticle must be the same
+    // screen-space "+", not a cross in one panel and a line in the others.  Two
+    // panels viewing the same point through different orientations (identity vs
+    // a 90-degree rotation about X, i.e. an xy- vs xz-style view) must yield the
+    // same in-plane arm sizes.
+    const viewport = { logicalWidth: 100, logicalHeight: 100 };
+    const position = Float32Array.of(0.2, 0.3, 0.4);
+
+    const xyView = computeHoverMarkerMatrix(
+      makeProjectionParameters({
+        viewProjectionMat: mat4.identity(mat4.create()),
+        displayDimensionIndices: Int32Array.of(0, 1, 2),
+        ...viewport,
+      }),
+      8,
+      position,
+    );
+    const rotated = mat4.fromXRotation(mat4.create(), Math.PI / 2);
+    const xzView = computeHoverMarkerMatrix(
+      makeProjectionParameters({
+        viewProjectionMat: rotated,
+        displayDimensionIndices: Int32Array.of(0, 1, 2),
+        ...viewport,
+      }),
+      8,
+      position,
+    );
+
+    // Both arms have the same non-zero screen-space length in both panels.
+    expect(xyView[0]).toBeGreaterThan(0);
+    expect(xyView[5]).toBeGreaterThan(0);
+    expect(xzView[0]).toBeCloseTo(xyView[0]);
+    expect(xzView[5]).toBeCloseTo(xyView[5]);
   });
 });
 

--- a/src/hover_position_marker.ts
+++ b/src/hover_position_marker.ts
@@ -1,0 +1,123 @@
+/**
+ * @license
+ * Copyright 2024 Google Inc.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @file Draws a small reticle marker at the mouse-hover position within a
+ * cross-section slice panel.  Used to display the position currently hovered in
+ * one panel as a marker in the other panels (see
+ * `showCrossSectionHoverPosition`).
+ */
+
+import type { ProjectionParameters } from "#src/projection_parameters.js";
+import { RefCounted } from "#src/util/disposable.js";
+import { mat4, type vec4 } from "#src/util/geom.js";
+import { GLBuffer } from "#src/webgl/buffer.js";
+import type { GL } from "#src/webgl/context.js";
+import type { ShaderProgram } from "#src/webgl/shader.js";
+import { trivialUniformColorShader } from "#src/webgl/trivial_shaders.js";
+
+const tempMat = mat4.create();
+
+/**
+ * Computes the transform that places a fixed-size marker centered at the
+ * specified global `position`, projected into the viewport described by
+ * `projectionParameters`.  This mirrors `computeAxisLineMatrix` but uses an
+ * arbitrary position (the mouse-hover position) rather than the navigation
+ * center.
+ */
+export function computeHoverMarkerMatrix(
+  projectionParameters: ProjectionParameters,
+  markerSize: number,
+  position: Float32Array,
+) {
+  const mat = mat4.identity(tempMat);
+  const {
+    displayDimensionRenderInfo: {
+      canonicalVoxelFactors,
+      displayDimensionIndices,
+    },
+  } = projectionParameters;
+  for (let i = 0; i < 3; ++i) {
+    const globalDim = displayDimensionIndices[i];
+    mat[12 + i] =
+      globalDim === -1 || globalDim >= position.length
+        ? 0
+        : position[globalDim];
+    mat[5 * i] = markerSize / canonicalVoxelFactors[i];
+  }
+  mat4.multiply(mat, projectionParameters.viewProjectionMat, mat);
+  return mat;
+}
+
+export class HoverPositionMarker extends RefCounted {
+  vertexBuffer: GLBuffer;
+  shader: ShaderProgram;
+
+  constructor(public gl: GL) {
+    super();
+    // Two line segments forming a "+" reticle in the local X/Y plane.
+    this.vertexBuffer = this.registerDisposer(
+      GLBuffer.fromData(
+        gl,
+        new Float32Array([
+          -1,
+          0,
+          0,
+          1, //
+          1,
+          0,
+          0,
+          1, //
+          0,
+          -1,
+          0,
+          1, //
+          0,
+          1,
+          0,
+          1, //
+        ]),
+        gl.ARRAY_BUFFER,
+        gl.STATIC_DRAW,
+      ),
+    );
+    this.shader = trivialUniformColorShader(gl);
+  }
+
+  static get(gl: GL) {
+    return gl.memoize.get(
+      "SliceViewPanel:HoverPositionMarker",
+      () => new HoverPositionMarker(gl),
+    );
+  }
+
+  draw(mat: mat4, color: vec4) {
+    const { shader, gl } = this;
+    shader.bind();
+    gl.uniformMatrix4fv(shader.uniform("uProjectionMatrix"), false, mat);
+    gl.uniform4fv(shader.uniform("uColor"), color);
+    const aVertexPosition = shader.attribute("aVertexPosition");
+    this.vertexBuffer.bindToVertexAttrib(aVertexPosition, 4);
+
+    gl.enable(gl.BLEND);
+    gl.blendFunc(gl.SRC_ALPHA, gl.ONE_MINUS_SRC_ALPHA);
+    gl.lineWidth(1);
+    gl.drawArrays(gl.LINES, 0, 4);
+    gl.disable(gl.BLEND);
+
+    gl.disableVertexAttribArray(aVertexPosition);
+  }
+}

--- a/src/hover_position_marker.ts
+++ b/src/hover_position_marker.ts
@@ -23,38 +23,68 @@
  */
 
 import type { ProjectionParameters } from "#src/projection_parameters.js";
-import { mat4 } from "#src/util/geom.js";
+import { mat4, vec4 } from "#src/util/geom.js";
 
 const tempMat = mat4.create();
+const tempPoint = vec4.create();
 
 /**
- * Computes the transform that places a fixed-size marker centered at the
- * specified global `position`, projected into the viewport described by
- * `projectionParameters`.  This mirrors `computeAxisLineMatrix` but uses an
- * arbitrary position (the mouse-hover position) rather than the navigation
- * center.
+ * Computes the transform that draws the hover marker as a fixed-size,
+ * screen-aligned "+" reticle centered at the projected location of the global
+ * `position` within the panel described by `projectionParameters`.
+ *
+ * The reticle is built in screen space -- rather than in the plane of the first
+ * two display dimensions -- so that it appears as a consistent crosshair in
+ * every cross-section panel regardless of that panel's orientation.  If it were
+ * built in a fixed world plane, an arm of the "+" that happens to point along a
+ * panel's depth axis would collapse to a point, leaving only a line in the
+ * orthoviews whose slice plane differs from that world plane.
+ *
+ * The returned matrix maps the unit "+" vertices (local x/y in [-1, 1], z = 0)
+ * directly to clip space with w = 1, so no view-projection multiply is applied
+ * afterwards.  Its third row carries the marker center's normalized device z
+ * (the signed distance from this panel's slice plane) for use by
+ * {@link crossSectionHoverMarkerAlpha}.
  */
 export function computeHoverMarkerMatrix(
   projectionParameters: ProjectionParameters,
-  markerSize: number,
+  markerSizeInPixels: number,
   position: Float32Array,
 ) {
-  const mat = mat4.identity(tempMat);
   const {
-    displayDimensionRenderInfo: {
-      canonicalVoxelFactors,
-      displayDimensionIndices,
-    },
+    displayDimensionRenderInfo: { displayDimensionIndices },
+    viewProjectionMat,
+    logicalWidth,
+    logicalHeight,
   } = projectionParameters;
+  // Project the hover position (taken along the display dimensions) into clip
+  // space to obtain the reticle center.
+  const point = tempPoint;
   for (let i = 0; i < 3; ++i) {
     const globalDim = displayDimensionIndices[i];
-    mat[12 + i] =
+    point[i] =
       globalDim === -1 || globalDim >= position.length
         ? 0
         : position[globalDim];
-    mat[5 * i] = markerSize / canonicalVoxelFactors[i];
   }
-  mat4.multiply(mat, projectionParameters.viewProjectionMat, mat);
+  point[3] = 1;
+  vec4.transformMat4(point, point, viewProjectionMat);
+  const w = point[3];
+  const cx = w !== 0 ? point[0] / w : 0;
+  const cy = w !== 0 ? point[1] / w : 0;
+  const cz = w !== 0 ? point[2] / w : 0;
+  // Half-extent of the reticle in normalized device coordinates for the
+  // requested pixel size (the unit "+" vertices span [-1, 1]).
+  const hx = logicalWidth !== 0 ? (2 * markerSizeInPixels) / logicalWidth : 0;
+  const hy = logicalHeight !== 0 ? (2 * markerSizeInPixels) / logicalHeight : 0;
+  const mat = mat4.identity(tempMat);
+  mat[0] = hx;
+  mat[5] = hy;
+  mat[10] = 0;
+  mat[12] = cx;
+  mat[13] = cy;
+  mat[14] = cz;
+  mat[15] = 1;
   return mat;
 }
 

--- a/src/hover_position_marker.ts
+++ b/src/hover_position_marker.ts
@@ -15,19 +15,15 @@
  */
 
 /**
- * @file Draws a small reticle marker at the mouse-hover position within a
- * cross-section slice panel.  Used to display the position currently hovered in
- * one panel as a marker in the other panels (see
- * `showCrossSectionHoverPosition`).
+ * @file Geometry and visibility logic for the cross-section hover marker: a
+ * small reticle drawn at the mouse-hover position of one cross-section slice
+ * panel and echoed into the other panels (see `showCrossSectionHoverPosition`).
+ * The WebGL rendering lives in `./hover_position_marker_renderer.js`; this module
+ * is kept free of WebGL dependencies so the logic can be unit-tested.
  */
 
 import type { ProjectionParameters } from "#src/projection_parameters.js";
-import { RefCounted } from "#src/util/disposable.js";
-import { mat4, type vec4 } from "#src/util/geom.js";
-import { GLBuffer } from "#src/webgl/buffer.js";
-import type { GL } from "#src/webgl/context.js";
-import type { ShaderProgram } from "#src/webgl/shader.js";
-import { trivialUniformColorShader } from "#src/webgl/trivial_shaders.js";
+import { mat4 } from "#src/util/geom.js";
 
 const tempMat = mat4.create();
 
@@ -62,62 +58,40 @@ export function computeHoverMarkerMatrix(
   return mat;
 }
 
-export class HoverPositionMarker extends RefCounted {
-  vertexBuffer: GLBuffer;
-  shader: ShaderProgram;
+/**
+ * Determines whether the cross-section hover marker should be drawn in a given
+ * cross-section slice panel.
+ *
+ * The marker echoes the position hovered in one panel into the *other* panels,
+ * so it is only drawn in a panel that does not currently contain the mouse
+ * cursor.  With a single cross-section panel (no side-by-side layout) the active
+ * cursor is always within that one panel, so the marker is never drawn; it only
+ * appears once two or more panels are shown side by side and the cursor is in a
+ * different panel than this one.
+ */
+export function shouldDrawCrossSectionHoverMarker(options: {
+  // The `showCrossSectionHoverPosition` viewer toggle.
+  enabled: boolean;
+  // Whether the shared mouse cursor is currently active in some panel.
+  mouseActive: boolean;
+  // Whether the mouse cursor is within this panel (i.e. `mouseX >= 0`).
+  mouseInThisPanel: boolean;
+}): boolean {
+  const { enabled, mouseActive, mouseInThisPanel } = options;
+  return enabled && mouseActive && !mouseInThisPanel;
+}
 
-  constructor(public gl: GL) {
-    super();
-    // Two line segments forming a "+" reticle in the local X/Y plane.
-    this.vertexBuffer = this.registerDisposer(
-      GLBuffer.fromData(
-        gl,
-        new Float32Array([
-          -1,
-          0,
-          0,
-          1, //
-          1,
-          0,
-          0,
-          1, //
-          0,
-          -1,
-          0,
-          1, //
-          0,
-          1,
-          0,
-          1, //
-        ]),
-        gl.ARRAY_BUFFER,
-        gl.STATIC_DRAW,
-      ),
-    );
-    this.shader = trivialUniformColorShader(gl);
-  }
-
-  static get(gl: GL) {
-    return gl.memoize.get(
-      "SliceViewPanel:HoverPositionMarker",
-      () => new HoverPositionMarker(gl),
-    );
-  }
-
-  draw(mat: mat4, color: vec4) {
-    const { shader, gl } = this;
-    shader.bind();
-    gl.uniformMatrix4fv(shader.uniform("uProjectionMatrix"), false, mat);
-    gl.uniform4fv(shader.uniform("uColor"), color);
-    const aVertexPosition = shader.attribute("aVertexPosition");
-    this.vertexBuffer.bindToVertexAttrib(aVertexPosition, 4);
-
-    gl.enable(gl.BLEND);
-    gl.blendFunc(gl.SRC_ALPHA, gl.ONE_MINUS_SRC_ALPHA);
-    gl.lineWidth(1);
-    gl.drawArrays(gl.LINES, 0, 4);
-    gl.disable(gl.BLEND);
-
-    gl.disableVertexAttribArray(aVertexPosition);
-  }
+/**
+ * Computes the opacity of the hover marker from its projected depth, so that the
+ * marker fades with distance from this panel's slice plane.  `markerMat` is the
+ * result of {@link computeHoverMarkerMatrix}; its last column is the marker
+ * center in clip space.  The normalized device z (`z/w`) is the signed distance
+ * from the slice plane, reaching magnitude 1 at the edge of the visible depth
+ * slab, so the marker is fully opaque on the plane and invisible at/beyond the
+ * slab edge.
+ */
+export function crossSectionHoverMarkerAlpha(markerMat: mat4): number {
+  const clipW = markerMat[15];
+  const ndcZ = clipW !== 0 ? markerMat[14] / clipW : 0;
+  return Math.max(0, 1 - Math.abs(ndcZ));
 }

--- a/src/hover_position_marker_renderer.ts
+++ b/src/hover_position_marker_renderer.ts
@@ -1,0 +1,75 @@
+/**
+ * @license
+ * Copyright 2024 Google Inc.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @file WebGL rendering for the cross-section hover marker.  The geometry and
+ * visibility logic lives in `./hover_position_marker.js`.
+ */
+
+import { RefCounted } from "#src/util/disposable.js";
+import type { mat4, vec4 } from "#src/util/geom.js";
+import { GLBuffer } from "#src/webgl/buffer.js";
+import type { GL } from "#src/webgl/context.js";
+import type { ShaderProgram } from "#src/webgl/shader.js";
+import { trivialUniformColorShader } from "#src/webgl/trivial_shaders.js";
+
+export class HoverPositionMarker extends RefCounted {
+  vertexBuffer: GLBuffer;
+  shader: ShaderProgram;
+
+  constructor(public gl: GL) {
+    super();
+    // Two line segments forming a "+" reticle in the local X/Y plane.
+    this.vertexBuffer = this.registerDisposer(
+      GLBuffer.fromData(
+        gl,
+        new Float32Array([
+          -1, 0, 0, 1, //
+          1, 0, 0, 1, //
+          0, -1, 0, 1, //
+          0, 1, 0, 1, //
+        ]),
+        gl.ARRAY_BUFFER,
+        gl.STATIC_DRAW,
+      ),
+    );
+    this.shader = trivialUniformColorShader(gl);
+  }
+
+  static get(gl: GL) {
+    return gl.memoize.get(
+      "SliceViewPanel:HoverPositionMarker",
+      () => new HoverPositionMarker(gl),
+    );
+  }
+
+  draw(mat: mat4, color: vec4) {
+    const { shader, gl } = this;
+    shader.bind();
+    gl.uniformMatrix4fv(shader.uniform("uProjectionMatrix"), false, mat);
+    gl.uniform4fv(shader.uniform("uColor"), color);
+    const aVertexPosition = shader.attribute("aVertexPosition");
+    this.vertexBuffer.bindToVertexAttrib(aVertexPosition, 4);
+
+    gl.enable(gl.BLEND);
+    gl.blendFunc(gl.SRC_ALPHA, gl.ONE_MINUS_SRC_ALPHA);
+    gl.lineWidth(1);
+    gl.drawArrays(gl.LINES, 0, 4);
+    gl.disable(gl.BLEND);
+
+    gl.disableVertexAttribArray(aVertexPosition);
+  }
+}

--- a/src/layer_group_viewer.ts
+++ b/src/layer_group_viewer.ts
@@ -91,6 +91,7 @@ export interface LayerGroupViewerState {
   velocity: Owned<CoordinateSpacePlaybackVelocity>;
   mouseState: MouseSelectionState;
   showAxisLines: TrackableBoolean;
+  showCrossSectionHoverPosition: TrackableBoolean;
   wireFrame: TrackableBoolean;
   enableAdaptiveDownsampling: TrackableBoolean;
   showScaleBar: TrackableBoolean;
@@ -354,6 +355,9 @@ export class LayerGroupViewer extends RefCounted {
   }
   get showAxisLines() {
     return this.viewerState.showAxisLines;
+  }
+  get showCrossSectionHoverPosition() {
+    return this.viewerState.showCrossSectionHoverPosition;
   }
   get wireFrame() {
     return this.viewerState.wireFrame;

--- a/src/layer_groups_layout.ts
+++ b/src/layer_groups_layout.ts
@@ -406,6 +406,7 @@ function getCommonViewerState(viewer: Viewer) {
   return {
     mouseState: viewer.mouseState,
     showAxisLines: viewer.showAxisLines,
+    showCrossSectionHoverPosition: viewer.showCrossSectionHoverPosition,
     wireFrame: viewer.wireFrame,
     enableAdaptiveDownsampling: viewer.enableAdaptiveDownsampling,
     showScaleBar: viewer.showScaleBar,

--- a/src/sliceview/panel.ts
+++ b/src/sliceview/panel.ts
@@ -18,8 +18,10 @@ import { AxesLineHelper, computeAxisLineMatrix } from "#src/axes_lines.js";
 import type { DisplayContext } from "#src/display_context.js";
 import {
   computeHoverMarkerMatrix,
-  HoverPositionMarker,
+  crossSectionHoverMarkerAlpha,
+  shouldDrawCrossSectionHoverMarker,
 } from "#src/hover_position_marker.js";
+import { HoverPositionMarker } from "#src/hover_position_marker_renderer.js";
 import type { VisibleRenderLayerTracker } from "#src/layer/index.js";
 import { makeRenderedPanelVisibleLayerTracker } from "#src/layer/index.js";
 import { PickIDManager } from "#src/object_picking.js";
@@ -425,10 +427,11 @@ export class SliceViewPanel extends RenderedDataPanel {
     // Draw the hover position coming from another panel, but not in the panel
     // the mouse is currently over (`mouseX >= 0`), where the real cursor is
     // already visible.
-    const showHoverMarker =
-      this.viewer.showCrossSectionHoverPosition.value &&
-      mouseState.active &&
-      this.mouseX < 0;
+    const showHoverMarker = shouldDrawCrossSectionHoverMarker({
+      enabled: this.viewer.showCrossSectionHoverPosition.value,
+      mouseActive: mouseState.active,
+      mouseInThisPanel: this.mouseX >= 0,
+    });
     if (
       this.viewer.showAxisLines.value ||
       this.viewer.showScaleBar.value ||
@@ -459,12 +462,8 @@ export class SliceViewPanel extends RenderedDataPanel {
           HOVER_MARKER_SIZE * zoom,
           mouseState.position,
         );
-        // The last column of `markerMat` is the marker center projected into
-        // clip space; its normalized z gives the signed distance from this
-        // panel's slice plane (|z| == 1 at the edge of the visible depth slab).
-        const clipW = markerMat[15];
-        const ndcZ = clipW !== 0 ? markerMat[14] / clipW : 0;
-        const alpha = Math.max(0, 1 - Math.abs(ndcZ));
+        // Fade the marker with distance from this panel's slice plane.
+        const alpha = crossSectionHoverMarkerAlpha(markerMat);
         if (alpha > 0) {
           vec4.set(tempHoverColor, 1, 0.85, 0, alpha);
           this.hoverMarker.draw(disableZProjection(markerMat), tempHoverColor);

--- a/src/sliceview/panel.ts
+++ b/src/sliceview/panel.ts
@@ -456,10 +456,11 @@ export class SliceViewPanel extends RenderedDataPanel {
         );
       }
       if (showHoverMarker) {
-        const { value: zoom } = this.viewer.navigationState.zoomFactor;
+        // A fixed-size, screen-aligned crosshair so it reads consistently in
+        // every orthoview regardless of the panel's orientation.
         const markerMat = computeHoverMarkerMatrix(
           projectionParameters,
-          HOVER_MARKER_SIZE * zoom,
+          HOVER_MARKER_SIZE,
           mouseState.position,
         );
         // Fade the marker with distance from this panel's slice plane.

--- a/src/sliceview/panel.ts
+++ b/src/sliceview/panel.ts
@@ -16,6 +16,10 @@
 
 import { AxesLineHelper, computeAxisLineMatrix } from "#src/axes_lines.js";
 import type { DisplayContext } from "#src/display_context.js";
+import {
+  computeHoverMarkerMatrix,
+  HoverPositionMarker,
+} from "#src/hover_position_marker.js";
 import type { VisibleRenderLayerTracker } from "#src/layer/index.js";
 import { makeRenderedPanelVisibleLayerTracker } from "#src/layer/index.js";
 import { PickIDManager } from "#src/object_picking.js";
@@ -98,12 +102,18 @@ void emit(vec4 color, highp uint pickId) {
 const tempVec3 = vec3.create();
 const tempVec3b = vec3.create();
 const tempVec4 = vec4.create();
+const tempHoverColor = vec4.create();
+
+// Half-length, in logical pixels, of the "+" reticle drawn at the hover
+// position that is synchronized across cross-section panels.
+const HOVER_MARKER_SIZE = 8;
 
 export class SliceViewPanel extends RenderedDataPanel {
   declare viewer: SliceViewerState;
   private sliceViewRenderHelper;
 
   private axesLineHelper = this.registerDisposer(AxesLineHelper.get(this.gl));
+  private hoverMarker = this.registerDisposer(HoverPositionMarker.get(this.gl));
 
   private colorFactor = vec4.fromValues(1, 1, 1, 1);
   private pickIDs = new PickIDManager();
@@ -261,6 +271,20 @@ export class SliceViewPanel extends RenderedDataPanel {
         }
       }),
     );
+    this.registerDisposer(
+      viewer.showCrossSectionHoverPosition.changed.add(() => {
+        if (this.visible) {
+          this.scheduleRedraw();
+        }
+      }),
+    );
+    this.registerDisposer(
+      viewer.mouseState.changed.add(() => {
+        if (this.visible && viewer.showCrossSectionHoverPosition.value) {
+          this.scheduleRedraw();
+        }
+      }),
+    );
 
     this.registerDisposer(
       viewer.showScaleBar.changed.add(() => {
@@ -397,7 +421,19 @@ export class SliceViewPanel extends RenderedDataPanel {
       renderLayer.draw(renderContext, attachment);
     }
     gl.disable(WebGL2RenderingContext.BLEND);
-    if (this.viewer.showAxisLines.value || this.viewer.showScaleBar.value) {
+    const { mouseState } = this.viewer;
+    // Draw the hover position coming from another panel, but not in the panel
+    // the mouse is currently over (`mouseX >= 0`), where the real cursor is
+    // already visible.
+    const showHoverMarker =
+      this.viewer.showCrossSectionHoverPosition.value &&
+      mouseState.active &&
+      this.mouseX < 0;
+    if (
+      this.viewer.showAxisLines.value ||
+      this.viewer.showScaleBar.value ||
+      showHoverMarker
+    ) {
       this.offscreenFramebuffer.bindSingle(OffscreenTextures.COLOR);
       if (this.viewer.showAxisLines.value) {
         const axisLength =
@@ -415,6 +451,24 @@ export class SliceViewPanel extends RenderedDataPanel {
             computeAxisLineMatrix(projectionParameters, axisLength * zoom),
           ),
         );
+      }
+      if (showHoverMarker) {
+        const { value: zoom } = this.viewer.navigationState.zoomFactor;
+        const markerMat = computeHoverMarkerMatrix(
+          projectionParameters,
+          HOVER_MARKER_SIZE * zoom,
+          mouseState.position,
+        );
+        // The last column of `markerMat` is the marker center projected into
+        // clip space; its normalized z gives the signed distance from this
+        // panel's slice plane (|z| == 1 at the edge of the visible depth slab).
+        const clipW = markerMat[15];
+        const ndcZ = clipW !== 0 ? markerMat[14] / clipW : 0;
+        const alpha = Math.max(0, 1 - Math.abs(ndcZ));
+        if (alpha > 0) {
+          vec4.set(tempHoverColor, 1, 0.85, 0, alpha);
+          this.hoverMarker.draw(disableZProjection(markerMat), tempHoverColor);
+        }
       }
       if (this.viewer.showScaleBar.value) {
         gl.enable(WebGL2RenderingContext.BLEND);

--- a/src/ui/default_input_event_bindings.ts
+++ b/src/ui/default_input_event_bindings.ts
@@ -28,6 +28,7 @@ export function getDefaultGlobalBindings() {
     map.set("keyb", "toggle-scale-bar");
     map.set("keyv", "toggle-default-annotations");
     map.set("keya", "toggle-axis-lines");
+    map.set("keyc", "toggle-cross-section-hover-position");
     map.set("keyo", "toggle-orthographic-projection");
 
     for (let i = 1; i <= 9; ++i) {

--- a/src/ui/viewer_settings.ts
+++ b/src/ui/viewer_settings.ts
@@ -116,6 +116,10 @@ export class ViewerSettingsPanel extends SidePanel {
       scroll.appendChild(labelElement);
     };
     addCheckbox("Show axis lines", viewer.showAxisLines);
+    addCheckbox(
+      "Show hover position in all cross-sections",
+      viewer.showCrossSectionHoverPosition,
+    );
     addCheckbox("Show scale bar", viewer.showScaleBar);
     addCheckbox("Show cross sections in 3-d", viewer.showPerspectiveSliceViews);
     addCheckbox(

--- a/src/viewer.ts
+++ b/src/viewer.ts
@@ -265,6 +265,10 @@ class TrackableViewerState extends CompoundTrackable {
     this.add("projectionDepth", viewer.projectionDepthRange);
     this.add("layers", viewer.layerSpecification);
     this.add("showAxisLines", viewer.showAxisLines);
+    this.add(
+      "showCrossSectionHoverPosition",
+      viewer.showCrossSectionHoverPosition,
+    );
     this.add("wireFrame", viewer.wireFrame);
     this.add("enableAdaptiveDownsampling", viewer.enableAdaptiveDownsampling);
     this.add("showScaleBar", viewer.showScaleBar);
@@ -439,6 +443,7 @@ export class Viewer extends RefCounted implements ViewerState {
     new SelectedLayerState(this.layerManager.addRef()),
   );
   showAxisLines = new TrackableBoolean(true, true);
+  showCrossSectionHoverPosition = new TrackableBoolean(false, false);
   wireFrame = new TrackableBoolean(false, false);
   enableAdaptiveDownsampling = new TrackableBoolean(true, true);
   showScaleBar = new TrackableBoolean(true, true);
@@ -1155,6 +1160,9 @@ export class Viewer extends RefCounted implements ViewerState {
     });
 
     this.bindAction("toggle-axis-lines", () => this.showAxisLines.toggle());
+    this.bindAction("toggle-cross-section-hover-position", () =>
+      this.showCrossSectionHoverPosition.toggle(),
+    );
     this.bindAction("toggle-scale-bar", () => this.showScaleBar.toggle());
     this.bindAction("toggle-default-annotations", () =>
       this.showDefaultAnnotations.toggle(),

--- a/src/viewer_state.ts
+++ b/src/viewer_state.ts
@@ -33,6 +33,7 @@ export interface ViewerState extends VisibilityPrioritySpecification {
   navigationState: NavigationState;
   mouseState: MouseSelectionState;
   showAxisLines: TrackableBoolean;
+  showCrossSectionHoverPosition: TrackableBoolean;
   layerManager: LayerManager;
   selectedLayer: SelectedLayerState;
   selectionDetailsState: TrackableDataSelectionState;

--- a/src/volume_rendering/volume_render_layer.ts
+++ b/src/volume_rendering/volume_render_layer.ts
@@ -454,10 +454,6 @@ float computeDepthFromClipSpace(vec4 clipSpacePosition) {
   float NDCDepthCoord = clipSpacePosition.z / clipSpacePosition.w;
   return (NDCDepthCoord + 1.0) * 0.5;
 }
-vec2 computeUVFromClipSpace(vec4 clipSpacePosition) {
-  vec2 NDCPosition = clipSpacePosition.xy / clipSpacePosition.w;
-  return (NDCPosition + 1.0) * 0.5;
-}
 `,
           ]);
           builder.setFragmentMainFunction(`
@@ -498,16 +494,22 @@ void main() {
   int endStep = min(uMaxSteps, int(floor((intersectEnd - uNearLimitFraction) / stepSize)) + 1);
   outputColor = vec4(0, 0, 0, 0);
   revealage = 1.0;
+  vec4 clipNearPoint = uModelViewProjectionMatrix * vec4(nearPoint, 1.0);
+  vec4 clipFarPoint = uModelViewProjectionMatrix * vec4(farPoint, 1.0);
+  float depthInBuffer = texture(uDepthSampler, (normalizedPosition + 1.0) * 0.5).r;
   for (int rayStep = startStep; rayStep < endStep; ++rayStep) {
-    vec3 position = mix(nearPoint, farPoint, uNearLimitFraction + float(rayStep) * stepSize);
-    vec4 clipSpacePosition = uModelViewProjectionMatrix * vec4(position, 1.0);
+    // linearly interpolate position and clip space position along the ray
+    float rayFraction = uNearLimitFraction + float(rayStep) * stepSize;
+    vec3 position = mix(nearPoint, farPoint, rayFraction);
+    vec4 clipSpacePosition = mix(clipNearPoint, clipFarPoint, rayFraction);
+
+    // compute depth at the ray position and check if it is behind an opaque object
     depthAtRayPosition = computeDepthFromClipSpace(clipSpacePosition);
-    vec2 uv = computeUVFromClipSpace(clipSpacePosition);
-    float depthInBuffer = texture(uDepthSampler, uv).r;
     bool rayPositionBehindOpaqueObject = (1.0 - depthAtRayPosition) < depthInBuffer;
     if (rayPositionBehindOpaqueObject) {
       break;
     }
+
     curChunkPosition = position - uTranslation;
     userMain();
     ${glsl_handleMaxProjectionUpdate}


### PR DESCRIPTION
## Summary

This implements an option to display the cursor in the cross section synchronously when layers are viewed side-by-side

## Details

A toggle (showCrossSectionHoverPosition) echoes the mouse-hover position from the cross-section panel. Sometimes is more convenient to view layers side by side and mouse over image features in order to verify them instead of toggling layers on and off.

* Bound to the c key and exposed in the viewer settings dialog.
* Only has an effect when two or more cross-section panels are shown side by side; a single panel never draws it (the active cursor is always in that panel).
