### PR TITLE
Camera sway behavior

### DIFF
--- a/src/navigation_state.ts
+++ b/src/navigation_state.ts
@@ -29,7 +29,7 @@ import type { WatchableValueInterface } from "#src/trackable_value.js";
 import { arraysEqual } from "#src/util/array.js";
 import type { Borrowed, Owned } from "#src/util/disposable.js";
 import { RefCounted } from "#src/util/disposable.js";
-import { mat3, mat4, quat, vec3 } from "#src/util/geom.js";
+import { kAxes, mat3, mat4, quat, vec3 } from "#src/util/geom.js";
 import {
   parseArray,
   parseFiniteVec,
@@ -1695,6 +1695,9 @@ export class LinkedDisplayDimensions extends SimpleLinkedBase<TrackableDisplayDi
 export class DisplayPose extends RefCounted {
   changed = new NullarySignal();
 
+  // Last sinusoidal sway angle applied per axis, used to compute the next incremental rotation.
+  private swayLastAngle = new Map<vec3, number>();
+
   get displayDimensions(): Borrowed<TrackableDisplayDimensions> {
     return this.displayDimensionRenderInfo.displayDimensions;
   }
@@ -1845,6 +1848,32 @@ export class DisplayPose extends RefCounted {
     const orientation = this.orientation.orientation;
     quat.multiply(orientation, orientation, temp);
     this.orientation.changed.dispatch();
+  }
+
+  swayRelative(axis: vec3) {
+    const period = 1.0; // Periodicity of the sway motion, in seconds.
+    const amplitude = 0.01; // Amplitude of the sway motion, in radians.
+    const omega = (2 * Math.PI) / period;
+    const t = performance.now() / 1000;
+    if (axis[2] != 1) {
+      // Sway back and forth or up and down along one axis.
+      const angle = amplitude * Math.sin(omega * t);
+      // Default to `angle` so the first call for a given axis produces no jump.
+      const lastAngle = this.swayLastAngle.get(axis) ?? angle;
+      this.swayLastAngle.set(axis, angle);
+      this.rotateRelative(axis, angle - lastAngle);
+    }
+    else {
+      // Sway around X and Y 90 degrees out of phase to trace a small circle.
+      const angleX = amplitude * Math.cos(omega * t);
+      const angleY = amplitude * Math.sin(omega * t);
+      const lastAngleX = this.swayLastAngle.get(kAxes[0]) ?? angleX;
+      const lastAngleY = this.swayLastAngle.get(kAxes[1]) ?? angleY;
+      this.swayLastAngle.set(kAxes[0], angleX);
+      this.swayLastAngle.set(kAxes[1], angleY);
+      this.rotateRelative(kAxes[0], angleX - lastAngleX);
+      this.rotateRelative(kAxes[1], angleY - lastAngleY);
+    }
   }
 
   rotateAbsolute(axis: vec3, angle: number, fixedPoint: Float32Array) {

--- a/src/rendered_data_panel.ts
+++ b/src/rendered_data_panel.ts
@@ -524,6 +524,29 @@ export abstract class RenderedDataPanel extends RenderedPanel {
       }
     }
 
+    for (let axis = 0; axis < 3; ++axis) {
+      const axisName = AXES_NAMES[axis];
+      registerActionListener(
+        element,
+        `sway-relative-${axisName}`,
+        () => {
+          this.context.flagContinuousCameraMotion();
+          this.navigationState.pose.swayRelative(kAxes[axis]);
+        },
+      );
+      const tempOffset = vec3.create();
+      registerActionListener(element, `${axisName}`, () => {
+        this.context.flagContinuousCameraMotion();
+        const { navigationState } = this;
+        const offset = tempOffset;
+        offset[0] = 0;
+        offset[1] = 0;
+        offset[2] = 0;
+        offset[axis] = +1;
+        navigationState.pose.translateVoxelsRelative(offset);
+      });
+    }
+
     registerActionListener(
       element,
       "zoom-via-wheel",

--- a/src/ui/default_input_event_bindings.ts
+++ b/src/ui/default_input_event_bindings.ts
@@ -107,6 +107,12 @@ export function getDefaultRenderedDataPanelBindings() {
         "shift+arrowup": "rotate-relative-x+",
         "shift+arrowleft": "rotate-relative-y-",
         "shift+arrowright": "rotate-relative-y+",
+        "alt+keye": "sway-relative-z",
+        "alt+keyr": "sway-relative-z",
+        "alt+arrowdown": "sway-relative-x",
+        "alt+arrowup": "sway-relative-x",
+        "alt+arrowleft": "sway-relative-y",
+        "alt+arrowright": "sway-relative-y",
         "control+wheel": { action: "zoom-via-wheel", preventDefault: true },
         "alt+wheel": {
           action: "adjust-depth-range-via-wheel",


### PR DESCRIPTION
The goal is to assist the user with visually understanding complex overlapping 3D structure. I often put the cursor over empty background and move it gently around to gain a parallax motion of the 3D view. I find that a lack of motion instantly "flattens" the 3D rendering, and likewise, that inducing some motion makes the structure "pop up" rather vividly. The tools provided by this PR automate the exact same behavior, and do so by producing smoother motions that a person can achieve by manual cursor dragging. I have included three similar tools under key commands closely related to the existing relative motion tools:

- Option left or right arrow (identical commands) produces hortizontal sway
- Option up or down arrow (identical commands) produces vertical sway
- Option E or R (identical commands) produces circular sway