### PR TITLE
fix: find groups in global search of command palette

### DIFF
--- a/src/ui/command_catalog.spec.ts
+++ b/src/ui/command_catalog.spec.ts
@@ -110,17 +110,6 @@ describe("collectActionBindings", () => {
     expect(forAction).toHaveLength(1);
     expect(forAction[0].eventAction.originalEventIdentifier).toBe("keya");
   });
-
-  it("excludes open-command-palette", () => {
-    const map = new EventActionMap();
-    map.set("f1", "open-command-palette");
-    map.set("keya", "some-action");
-    const ids = collectActionBindings(makeInputEventBindings(map)).map(
-      (b) => b.actionId,
-    );
-    expect(ids).not.toContain("open-command-palette");
-    expect(ids).toContain("some-action");
-  });
 });
 
 describe("CommandCatalog.filter", () => {
@@ -140,20 +129,12 @@ describe("CommandCatalog.filter", () => {
     expect(catalog.filter("")).toStrictEqual(catalog.commands);
   });
 
-  it("is case-insensitive", () => {
-    expect(makeCatalog().filter("EDIT")).toHaveLength(1);
-    expect(makeCatalog().filter("edit")).toHaveLength(1);
-  });
-
-  it("ranks prefix matches before substring matches", () => {
-    // "Screenshot" is a prefix match; "Edit JSON State" is a substring match.
-    // Verify all prefix matches appear before all substring matches.
-    const results = makeCatalog().filter("s");
-    const screenshotIndex = results.findIndex((r) => r.label === "Screenshot");
-    const stateIndex = results.findIndex((r) => r.label === "Edit JSON State");
-    expect(screenshotIndex).toBeGreaterThanOrEqual(0);
-    expect(stateIndex).toBeGreaterThanOrEqual(0);
-    expect(screenshotIndex).toBeLessThan(stateIndex);
+  it("matches a command by label", () => {
+    expect(
+      makeCatalog()
+        .filter("edit")
+        .map((entry) => entry.label),
+    ).toStrictEqual(["Edit JSON State"]);
   });
 
   it("returns empty for a non-matching query", () => {

--- a/src/ui/command_catalog.ts
+++ b/src/ui/command_catalog.ts
@@ -39,6 +39,7 @@ import type {
   NormalizedEventIdentifier,
 } from "#src/util/event_action_map.js";
 import { friendlyEventIdentifier } from "#src/util/event_action_map.js";
+import { rankedMatches } from "#src/util/ranked_matches.js";
 import { Signal } from "#src/util/signal.js";
 import type { InputEventBindings } from "#src/viewer.js";
 
@@ -210,7 +211,6 @@ export function collectActionBindings(
   ) => {
     for (const [normalizedId, eventAction] of bindings) {
       if (!isKeyboardEvent(normalizedId)) continue;
-      if (eventAction.action === "open-command-palette") continue;
       if (!seenBindings.has(eventAction.action)) {
         seenBindings.set(eventAction.action, eventAction);
       }
@@ -229,6 +229,7 @@ export function collectActionBindings(
 
 export class CommandCatalog extends RefCounted {
   commands: readonly CommandEntry[] = [];
+  groups: readonly CommandGroup[] = [];
   readonly changed = new Signal();
   private readonly debouncedRebuild: DebouncedFunction;
 
@@ -439,45 +440,29 @@ export class CommandCatalog extends RefCounted {
       }
     }
 
+    const groups: CommandGroup[] = [];
+    for (const { group } of commands) {
+      if (group !== undefined && !groups.includes(group)) groups.push(group);
+    }
+
     this.commands = commands;
+    this.groups = groups;
     this.changed.dispatch();
   }
 
-  // Restricting to `groupLabel` scopes the search to a single group's entries
-  // filtering with no args can be used to exclude disabled commands
+  // Without a `groupLabel`, grouped entries are omitted, since their group
+  // stands in for them as a single row.
   filter(
     searchString: string = "",
     groupLabel?: string,
-    ignoreGroupsForGlobalSearch: boolean = true,
-    excludeDisabled: boolean = true,
   ): readonly CommandEntry[] {
-    let pool = this.commands;
-    if (groupLabel !== undefined) {
-      pool = pool.filter(
-        (entry) =>
-          entry.group?.label === groupLabel &&
-          (!excludeDisabled || entry.command.enabled),
-      );
-    } else if (ignoreGroupsForGlobalSearch) {
-      pool = pool.filter(
-        (entry) =>
-          entry.group === undefined &&
-          (!excludeDisabled || entry.command.enabled),
-      );
-    }
-
-    if (searchString === "") return pool;
-
-    const query = searchString.toLowerCase();
-    const prefixMatches: CommandEntry[] = [];
-    const substringMatches: CommandEntry[] = [];
-
-    for (const command of pool) {
-      const label = command.label.toLowerCase();
-      if (label.startsWith(query)) prefixMatches.push(command);
-      else if (label.includes(query)) substringMatches.push(command);
-    }
-
-    return [...prefixMatches, ...substringMatches];
+    const pool = this.commands.filter(
+      (entry) =>
+        entry.command.enabled &&
+        (groupLabel === undefined
+          ? entry.group === undefined
+          : entry.group?.label === groupLabel),
+    );
+    return rankedMatches(pool, "label", searchString);
   }
 }

--- a/src/ui/command_palette.ts
+++ b/src/ui/command_palette.ts
@@ -21,9 +21,11 @@ import type {
   CommandEntry,
   CommandGroup,
 } from "#src/ui/command_catalog.js";
+import { rankedMatches } from "#src/util/ranked_matches.js";
 import type { Viewer } from "#src/viewer.js";
 
 const COMMAND_INPUT_PLACEHOLDER = "Type to find a command...";
+const OPEN_COMMAND_PALETTE_ACTION = "open-command-palette";
 
 type PaletteRow =
   | { readonly kind: "command"; readonly entry: CommandEntry }
@@ -200,9 +202,17 @@ export class CommandPalette extends Overlay {
     return rowElement;
   }
 
+  private computeDisplayRows(): readonly PaletteRow[] {
+    return this.computeCatalogRows().filter(
+      (row) =>
+        row.kind !== "command" ||
+        row.entry.command.id !== OPEN_COMMAND_PALETTE_ACTION,
+    );
+  }
+
   // Inside a group, or while searching, the view is a flat list of matching
   // commands. Otherwise, entries sharing a group collapse into one header row.
-  private computeDisplayRows(): readonly PaletteRow[] {
+  private computeCatalogRows(): readonly PaletteRow[] {
     const searchValue = this.searchInput.value;
     if (this.currentGroup !== undefined) {
       return this.catalog
@@ -210,9 +220,14 @@ export class CommandPalette extends Overlay {
         .map((entry) => ({ kind: "command", entry }) as const);
     }
     if (searchValue !== "") {
-      return this.catalog
-        .filter(searchValue)
-        .map((entry) => ({ kind: "command", entry }) as const);
+      return [
+        ...rankedMatches(this.catalog.groups, "label", searchValue).map(
+          (group) => ({ kind: "group-header", group }) as const,
+        ),
+        ...this.catalog
+          .filter(searchValue)
+          .map((entry) => ({ kind: "command", entry }) as const),
+      ];
     }
     const rows: PaletteRow[] = [];
     const seenGroups = new Set<string>();
@@ -336,5 +351,5 @@ export function bindCommandPalette(viewer: Viewer): void {
         : viewer.element;
     openPalette = new CommandPalette(viewer.commandCatalog, dispatchTarget);
   };
-  viewer.bindAction("open-command-palette", openCommandPalette);
+  viewer.bindAction(OPEN_COMMAND_PALETTE_ACTION, openCommandPalette);
 }

--- a/src/ui/default_commands.ts
+++ b/src/ui/default_commands.ts
@@ -135,6 +135,11 @@ const STATIC_COMMANDS: readonly BuiltinCommand[] = [
     label: "Show Help",
     description: "Open the keyboard and mouse bindings help panel.",
   },
+  {
+    id: "open-command-palette",
+    label: "Open Command Palette",
+    description: "Open the searchable list of commands.",
+  },
   // Navigation.
   {
     id: "snap",

--- a/src/util/ranked_matches.spec.ts
+++ b/src/util/ranked_matches.spec.ts
@@ -1,0 +1,61 @@
+/**
+ * @license
+ * Copyright 2026 Google Inc.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it } from "vitest";
+import { rankedMatches } from "#src/util/ranked_matches.js";
+
+describe("rankedMatches", () => {
+  const items = [
+    { label: "Edit JSON State" },
+    { label: "Screenshot" },
+    { label: "Toggle Scale Bar" },
+  ];
+
+  it("returns all items for an empty query", () => {
+    expect(rankedMatches(items, "label", "")).toStrictEqual(items);
+  });
+
+  it("is case-insensitive", () => {
+    expect(rankedMatches(items, "label", "EDIT")).toStrictEqual([
+      { label: "Edit JSON State" },
+    ]);
+    expect(rankedMatches(items, "label", "edit")).toStrictEqual([
+      { label: "Edit JSON State" },
+    ]);
+  });
+
+  it("ranks prefix matches before substring matches", () => {
+    expect(rankedMatches(items, "label", "s")).toStrictEqual([
+      { label: "Screenshot" },
+      { label: "Edit JSON State" },
+      { label: "Toggle Scale Bar" },
+    ]);
+  });
+
+  it("returns empty for a non-matching query", () => {
+    expect(rankedMatches(items, "label", "xyz")).toHaveLength(0);
+  });
+
+  it("matches on the named property", () => {
+    const groups = [
+      { label: "Select Layer", shortcut: "Ctrl+1–9" },
+      { label: "Toggle Layer Visibility", shortcut: "1–9" },
+    ];
+    expect(rankedMatches(groups, "shortcut", "ctrl")).toStrictEqual([
+      { label: "Select Layer", shortcut: "Ctrl+1–9" },
+    ]);
+  });
+});

--- a/src/util/ranked_matches.ts
+++ b/src/util/ranked_matches.ts
@@ -1,0 +1,32 @@
+/**
+ * @license
+ * Copyright 2026 Google Inc.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export function rankedMatches<K extends string, T extends Record<K, string>>(
+  items: readonly T[],
+  property: K,
+  query: string,
+): readonly T[] {
+  if (query === "") return items;
+  const lowerCaseQuery = query.toLowerCase();
+  const prefixMatches: T[] = [];
+  const substringMatches: T[] = [];
+  for (const item of items) {
+    const text = item[property].toLowerCase();
+    if (text.startsWith(lowerCaseQuery)) prefixMatches.push(item);
+    else if (text.includes(lowerCaseQuery)) substringMatches.push(item);
+  }
+  return [...prefixMatches, ...substringMatches];
+}


### PR DESCRIPTION
Should fix #1102. Extracts the search and rank out of the catalog, and then uses the same search and rank across both the catalog commands and the catalog groups. 

Also fixes another smaller thing which is to expose the open command palette command to the catalog of commands, and just hide that command in the palette. It's an available command so I think it should be in the catalog, but showing it in the palette doesn't make much sense since the palette is already open.