### PR TITLE
fix find path with new lvl2ids

### DIFF
--- a/src/datasource/graphene/frontend.ts
+++ b/src/datasource/graphene/frontend.ts
@@ -2127,13 +2127,26 @@ class GrapheneGraphSource extends SegmentationGraphSource {
         // maybe a small fraction have no info
         // sometime l2 is so small (single voxel), it is ignored by l2
         // best to just drop those points
-        centroids = l2_path
+        // note that the l2 cache reports a missing id as an empty object
+        // rather than omitting it, so an absent rep_coord_nm also means
+        // missing; treating it as malformed would throw away the whole
+        // refinement over a single uncached id (common right after an edit)
+        const refined = l2_path
           .map((id) => {
             return verifyOptionalObjectProperty(attributes, id, (x) => {
-              return verifyFloatArray(x["rep_coord_nm"]);
+              return verifyOptionalObjectProperty(
+                x,
+                "rep_coord_nm",
+                verifyFloatArray,
+              );
             });
           })
           .filter((x): x is number[] => x !== undefined);
+        // if nothing could be refined, keep the unrefined path rather than
+        // replacing it with an empty one
+        if (refined.length > 0) {
+          centroids = refined;
+        }
       } catch (e) {
         console.log("e", e);
       }

--- a/src/datasource/graphene/frontend.ts
+++ b/src/datasource/graphene/frontend.ts
@@ -2122,31 +2122,25 @@ class GrapheneGraphSource extends SegmentationGraphSource {
           table,
           l2_path,
         );
-        // many reasons why an l2 id might not have info
-        // l2 cache has a process that takes time for new ids (even hours)
-        // maybe a small fraction have no info
-        // sometime l2 is so small (single voxel), it is ignored by l2
-        // best to just drop those points
-        // note that the l2 cache reports a missing id as an empty object
-        // rather than omitting it, so an absent rep_coord_nm also means
-        // missing; treating it as malformed would throw away the whole
-        // refinement over a single uncached id (common right after an edit)
-        const refined = l2_path
-          .map((id) => {
-            return verifyOptionalObjectProperty(attributes, id, (x) => {
-              return verifyOptionalObjectProperty(
-                x,
-                "rep_coord_nm",
-                verifyFloatArray,
-              );
-            });
+        // The l2 cache always includes an entry for every requested id, but
+        // that entry has no rep_coord_nm when the properties have not been
+        // computed yet. That is common right after an edit: a split creates
+        // new l2 ids and immediately retriggers find path. It also happens for
+        // an l2 so small that the cache ignores it.
+        //
+        // Fall back to the chunk level approximation of the point rather than
+        // dropping it. Because the l2 cache is available we requested
+        // precision_mode=0 above, so centroids is the graph server's rough
+        // coordinate path: one chunk center per l2 id, in order.
+        const roughCentroids = centroids;
+        centroids = l2_path
+          .map((id, i) => {
+            const repCoord = verifyObjectProperty(attributes, id, (x) =>
+              verifyOptionalObjectProperty(x, "rep_coord_nm", verifyFloatArray),
+            );
+            return repCoord ?? roughCentroids[i];
           })
           .filter((x): x is number[] => x !== undefined);
-        // if nothing could be refined, keep the unrefined path rather than
-        // replacing it with an empty one
-        if (refined.length > 0) {
-          centroids = refined;
-        }
       } catch (e) {
         console.log("e", e);
       }


### PR DESCRIPTION
when the find path tool runs with precision mode on a newly formed ID, it is likely a subset of level2graph nodes might not have attributes yet, but this fixes a problem with the current implementation where the makes all the nodes not use the pcgl2cache point, rather than just the ones that weren't included in the response.