### PR TITLE
annotation list properties with filtering

### DIFF
--- a/src/annotation/annotation_derived_properties.spec.ts
+++ b/src/annotation/annotation_derived_properties.spec.ts
@@ -1,0 +1,295 @@
+/**
+ * @license
+ * Copyright 2024 Google Inc.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+  analyzeDerivedProperties,
+  collectPhysicalDimensions,
+  prettyUnit,
+} from "#src/annotation/annotation_derived_properties.js";
+import type { Annotation } from "#src/annotation/index.js";
+import { AnnotationType } from "#src/annotation/index.js";
+import type { CoordinateSpace } from "#src/coordinate_transform.js";
+import type { ChunkTransformParameters } from "#src/render_coordinate_transform.js";
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+function coordSpace(
+  names: string[],
+  units: string[],
+  scales: number[],
+): CoordinateSpace {
+  return {
+    rank: names.length,
+    names,
+    units,
+    scales: Float64Array.from(scales),
+  } as unknown as CoordinateSpace;
+}
+
+/** Identity chunk→layer transform of the given rank (global dims map 1:1). */
+function identityTransform(rank: number): ChunkTransformParameters {
+  const stride = rank + 1;
+  const mat = new Float32Array(stride * stride);
+  for (let i = 0; i < stride; ++i) mat[stride * i + i] = 1;
+  const seq = Array.from({ length: rank }, (_, i) => i);
+  return {
+    layerRank: rank,
+    chunkToLayerTransform: mat,
+    modelTransform: {
+      globalToRenderLayerDimensions: seq,
+      localToRenderLayerDimensions: [],
+    },
+  } as unknown as ChunkTransformParameters;
+}
+
+let nextId = 0;
+function line(pointA: number[], pointB: number[]): Annotation {
+  return {
+    type: AnnotationType.LINE,
+    id: `l${nextId++}`,
+    pointA: Float32Array.from(pointA),
+    pointB: Float32Array.from(pointB),
+    properties: [],
+  } as Annotation;
+}
+function box(pointA: number[], pointB: number[]): Annotation {
+  return {
+    type: AnnotationType.AXIS_ALIGNED_BOUNDING_BOX,
+    id: `b${nextId++}`,
+    pointA: Float32Array.from(pointA),
+    pointB: Float32Array.from(pointB),
+    properties: [],
+  } as Annotation;
+}
+function ellipsoid(center: number[], radii: number[]): Annotation {
+  return {
+    type: AnnotationType.ELLIPSOID,
+    id: `e${nextId++}`,
+    center: Float32Array.from(center),
+    radii: Float32Array.from(radii),
+    properties: [],
+  } as Annotation;
+}
+function polyline(points: number[][]): Annotation {
+  return {
+    type: AnnotationType.POLYLINE,
+    id: `p${nextId++}`,
+    points: points.map((p) => Float32Array.from(p)),
+    properties: [],
+  } as Annotation;
+}
+function point(coords: number[]): Annotation {
+  return {
+    type: AnnotationType.POINT,
+    id: `pt${nextId++}`,
+    point: Float32Array.from(coords),
+    properties: [],
+  } as Annotation;
+}
+
+function analyze(
+  annotations: Annotation[],
+  space: CoordinateSpace,
+): ReturnType<typeof analyzeDerivedProperties> {
+  const rank = space.rank;
+  const transform = identityTransform(rank);
+  return analyzeDerivedProperties({
+    annotations: annotations.map((annotation) => ({
+      id: annotation.id,
+      annotation,
+      chunkTransform: transform,
+    })),
+    globalCoordinateSpace: space,
+    localCoordinateSpace: coordSpace([], [], []),
+    globalDimensionIndices: Array.from({ length: rank }, (_, i) => i),
+    localDimensionIndices: [],
+  });
+}
+
+const schemaIds = (r: ReturnType<typeof analyzeDerivedProperties>) =>
+  new Set(r.schemas.map((s) => s.identifier));
+const valueOf = (
+  r: ReturnType<typeof analyzeDerivedProperties>,
+  id: string,
+  prop: string,
+) => r.valuesByAnnotationId.get(id)?.get(prop);
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("prettyUnit", () => {
+  it("formats compound units with superscripts", () => {
+    expect(prettyUnit("m")).toBe("m");
+    expect(prettyUnit("s")).toBe("s");
+    expect(prettyUnit("m^2")).toBe("m²");
+    expect(prettyUnit("m^3")).toBe("m³");
+  });
+});
+
+describe("collectPhysicalDimensions", () => {
+  it("skips unitless dimensions and records base units", () => {
+    const space = coordSpace(
+      ["x", "y", "z", "t", "c"],
+      ["nm", "nm", "m", "s", ""],
+      [1e-9, 1e-9, 1, 1, 1],
+    );
+    const dims = collectPhysicalDimensions(space, [0, 1, 2, 3, 4], "global");
+    expect(dims.map((d) => d.name)).toEqual(["x", "y", "z", "t"]);
+    expect(dims.map((d) => d.baseUnit)).toEqual(["m", "m", "m", "s"]);
+  });
+});
+
+describe("analyzeDerivedProperties", () => {
+  const meters3 = () => coordSpace(["x", "y", "z"], ["m", "m", "m"], [1, 1, 1]);
+
+  it("computes line length over active spatial dims (3-4-5)", () => {
+    const a = line([0, 0, 0], [3, 4, 0]);
+    const r = analyze([a], meters3());
+    // z is constant (0) → inactive; length over {x,y} = 5.
+    expect(valueOf(r, a.id, "length")).toBeCloseTo(5, 6);
+    expect(schemaIds(r).has("length")).toBe(true);
+  });
+
+  it("drops delta for a constant dimension", () => {
+    const a = line([0, 0, 0], [3, 4, 0]);
+    const r = analyze([a], meters3());
+    expect(schemaIds(r).has("delta_x")).toBe(true);
+    expect(schemaIds(r).has("delta_y")).toBe(true);
+    // z never varies → no delta_z.
+    expect(schemaIds(r).has("delta_z")).toBe(false);
+    expect(valueOf(r, a.id, "delta_x")).toBeCloseTo(3, 6);
+  });
+
+  it("computes box volume (3D) and area (2D) by active-dim count", () => {
+    const r3 = analyze([box([0, 0, 0], [2, 3, 4])], meters3());
+    expect(schemaIds(r3).has("volume")).toBe(true);
+    const b3 = [...r3.valuesByAnnotationId.keys()][0];
+    expect(valueOf(r3, b3, "volume")).toBeCloseTo(24, 5);
+
+    // Only x and y vary → 2 active spatial dims → "area".
+    const r2 = analyze([box([0, 0, 0], [2, 3, 0])], meters3());
+    expect(schemaIds(r2).has("area")).toBe(true);
+    expect(schemaIds(r2).has("volume")).toBe(false);
+    const b2 = [...r2.valuesByAnnotationId.keys()][0];
+    expect(valueOf(r2, b2, "area")).toBeCloseTo(6, 5);
+  });
+
+  it("computes ellipsoid n-ball volume and diameter delta", () => {
+    const e = ellipsoid([0, 0, 0], [1, 2, 3]);
+    const r = analyze([e], meters3());
+    // (4/3)π r1 r2 r3 = 8π
+    expect(valueOf(r, e.id, "volume")).toBeCloseTo(8 * Math.PI, 4);
+    // delta = diameter = 2*radius
+    expect(valueOf(r, e.id, "delta_x")).toBeCloseTo(2, 6);
+    expect(valueOf(r, e.id, "delta_z")).toBeCloseTo(6, 6);
+  });
+
+  it("computes polyline length and extent", () => {
+    const p = polyline([
+      [0, 0, 0],
+      [3, 0, 0],
+      [3, 4, 0],
+    ]);
+    const r = analyze(
+      [p],
+      coordSpace(["x", "y", "z"], ["m", "m", "m"], [1, 1, 1]),
+    );
+    // path = 3 + 4 = 7
+    expect(valueOf(r, p.id, "length")).toBeCloseTo(7, 6);
+    // extent_x = 3, extent_y = 4
+    expect(valueOf(r, p.id, "extent_x")).toBeCloseTo(3, 6);
+    expect(valueOf(r, p.id, "extent_y")).toBeCloseTo(4, 6);
+    // delta_x = last - first = 3 - 0 = 3
+    expect(valueOf(r, p.id, "delta_x")).toBeCloseTo(3, 6);
+  });
+
+  it("scales mixed units to SI base (nm and m combine in meters)", () => {
+    // x in nm (1e-9 m), y in m. Line from origin to (1e9 nm, 0).
+    const space = coordSpace(["x", "y"], ["nm", "m"], [1e-9, 1]);
+    const a = line([1e9, 0], [0, 1]);
+    const r = analyze([a], space);
+    // dx = 1e9 * 1e-9 = 1 m; dy = 1 m; length = sqrt(2).
+    expect(valueOf(r, a.id, "length")).toBeCloseTo(Math.SQRT2, 6);
+  });
+
+  describe("temporal", () => {
+    const xyt = () => coordSpace(["x", "y", "t"], ["m", "m", "s"], [1, 1, 1]);
+
+    it("computes duration and omits temporal delta for monotonic lines", () => {
+      const a = line([0, 0, 0], [3, 4, 5]);
+      const r = analyze([a], xyt());
+      expect(valueOf(r, a.id, "duration")).toBeCloseTo(5, 6);
+      expect(schemaIds(r).has("duration")).toBe(true);
+      // Lines never get temporal delta (always monotonic).
+      expect(schemaIds(r).has("delta_t")).toBe(false);
+    });
+
+    it("drops all temporal properties when time never varies", () => {
+      const r = analyze([line([0, 0, 0], [3, 4, 0])], xyt());
+      expect(schemaIds(r).has("duration")).toBe(false);
+      expect(schemaIds(r).has("delta_t")).toBe(false);
+    });
+
+    it("keeps temporal delta for a non-monotonic polyline", () => {
+      // t goes 0 → 5 → 2 (reverses) → non-monotonic.
+      const p = polyline([
+        [0, 0, 0],
+        [1, 0, 5],
+        [2, 0, 2],
+      ]);
+      const r = analyze([p], xyt());
+      expect(schemaIds(r).has("delta_t")).toBe(true);
+      // delta_t = last - first = 2 - 0 = 2
+      expect(valueOf(r, p.id, "delta_t")).toBeCloseTo(2, 6);
+    });
+  });
+
+  it("yields NaN for type-mismatched properties in mixed layers", () => {
+    // 2 active spatial dims → line has "length", box has "area".
+    const l = line([0, 0], [3, 4]);
+    const b = box([0, 0], [2, 3]);
+    const r = analyze([l, b], coordSpace(["x", "y"], ["m", "m"], [1, 1]));
+    expect(valueOf(r, l.id, "length")).toBeCloseTo(5, 6);
+    expect(Number.isNaN(valueOf(r, l.id, "area")!)).toBe(true);
+    expect(valueOf(r, b.id, "area")).toBeCloseTo(6, 5);
+    expect(Number.isNaN(valueOf(r, b.id, "length")!)).toBe(true);
+  });
+
+  it("produces no derived properties for a point-only layer", () => {
+    const r = analyze([point([1, 2, 3]), point([4, 5, 6])], meters3());
+    expect(r.schemas.length).toBe(0);
+    expect(r.warning).toBeUndefined();
+  });
+
+  it("warns when measurable annotations exist but units are missing", () => {
+    const space = coordSpace(["x", "y"], ["", ""], [1, 1]);
+    const r = analyze([line([0, 0], [3, 4])], space);
+    expect(r.schemas.length).toBe(0);
+    expect(r.warning).toBeDefined();
+  });
+
+  it("computeForAnnotation matches the set-wide values", () => {
+    const a = line([0, 0, 0], [3, 4, 0]);
+    const space = meters3();
+    const r = analyze([a], space);
+    const recomputed = r.computeForAnnotation(a, identityTransform(space.rank));
+    expect(recomputed.get("length")).toBeCloseTo(5, 6);
+  });
+});

--- a/src/annotation/annotation_derived_properties.spec.ts
+++ b/src/annotation/annotation_derived_properties.spec.ts
@@ -167,6 +167,21 @@ describe("analyzeDerivedProperties", () => {
     expect(schemaIds(r).has("length")).toBe(true);
   });
 
+  it("unions applicability for derived properties with shared ids", () => {
+    const a = line([0, 0, 0], [3, 4, 0]);
+    const b = polyline([
+      [0, 0, 0],
+      [0, 3, 0],
+      [4, 3, 0],
+    ]);
+    const r = analyze([a, b], meters3());
+    const length = r.schemas.find((schema) => schema.identifier === "length");
+    expect(length?.applicableAnnotationTypes).toEqual([
+      AnnotationType.LINE,
+      AnnotationType.POLYLINE,
+    ]);
+  });
+
   it("drops delta for a constant dimension", () => {
     const a = line([0, 0, 0], [3, 4, 0]);
     const r = analyze([a], meters3());

--- a/src/annotation/annotation_derived_properties.ts
+++ b/src/annotation/annotation_derived_properties.ts
@@ -598,6 +598,13 @@ export function analyzeDerivedProperties(
       bounds: [bounds[0], bounds[1]] as DataTypeInterval,
       description: d.description,
       baseUnit: d.baseUnit,
+      applicableAnnotationTypes: [
+        ...new Set(
+          descriptors
+            .filter((candidate) => candidate.id === d.id)
+            .flatMap((candidate) => [...candidate.appliesTo]),
+        ),
+      ],
     });
   }
 

--- a/src/annotation/annotation_derived_properties.ts
+++ b/src/annotation/annotation_derived_properties.ts
@@ -1,0 +1,642 @@
+/**
+ * @license
+ * Copyright 2024 Google Inc.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Derived (computed) geometric numerical properties for annotations: length,
+// area/volume, duration, delta_{dim}, extent_{dim}.  These are computed live
+// from annotation geometry transformed into the view's global coordinate system
+// and expressed in SI base units (meters, seconds, m^2, m^3...).  They are
+// synthetic — injected into the annotation query schema/items exactly like the
+// coordinate-dimension properties — and never persisted onto annotations.
+//
+// The module is split so that the metric math (the generator registry, operating
+// on a plain PhysicalGeometry) is unit-testable without coordinate transforms,
+// while extractPhysicalGeometry performs the transform-dependent extraction.
+
+import type { AnnotationNumericPropSchema } from "#src/annotation/annotation_query.js";
+import type { Annotation } from "#src/annotation/index.js";
+import {
+  AnnotationType,
+  annotationTypeHandlers,
+} from "#src/annotation/index.js";
+import type { CoordinateSpace } from "#src/coordinate_transform.js";
+import type { ChunkTransformParameters } from "#src/render_coordinate_transform.js";
+import { DataType } from "#src/util/data_type.js";
+import type { DataTypeInterval } from "#src/util/lerp.js";
+import { transformPoint, transformVector } from "#src/util/matrix.js";
+import { supportedUnits } from "#src/util/si_units.js";
+
+// ============================================================================
+// Dimension references and unit grouping
+// ============================================================================
+
+/** A view dimension that carries a physical unit, with the data needed to map a
+ * transformed (layer-space) coordinate to an SI-base-unit physical value.  The
+ * layer-dimension index is resolved per-annotation (from each annotation's own
+ * transform) since it can differ between attached states. */
+export interface DimRef {
+  /** Display name of the dimension (e.g. "x", "t"). */
+  name: string;
+  /** SI base unit: "m" (spatial), "s" (temporal), "Hz", "rad/s". */
+  baseUnit: string;
+  /** Whether this is a global or local coordinate-space dimension. */
+  scope: "global" | "local";
+  /** Index into the (global or local) coordinate space. */
+  coordDim: number;
+  /** SI-base-units per coordinate unit (coordinateSpace.scales[coordDim]). */
+  scale: number;
+}
+
+/**
+ * Build the list of physical-unit dimensions visible to the annotation layer.
+ * Unitless dimensions (unit === "") are skipped.
+ */
+export function collectPhysicalDimensions(
+  coordinateSpace: CoordinateSpace,
+  viewDimIndices: readonly number[],
+  scope: "global" | "local",
+): DimRef[] {
+  const result: DimRef[] = [];
+  for (const coordDim of viewDimIndices) {
+    const unit = coordinateSpace.units[coordDim] ?? "";
+    const baseUnit = supportedUnits.get(unit)?.unit ?? "";
+    if (baseUnit === "") continue; // Unitless dimension: no derived properties.
+    result.push({
+      name: coordinateSpace.names[coordDim],
+      baseUnit,
+      scope,
+      coordDim,
+      scale: coordinateSpace.scales[coordDim],
+    });
+  }
+  return result;
+}
+
+// ============================================================================
+// Physical geometry
+// ============================================================================
+
+/** Annotation geometry sampled in SI base units, indexed by an active-dimension
+ * layout.  `points[k][i]` is the physical coordinate of point k along active
+ * dimension i; `radii[i]` is the (absolute) physical radius for an ellipsoid. */
+export interface PhysicalGeometry {
+  type: AnnotationType;
+  points: number[][];
+  radii?: number[];
+}
+
+/**
+ * Extract an annotation's geometry into SI base units along the provided
+ * dimensions, transforming chunk coordinates to layer space (so coordinate
+ * transforms are accounted for) and scaling each dimension by its physical scale.
+ */
+export function extractPhysicalGeometry(
+  annotation: Annotation,
+  chunkTransform: ChunkTransformParameters,
+  dims: readonly DimRef[],
+): PhysicalGeometry {
+  const { layerRank } = chunkTransform;
+  const { globalToRenderLayerDimensions, localToRenderLayerDimensions } =
+    chunkTransform.modelTransform;
+  // Resolve each dimension's layer index from this annotation's own transform.
+  const layerDims = dims.map((d) =>
+    d.scope === "global"
+      ? globalToRenderLayerDimensions[d.coordDim]
+      : localToRenderLayerDimensions[d.coordDim],
+  );
+  const padded = new Float32Array(layerRank);
+  const out = new Float32Array(layerRank);
+  const points: number[][] = [];
+  let radii: number[] | undefined;
+  annotationTypeHandlers[annotation.type].visitGeometry(
+    annotation,
+    (vec: Float32Array, isVector: boolean) => {
+      padded.fill(0);
+      padded.set(vec.subarray(0, layerRank));
+      (isVector ? transformVector : transformPoint)(
+        out,
+        chunkTransform.chunkToLayerTransform,
+        layerRank + 1,
+        padded,
+        layerRank,
+      );
+      const coords = dims.map((_, i) => {
+        const ld = layerDims[i];
+        return ld === undefined || ld === -1 ? NaN : out[ld] * dims[i].scale;
+      });
+      if (isVector) {
+        // Only the ellipsoid emits a vector (its radii).
+        radii = coords.map(Math.abs);
+      } else {
+        points.push(coords);
+      }
+    },
+  );
+  return { type: annotation.type, points, radii };
+}
+
+// ============================================================================
+// Derived property generators (registry)
+// ============================================================================
+
+/** Context shared by generators describing the active (relevant) dimensions. */
+interface BuildContext {
+  activeDims: DimRef[];
+  /** Indices into `activeDims` whose baseUnit is spatial ("m"). */
+  spatial: number[];
+  /** Indices into `activeDims` whose baseUnit is temporal ("s"). */
+  temporal: number[];
+}
+
+type DescriptorKind = "normal" | "temporalDelta";
+
+interface DerivedPropDescriptor {
+  id: string;
+  description: string;
+  /** Display base unit: "m" | "s" | "m^2" | "m^3" | ... */
+  baseUnit: string;
+  appliesTo: ReadonlySet<AnnotationType>;
+  /** Compute the value in SI base units, or NaN if not applicable. */
+  compute: (geom: PhysicalGeometry) => number;
+  kind: DescriptorKind;
+}
+
+type DescriptorBuilder = (ctx: BuildContext) => DerivedPropDescriptor[];
+
+const LINE_POLY = new Set([AnnotationType.LINE, AnnotationType.POLYLINE]);
+const BOX_ELLIPSOID = new Set([
+  AnnotationType.AXIS_ALIGNED_BOUNDING_BOX,
+  AnnotationType.ELLIPSOID,
+]);
+const ALL_NON_POINT = new Set([
+  AnnotationType.LINE,
+  AnnotationType.POLYLINE,
+  AnnotationType.AXIS_ALIGNED_BOUNDING_BOX,
+  AnnotationType.ELLIPSOID,
+]);
+const POLY = new Set([AnnotationType.POLYLINE]);
+
+/** Unit n-ball volume coefficient C_n (volume = C_n * product(radii)). */
+function ballVolumeCoefficient(n: number): number {
+  if (n <= 0) return 1;
+  if (n === 1) return 2;
+  let prev2 = 1; // C_0
+  let prev1 = 2; // C_1
+  for (let k = 2; k <= n; ++k) {
+    const c = ((2 * Math.PI) / k) * prev2;
+    prev2 = prev1;
+    prev1 = c;
+  }
+  return prev1;
+}
+
+/** Euclidean norm of the difference of two points over the given dim indices. */
+function segmentNorm(a: number[], b: number[], idx: number[]): number {
+  let sum = 0;
+  for (const i of idx) {
+    const d = a[i] - b[i];
+    sum += d * d;
+  }
+  return Math.sqrt(sum);
+}
+
+// length: summed Euclidean path distance over spatial dims (lines, polylines).
+const buildPathLength: DescriptorBuilder = ({ spatial }) => {
+  if (spatial.length === 0) return [];
+  return [
+    {
+      id: "length",
+      description: "Euclidean path length",
+      baseUnit: "m",
+      appliesTo: LINE_POLY,
+      kind: "normal",
+      compute: (geom) => {
+        const { points } = geom;
+        if (points.length < 2) return NaN;
+        let total = 0;
+        for (let k = 1; k < points.length; ++k) {
+          total += segmentNorm(points[k], points[k - 1], spatial);
+        }
+        return total;
+      },
+    },
+  ];
+};
+
+// length/area/volume: spatial measure of boxes (product of |delta|) and
+// ellipsoids (n-ball volume from radii), named by spatial-dimension count.
+const buildSpatialMeasure: DescriptorBuilder = ({ spatial }) => {
+  const n = spatial.length;
+  if (n === 0) return [];
+  const id = n === 1 ? "length" : n === 2 ? "area" : "volume";
+  const baseUnit = n === 1 ? "m" : n === 2 ? "m^2" : "m^3";
+  const coeff = ballVolumeCoefficient(n);
+  return [
+    {
+      id,
+      description:
+        n === 1
+          ? "Spatial extent"
+          : n === 2
+            ? "Spatial area"
+            : "Spatial volume",
+      baseUnit,
+      appliesTo: BOX_ELLIPSOID,
+      kind: "normal",
+      compute: (geom) => {
+        if (geom.type === AnnotationType.AXIS_ALIGNED_BOUNDING_BOX) {
+          const { points } = geom;
+          if (points.length < 2) return NaN;
+          let product = 1;
+          for (const i of spatial) {
+            product *= Math.abs(points[0][i] - points[1][i]);
+          }
+          return product;
+        }
+        if (geom.type === AnnotationType.ELLIPSOID) {
+          const { radii } = geom;
+          if (radii === undefined) return NaN;
+          let product = coeff;
+          for (const i of spatial) product *= Math.abs(radii[i]);
+          return product;
+        }
+        return NaN;
+      },
+    },
+  ];
+};
+
+// duration: temporal span over temporal dims (lines, polylines, boxes, ellipsoids).
+const buildDuration: DescriptorBuilder = ({ temporal }) => {
+  if (temporal.length === 0) return [];
+  return [
+    {
+      id: "duration",
+      description: "Temporal duration",
+      baseUnit: "s",
+      appliesTo: ALL_NON_POINT,
+      kind: "normal",
+      compute: (geom) => {
+        const { points, radii, type } = geom;
+        if (type === AnnotationType.ELLIPSOID) {
+          if (radii === undefined) return NaN;
+          let sum = 0;
+          for (const i of temporal) sum += radii[i] * radii[i];
+          return 2 * Math.sqrt(sum);
+        }
+        if (points.length < 2) return NaN;
+        let total = 0;
+        for (let k = 1; k < points.length; ++k) {
+          total += segmentNorm(points[k], points[k - 1], temporal);
+        }
+        return total;
+      },
+    },
+  ];
+};
+
+// delta_{dim}: signed start-end per dimension (spatial for all non-point types;
+// temporal only for polylines).  Ellipsoid delta is the diameter (2*radii).
+const buildDeltaDims: DescriptorBuilder = ({
+  activeDims,
+  spatial,
+  temporal,
+}) => {
+  const descriptors: DerivedPropDescriptor[] = [];
+  const make = (
+    i: number,
+    appliesTo: ReadonlySet<AnnotationType>,
+    kind: DescriptorKind,
+  ): DerivedPropDescriptor => {
+    const dim = activeDims[i];
+    return {
+      id: `delta_${dim.name}`,
+      description: `Signed extent along ${dim.name} (end - start)`,
+      baseUnit: dim.baseUnit,
+      appliesTo,
+      kind,
+      compute: (geom) => {
+        if (geom.type === AnnotationType.ELLIPSOID) {
+          return geom.radii === undefined ? NaN : 2 * geom.radii[i];
+        }
+        const { points } = geom;
+        if (points.length < 2) return NaN;
+        return points[points.length - 1][i] - points[0][i];
+      },
+    };
+  };
+  for (const i of spatial) descriptors.push(make(i, ALL_NON_POINT, "normal"));
+  for (const i of temporal) descriptors.push(make(i, POLY, "temporalDelta"));
+  return descriptors;
+};
+
+// extent_{dim}: max - min over all points per spatial dimension (polylines).
+const buildExtentDims: DescriptorBuilder = ({ activeDims, spatial }) => {
+  return spatial.map((i) => {
+    const dim = activeDims[i];
+    return {
+      id: `extent_${dim.name}`,
+      description: `Coordinate span along ${dim.name} (max - min)`,
+      baseUnit: dim.baseUnit,
+      appliesTo: POLY,
+      kind: "normal" as DescriptorKind,
+      compute: (geom: PhysicalGeometry) => {
+        const { points } = geom;
+        if (points.length === 0) return NaN;
+        let min = Infinity;
+        let max = -Infinity;
+        for (const p of points) {
+          const v = p[i];
+          if (v < min) min = v;
+          if (v > max) max = v;
+        }
+        return max - min;
+      },
+    };
+  });
+};
+
+const REGISTRY: DescriptorBuilder[] = [
+  buildPathLength,
+  buildSpatialMeasure,
+  buildDuration,
+  buildDeltaDims,
+  buildExtentDims,
+];
+
+// ============================================================================
+// Set-wide analysis
+// ============================================================================
+
+export interface DerivedAnalysisInput {
+  annotations: Array<{
+    id: string;
+    annotation: Annotation;
+    chunkTransform: ChunkTransformParameters;
+  }>;
+  globalCoordinateSpace: CoordinateSpace;
+  localCoordinateSpace: CoordinateSpace;
+  globalDimensionIndices: readonly number[];
+  localDimensionIndices: readonly number[];
+}
+
+export interface DerivedAnalysisResult {
+  /** Relevant derived properties, with `baseUnit` metadata, for the query schema. */
+  schemas: AnnotationNumericPropSchema[];
+  /** Per-annotation derived values (NaN where the property does not apply). */
+  valuesByAnnotationId: Map<string, Map<string, number>>;
+  /** Recompute derived values for a single annotation (e.g. for selection panel). */
+  computeForAnnotation: (
+    annotation: Annotation,
+    chunkTransform: ChunkTransformParameters,
+  ) => Map<string, number>;
+  /** Warning message when measurable annotations exist but units are missing. */
+  warning: string | undefined;
+}
+
+const MEASURABLE_TYPES = ALL_NON_POINT;
+
+function computeDescriptorValues(
+  descriptors: DerivedPropDescriptor[],
+  geom: PhysicalGeometry,
+): Map<string, number> {
+  // Multiple descriptors may share an id (e.g. "length" from path-length and
+  // from a 1-D box measure) with disjoint appliesTo; the applicable (finite) one
+  // wins.
+  const out = new Map<string, number>();
+  for (const d of descriptors) {
+    const value = d.appliesTo.has(geom.type) ? d.compute(geom) : NaN;
+    const existing = out.get(d.id);
+    if (
+      existing === undefined ||
+      (!Number.isFinite(existing) && Number.isFinite(value))
+    ) {
+      out.set(d.id, value);
+    }
+  }
+  return out;
+}
+
+export function analyzeDerivedProperties(
+  input: DerivedAnalysisInput,
+): DerivedAnalysisResult {
+  const {
+    annotations,
+    globalCoordinateSpace,
+    localCoordinateSpace,
+    globalDimensionIndices,
+    localDimensionIndices,
+  } = input;
+
+  // Candidate physical dimensions (global then local).
+  const candidateDims: DimRef[] = [
+    ...collectPhysicalDimensions(
+      globalCoordinateSpace,
+      globalDimensionIndices,
+      "global",
+    ),
+    ...collectPhysicalDimensions(
+      localCoordinateSpace,
+      localDimensionIndices,
+      "local",
+    ),
+  ];
+
+  const measurableExists = annotations.some(({ annotation }) =>
+    MEASURABLE_TYPES.has(annotation.type),
+  );
+  const warning =
+    measurableExists && candidateDims.length === 0
+      ? "Some annotations support measurements (length, volume, duration), " +
+        "but the output dimensions have no physical units. Set units for your " +
+        "dimensions in the Source tab to enable these properties."
+      : undefined;
+
+  const empty: DerivedAnalysisResult = {
+    schemas: [],
+    valuesByAnnotationId: new Map(),
+    computeForAnnotation: () => new Map(),
+    warning,
+  };
+  if (candidateDims.length === 0 || annotations.length === 0) return empty;
+
+  // Pass 1: extract physical geometry per annotation (over candidate dims) and
+  // accumulate per-dimension global min/max to determine "active" dimensions.
+  const min = new Float64Array(candidateDims.length).fill(Infinity);
+  const max = new Float64Array(candidateDims.length).fill(-Infinity);
+  const cached: Array<{ id: string; geom: PhysicalGeometry }> = [];
+  for (const { id, annotation, chunkTransform } of annotations) {
+    const geom = extractPhysicalGeometry(
+      annotation,
+      chunkTransform,
+      candidateDims,
+    );
+    cached.push({ id, geom });
+    for (const p of geom.points) {
+      for (let i = 0; i < candidateDims.length; ++i) {
+        const v = p[i];
+        if (!Number.isFinite(v)) continue;
+        if (v < min[i]) min[i] = v;
+        if (v > max[i]) max[i] = v;
+      }
+    }
+    // Ellipsoid radii extend the spatial/temporal extent around the center.
+    const { radii } = geom;
+    if (radii !== undefined && geom.points.length > 0) {
+      const c = geom.points[0];
+      for (let i = 0; i < candidateDims.length; ++i) {
+        const lo = c[i] - Math.abs(radii[i]);
+        const hi = c[i] + Math.abs(radii[i]);
+        if (Number.isFinite(lo) && lo < min[i]) min[i] = lo;
+        if (Number.isFinite(hi) && hi > max[i]) max[i] = hi;
+      }
+    }
+  }
+
+  // Active dims: those that vary across the set (a coordinate that never changes
+  // — e.g. t always 0 — is excluded from all calculations).
+  const activeCandidate: number[] = [];
+  for (let i = 0; i < candidateDims.length; ++i) {
+    if (min[i] < max[i]) activeCandidate.push(i);
+  }
+  if (activeCandidate.length === 0) return empty;
+
+  const activeDims = activeCandidate.map((i) => candidateDims[i]);
+  // Map from a PhysicalGeometry over candidate dims → compact active layout.
+  const selectActive = (geom: PhysicalGeometry): PhysicalGeometry => ({
+    type: geom.type,
+    points: geom.points.map((p) => activeCandidate.map((i) => p[i])),
+    radii:
+      geom.radii === undefined
+        ? undefined
+        : activeCandidate.map((i) => geom.radii![i]),
+  });
+
+  const spatial: number[] = [];
+  const temporal: number[] = [];
+  activeDims.forEach((d, i) => {
+    if (d.baseUnit === "m") spatial.push(i);
+    else if (d.baseUnit === "s") temporal.push(i);
+  });
+
+  // Build descriptors from the registry over the active dims.
+  const ctx: BuildContext = { activeDims, spatial, temporal };
+  const descriptors = REGISTRY.flatMap((build) => build(ctx));
+
+  // Pass 2: compute every descriptor for every annotation.
+  const valuesByAnnotationId = new Map<string, Map<string, number>>();
+  // Track relevance: which ids have any nonzero finite value, and whether any
+  // polyline is non-monotonic in time (for temporal delta relevance).
+  const idHasNonZero = new Map<string, boolean>();
+  const idHasFinite = new Map<string, boolean>();
+  const idBounds = new Map<string, [number, number]>();
+  let anyNonMonotonicPolyline = false;
+
+  for (const { id, geom: candidateGeom } of cached) {
+    const geom = selectActive(candidateGeom);
+    const values = computeDescriptorValues(descriptors, geom);
+    valuesByAnnotationId.set(id, values);
+    for (const [pid, value] of values) {
+      if (!Number.isFinite(value)) continue;
+      idHasFinite.set(pid, true);
+      if (value !== 0) idHasNonZero.set(pid, true);
+      const b = idBounds.get(pid);
+      if (b === undefined) idBounds.set(pid, [value, value]);
+      else {
+        if (value < b[0]) b[0] = value;
+        if (value > b[1]) b[1] = value;
+      }
+    }
+    // Non-monotonic check: a polyline whose summed |Δt| exceeds |net Δt| in some
+    // temporal dim reverses direction; only then is delta_t not duplicative of
+    // duration.
+    if (geom.type === AnnotationType.POLYLINE && temporal.length > 0) {
+      for (const i of temporal) {
+        let sumAbs = 0;
+        for (let k = 1; k < geom.points.length; ++k) {
+          sumAbs += Math.abs(geom.points[k][i] - geom.points[k - 1][i]);
+        }
+        const net = Math.abs(
+          geom.points[0][i] - geom.points[geom.points.length - 1][i],
+        );
+        if (sumAbs - net > 1e-30) anyNonMonotonicPolyline = true;
+      }
+    }
+  }
+
+  // Determine which descriptor ids survive relevance pruning.
+  const survivingIds = new Set<string>();
+  for (const d of descriptors) {
+    if (!idHasFinite.get(d.id)) continue; // no applicable annotation
+    if (!idHasNonZero.get(d.id)) continue; // all-zero → trivial
+    if (d.kind === "temporalDelta" && !anyNonMonotonicPolyline) continue;
+    survivingIds.add(d.id);
+  }
+
+  // Build schemas (one per surviving id; dedupe shared ids).
+  const schemas: AnnotationNumericPropSchema[] = [];
+  const seen = new Set<string>();
+  for (const d of descriptors) {
+    if (!survivingIds.has(d.id) || seen.has(d.id)) continue;
+    seen.add(d.id);
+    const bounds = idBounds.get(d.id)!;
+    schemas.push({
+      identifier: d.id,
+      dataType: DataType.FLOAT32,
+      bounds: [bounds[0], bounds[1]] as DataTypeInterval,
+      description: d.description,
+      baseUnit: d.baseUnit,
+    });
+  }
+
+  // Prune non-surviving ids from the per-annotation value maps.
+  for (const values of valuesByAnnotationId.values()) {
+    for (const pid of values.keys()) {
+      if (!survivingIds.has(pid)) values.delete(pid);
+    }
+  }
+
+  const survivingDescriptors = descriptors.filter((d) =>
+    survivingIds.has(d.id),
+  );
+  const computeForAnnotation = (
+    annotation: Annotation,
+    chunkTransform: ChunkTransformParameters,
+  ): Map<string, number> => {
+    const geom = selectActive(
+      extractPhysicalGeometry(annotation, chunkTransform, candidateDims),
+    );
+    const values = computeDescriptorValues(survivingDescriptors, geom);
+    for (const pid of values.keys()) {
+      if (!survivingIds.has(pid)) values.delete(pid);
+    }
+    return values;
+  };
+
+  return { schemas, valuesByAnnotationId, computeForAnnotation, warning };
+}
+
+// ============================================================================
+// Display formatting
+// ============================================================================
+
+const SUPERSCRIPT: Record<string, string> = { "2": "²", "3": "³" };
+
+/** Pretty unit label for a column header / value suffix ("m" → "m", "m^2" → "m²"). */
+export function prettyUnit(baseUnit: string): string {
+  const m = baseUnit.match(/^([a-zA-Z/]+)\^(\d+)$/);
+  if (m !== null) return `${m[1]}${SUPERSCRIPT[m[2]] ?? `^${m[2]}`}`;
+  return baseUnit;
+}

--- a/src/annotation/annotation_layer_state.ts
+++ b/src/annotation/annotation_layer_state.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import type { DerivedAnalysisResult } from "#src/annotation/annotation_derived_properties.js";
 import type { MultiscaleAnnotationSource } from "#src/annotation/frontend_source.js";
 import type {
   AnnotationPropertySpec,
@@ -182,6 +183,11 @@ export class AnnotationDisplayState extends RefCounted {
     this.ignoreNullSegmentFilter,
   );
   hoverState = new AnnotationHoverState(undefined);
+  filteredAnnotationIds = new WatchableValue<ReadonlySet<string> | null>(null);
+  // Latest derived (computed) geometric property analysis, published by the
+  // annotation list view so the selection-details panel can show the same
+  // length/volume/duration metrics.
+  derivedProperties: DerivedAnalysisResult | undefined = undefined;
 }
 
 export class AnnotationLayerState extends RefCounted {

--- a/src/annotation/annotation_query.spec.ts
+++ b/src/annotation/annotation_query.spec.ts
@@ -443,6 +443,16 @@ describe("unparseAnnotationQuery", () => {
     ) as any;
     expect(reparsed.boolConstraints[0].value).toBe(false);
   });
+
+  it("serializes mixed clauses in canonical syntax", () => {
+    const q = parseAnnotationQuery(
+      schema,
+      "<score |count score>=0.5 #status=active -#verified /foo/",
+    ) as any;
+    expect(unparseAnnotationQuery(q, new Map([["score", [0, 1]]]))).toBe(
+      "<score |count score>=0.5 #status=1 -#verified /foo/",
+    );
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/src/annotation/annotation_query.spec.ts
+++ b/src/annotation/annotation_query.spec.ts
@@ -27,6 +27,7 @@ import {
   parseAnnotationQuery,
   unparseAnnotationQuery,
 } from "#src/annotation/annotation_query.js";
+import { AnnotationType } from "#src/annotation/index.js";
 import { DataType } from "#src/util/data_type.js";
 
 // ---------------------------------------------------------------------------
@@ -453,6 +454,42 @@ describe("unparseAnnotationQuery", () => {
       "<score |count score>=0.5 #status=1 -#verified /foo/",
     );
   });
+
+  it("uses a property's display unit for generated constraints", () => {
+    const unitSchema = {
+      numericProps: [
+        {
+          identifier: "length",
+          dataType: DataType.FLOAT32,
+          bounds: [0, 30e-9] as [number, number],
+          baseUnit: "m",
+        },
+      ],
+      enumProps: [],
+      boolProps: [],
+    };
+    const q = parseAnnotationQuery(unitSchema, "length>=5nm") as any;
+    expect(q.numericalConstraints[0].bounds[0]).toBeCloseTo(5e-9);
+    expect(
+      unparseAnnotationQuery(
+        q,
+        new Map([["length", [0, 30e-9]]]),
+        new Map([["length", "m"]]),
+      ),
+    ).toBe("length>=5.00nm");
+
+    const precise = parseAnnotationQuery(
+      unitSchema,
+      "length>=26.1234nm",
+    ) as any;
+    expect(
+      unparseAnnotationQuery(
+        precise,
+        new Map([["length", [0, 30e-9]]]),
+        new Map([["length", "m"]]),
+      ),
+    ).toBe("length>=26.1234nm");
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -466,6 +503,57 @@ describe("makeAnnotationNumericalDataSource", () => {
   it("exposes numericProps as properties", () => {
     const ds = makeAnnotationNumericalDataSource(schema, () => items);
     expect(ds.properties.map((p) => p.id)).toEqual(["score", "count"]);
+  });
+
+  it("exposes derived property units", () => {
+    const unitSchema = {
+      ...schema,
+      numericProps: [{ ...schema.numericProps[0], baseUnit: "m" }],
+    };
+    const ds = makeAnnotationNumericalDataSource(unitSchema, () => items);
+    expect(ds.properties[0].baseUnit).toBe("m");
+  });
+
+  it("evaluates derived property applicability against type constraints", () => {
+    const applicabilitySchema = {
+      ...schema,
+      numericProps: [
+        {
+          ...schema.numericProps[0],
+          applicableAnnotationTypes: [
+            AnnotationType.LINE,
+            AnnotationType.POLYLINE,
+          ],
+        },
+        schema.numericProps[1],
+      ],
+    };
+    const ds = makeAnnotationNumericalDataSource(
+      applicabilitySchema,
+      () => items,
+    );
+    const length = ds.properties[0];
+    const count = ds.properties[1];
+    const isApplicable = (include: number[], exclude: number[] = []) =>
+      ds.isPropertyApplicable!(length, {
+        query: {
+          sortBy: [],
+          includeColumns: [],
+          numericalConstraints: [],
+          enumConstraints: [{ fieldId: "type", include, exclude }],
+        },
+      } as any);
+
+    expect(ds.isPropertyApplicable!(length, undefined)).toBe(true);
+    expect(isApplicable([AnnotationType.POINT])).toBe(false);
+    expect(isApplicable([AnnotationType.LINE])).toBe(true);
+    expect(isApplicable([AnnotationType.POINT, AnnotationType.POLYLINE])).toBe(
+      true,
+    );
+    expect(
+      isApplicable([], [AnnotationType.LINE, AnnotationType.POLYLINE]),
+    ).toBe(false);
+    expect(ds.isPropertyApplicable!(count, undefined)).toBe(true);
   });
 
   it("fills histograms when query has indices", () => {

--- a/src/annotation/annotation_query.spec.ts
+++ b/src/annotation/annotation_query.spec.ts
@@ -120,6 +120,20 @@ describe("buildAnnotationQuerySchema", () => {
     expect(statusProp.enumValues).toEqual([0, 1, 2]);
   });
 
+  it("marks coordinate dimensions as non-toggleable columns", () => {
+    const schema = buildAnnotationQuerySchema(ALL_SPECS as any, [
+      { id: "x", description: "x coordinate" },
+    ]);
+    expect(
+      schema.numericProps.find((property) => property.identifier === "x")
+        ?.columnToggleable,
+    ).toBe(false);
+    expect(
+      schema.numericProps.find((property) => property.identifier === "score")
+        ?.columnToggleable,
+    ).toBeUndefined();
+  });
+
   it("skips rgb/rgba specs", () => {
     const schema = buildAnnotationQuerySchema([
       {
@@ -503,6 +517,16 @@ describe("makeAnnotationNumericalDataSource", () => {
   it("exposes numericProps as properties", () => {
     const ds = makeAnnotationNumericalDataSource(schema, () => items);
     expect(ds.properties.map((p) => p.id)).toEqual(["score", "count"]);
+  });
+
+  it("preserves coordinate column toggleability", () => {
+    const coordinateSchema = buildAnnotationQuerySchema(ALL_SPECS as any, [
+      { id: "x" },
+    ]);
+    const ds = makeAnnotationNumericalDataSource(coordinateSchema, () => items);
+    expect(ds.properties.find((property) => property.id === "x")).toMatchObject(
+      { columnToggleable: false },
+    );
   });
 
   it("exposes derived property units", () => {

--- a/src/annotation/annotation_query.spec.ts
+++ b/src/annotation/annotation_query.spec.ts
@@ -1,0 +1,489 @@
+/**
+ * @license
+ * Copyright 2024 Google Inc.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it } from "vitest";
+import type {
+  AnnotationQueryItem,
+  AnnotationQuerySchema,
+} from "#src/annotation/annotation_query.js";
+import {
+  buildAnnotationQueryItems,
+  buildAnnotationQuerySchema,
+  executeAnnotationQuery,
+  makeAnnotationNumericalDataSource,
+  parseAnnotationQuery,
+  unparseAnnotationQuery,
+} from "#src/annotation/annotation_query.js";
+import { DataType } from "#src/util/data_type.js";
+
+// ---------------------------------------------------------------------------
+// Test fixtures
+// ---------------------------------------------------------------------------
+
+const FLOAT_SPEC = {
+  type: "float32" as const,
+  identifier: "score",
+  description: "Score value",
+  default: 0,
+  min: 0,
+  max: 1,
+};
+const INT_SPEC = {
+  type: "int32" as const,
+  identifier: "count",
+  description: undefined,
+  default: 0,
+};
+const ENUM_SPEC = {
+  type: "uint8" as const,
+  identifier: "status",
+  description: "Status code",
+  default: 0,
+  enumValues: [0, 1, 2],
+  enumLabels: ["pending", "active", "done"],
+};
+const BOOL_SPEC = {
+  type: "bool" as const,
+  identifier: "verified",
+  description: undefined,
+  default: 0,
+};
+
+const ALL_SPECS = [FLOAT_SPEC, INT_SPEC, ENUM_SPEC, BOOL_SPEC];
+
+function makeSchema(): AnnotationQuerySchema {
+  return buildAnnotationQuerySchema(ALL_SPECS as any);
+}
+
+// Build items directly (without a real AnnotationLayerState)
+function makeItems(
+  rows: Array<{
+    description?: string;
+    score?: number;
+    count?: number;
+    status?: number;
+    verified?: boolean;
+  }>,
+): AnnotationQueryItem[] {
+  return rows.map((r) => {
+    const values = new Map<string, number | boolean>();
+    if (r.score !== undefined) values.set("score", r.score);
+    if (r.count !== undefined) values.set("count", r.count);
+    if (r.status !== undefined) values.set("status", r.status);
+    if (r.verified !== undefined) values.set("verified", r.verified);
+    return { description: r.description ?? "", values };
+  });
+}
+
+// ---------------------------------------------------------------------------
+// buildAnnotationQuerySchema
+// ---------------------------------------------------------------------------
+
+describe("buildAnnotationQuerySchema", () => {
+  it("partitions specs correctly", () => {
+    const schema = makeSchema();
+    expect(schema.numericProps.map((p) => p.identifier)).toEqual([
+      "score",
+      "count",
+    ]);
+    expect(schema.enumProps.map((p) => p.identifier)).toEqual(["status"]);
+    expect(schema.boolProps.map((p) => p.identifier)).toEqual(["verified"]);
+  });
+
+  it("sets bounds from spec min/max", () => {
+    const schema = makeSchema();
+    const scoreProp = schema.numericProps.find(
+      (p) => p.identifier === "score",
+    )!;
+    expect(scoreProp.bounds).toEqual([0, 1]);
+    expect(scoreProp.dataType).toBe(DataType.FLOAT32);
+  });
+
+  it("sets enum labels", () => {
+    const schema = makeSchema();
+    const statusProp = schema.enumProps[0];
+    expect(statusProp.enumLabels).toEqual(["pending", "active", "done"]);
+    expect(statusProp.enumValues).toEqual([0, 1, 2]);
+  });
+
+  it("skips rgb/rgba specs", () => {
+    const schema = buildAnnotationQuerySchema([
+      {
+        type: "rgb",
+        identifier: "color",
+        description: undefined,
+        default: 0,
+      } as any,
+      FLOAT_SPEC as any,
+    ]);
+    expect(schema.numericProps.map((p) => p.identifier)).toEqual(["score"]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildAnnotationQueryItems
+// ---------------------------------------------------------------------------
+
+describe("buildAnnotationQueryItems", () => {
+  it("extracts property values by identifier", () => {
+    const items = buildAnnotationQueryItems([
+      {
+        annotation: {
+          description: "hello",
+          properties: [0.5, 3, 1, 1],
+        },
+        propSpecs: ALL_SPECS as any,
+      },
+    ]);
+    expect(items[0].description).toBe("hello");
+    expect(items[0].values.get("score")).toBeCloseTo(0.5);
+    expect(items[0].values.get("count")).toBe(3);
+    expect(items[0].values.get("status")).toBe(1);
+    expect(items[0].values.get("verified")).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// parseAnnotationQuery
+// ---------------------------------------------------------------------------
+
+describe("parseAnnotationQuery", () => {
+  const schema = makeSchema();
+
+  it("returns empty query for empty string", () => {
+    const result = parseAnnotationQuery(schema, "");
+    expect("errors" in result).toBe(false);
+    const q = result as any;
+    expect(q.prefix).toBeUndefined();
+    expect(q.regexp).toBeUndefined();
+    expect(q.sortBy).toEqual([{ fieldId: "index", order: "<" }]);
+  });
+
+  it("parses description prefix", () => {
+    const q = parseAnnotationQuery(schema, "hello world") as any;
+    expect(q.prefix).toBe("hello world");
+  });
+
+  it("parses regexp", () => {
+    const q = parseAnnotationQuery(schema, "/foo.*/") as any;
+    expect(q.regexp?.source).toBe("foo.*");
+  });
+
+  it("parses sort ascending", () => {
+    const q = parseAnnotationQuery(schema, "<score") as any;
+    expect(q.sortBy).toContainEqual({ fieldId: "score", order: "<" });
+  });
+
+  it("parses sort descending", () => {
+    const q = parseAnnotationQuery(schema, ">count") as any;
+    expect(q.sortBy[0]).toEqual({ fieldId: "count", order: ">" });
+  });
+
+  it("parses sort by description", () => {
+    const q = parseAnnotationQuery(schema, "<description") as any;
+    expect(q.sortBy[0]).toEqual({ fieldId: "description", order: "<" });
+  });
+
+  it("parses column include", () => {
+    const q = parseAnnotationQuery(schema, "|score") as any;
+    expect(q.includeColumns).toContain("score");
+  });
+
+  it("parses numeric less-than constraint", () => {
+    const q = parseAnnotationQuery(schema, "score<0.8") as any;
+    expect(q.numericalConstraints[0].fieldId).toBe("score");
+    expect(q.numericalConstraints[0].bounds[1] as number).toBeLessThan(0.8);
+  });
+
+  it("parses numeric equal constraint", () => {
+    const q = parseAnnotationQuery(schema, "count=5") as any;
+    expect(q.numericalConstraints[0].bounds).toEqual([5, 5]);
+  });
+
+  it("parses numeric range: two constraints on same field", () => {
+    const q = parseAnnotationQuery(schema, "score>=0.2 score<=0.9") as any;
+    expect(q.numericalConstraints[0].fieldId).toBe("score");
+    expect(q.numericalConstraints[0].bounds[0]).toBeCloseTo(0.2);
+    expect(q.numericalConstraints[0].bounds[1]).toBeCloseTo(0.9);
+  });
+
+  it("parses enum include by label", () => {
+    const q = parseAnnotationQuery(schema, "#status=active") as any;
+    expect(q.enumConstraints[0].fieldId).toBe("status");
+    expect(q.enumConstraints[0].include).toEqual([1]);
+  });
+
+  it("parses enum exclude by label (case-insensitive)", () => {
+    const q = parseAnnotationQuery(schema, "-#status=DONE") as any;
+    expect(q.enumConstraints[0].exclude).toEqual([2]);
+  });
+
+  it("parses bool require-true", () => {
+    const q = parseAnnotationQuery(schema, "#verified") as any;
+    expect(q.boolConstraints[0]).toEqual({ fieldId: "verified", value: true });
+  });
+
+  it("parses bool require-false", () => {
+    const q = parseAnnotationQuery(schema, "-#verified") as any;
+    expect(q.boolConstraints[0]).toEqual({ fieldId: "verified", value: false });
+  });
+
+  it("returns error for unknown field in sort", () => {
+    const result = parseAnnotationQuery(schema, "<nonexistent");
+    expect("errors" in result).toBe(true);
+  });
+
+  it("returns error for unknown numeric field", () => {
+    const result = parseAnnotationQuery(schema, "nonexistent>=5");
+    expect("errors" in result).toBe(true);
+  });
+
+  it("returns error for unknown enum property", () => {
+    const result = parseAnnotationQuery(schema, "#nonexistent=val");
+    expect("errors" in result).toBe(true);
+  });
+
+  it("returns error for impossible constraint", () => {
+    const result = parseAnnotationQuery(schema, "score>=0.9 score<=0.1");
+    expect("errors" in result).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// executeAnnotationQuery
+// ---------------------------------------------------------------------------
+
+describe("executeAnnotationQuery", () => {
+  const schema = makeSchema();
+  const items = makeItems([
+    { description: "apple", score: 0.9, count: 1, status: 0, verified: true },
+    { description: "banana", score: 0.5, count: 2, status: 1, verified: false },
+    { description: "cherry", score: 0.3, count: 3, status: 2, verified: true },
+    {
+      description: "apricot",
+      score: 0.7,
+      count: 4,
+      status: 0,
+      verified: false,
+    },
+  ]);
+
+  it("returns all indices when query has no constraints", () => {
+    const q = parseAnnotationQuery(schema, "") as any;
+    const result = executeAnnotationQuery(items, q);
+    expect(result.count).toBe(4);
+    expect(result.total).toBe(4);
+  });
+
+  it("filters by description prefix", () => {
+    const q = parseAnnotationQuery(schema, "ap") as any;
+    const result = executeAnnotationQuery(items, q);
+    // apple and apricot
+    expect(result.count).toBe(2);
+    expect(Array.from(result.indices!)).toEqual(expect.arrayContaining([0, 3]));
+  });
+
+  it("filters by description regexp", () => {
+    const q = parseAnnotationQuery(schema, "/^a/") as any;
+    const result = executeAnnotationQuery(items, q);
+    expect(result.count).toBe(2);
+  });
+
+  it("filters by numeric constraint", () => {
+    const q = parseAnnotationQuery(schema, "score>=0.6") as any;
+    const result = executeAnnotationQuery(items, q);
+    // apple(0.9), banana(0.5 — NO), apricot(0.7) → 2 items
+    expect(result.count).toBe(2);
+  });
+
+  it("filters by enum include", () => {
+    const q = parseAnnotationQuery(schema, "#status=pending") as any;
+    const result = executeAnnotationQuery(items, q);
+    // apple(status=0=pending) and apricot(status=0=pending) → 2
+    expect(result.count).toBe(2);
+  });
+
+  it("filters by enum exclude", () => {
+    const q = parseAnnotationQuery(schema, "-#status=pending") as any;
+    const result = executeAnnotationQuery(items, q);
+    // banana(1) and cherry(2) → 2
+    expect(result.count).toBe(2);
+  });
+
+  it("filters by bool true", () => {
+    const q = parseAnnotationQuery(schema, "#verified") as any;
+    const result = executeAnnotationQuery(items, q);
+    // apple and cherry → 2
+    expect(result.count).toBe(2);
+  });
+
+  it("filters by bool false", () => {
+    const q = parseAnnotationQuery(schema, "-#verified") as any;
+    const result = executeAnnotationQuery(items, q);
+    // banana and apricot → 2
+    expect(result.count).toBe(2);
+  });
+
+  it("sorts by property ascending", () => {
+    const q = parseAnnotationQuery(schema, "<count") as any;
+    const result = executeAnnotationQuery(items, q);
+    const counts = Array.from(result.indices!).map(
+      (i) => items[i].values.get("count") as number,
+    );
+    expect(counts).toEqual([1, 2, 3, 4]);
+  });
+
+  it("sorts by property descending", () => {
+    const q = parseAnnotationQuery(schema, ">score") as any;
+    const result = executeAnnotationQuery(items, q);
+    const scores = Array.from(result.indices!).map(
+      (i) => items[i].values.get("score") as number,
+    );
+    // descending: 0.9, 0.7, 0.5, 0.3
+    expect(scores[0]).toBeGreaterThan(scores[1]);
+    expect(scores[1]).toBeGreaterThan(scores[2]);
+  });
+
+  it("sorts by description", () => {
+    const q = parseAnnotationQuery(schema, "<description") as any;
+    const result = executeAnnotationQuery(items, q);
+    const descs = Array.from(result.indices!).map((i) => items[i].description);
+    expect(descs).toEqual(["apple", "apricot", "banana", "cherry"]);
+  });
+
+  it("combines prefix and numeric constraint", () => {
+    const q = parseAnnotationQuery(schema, "a score>=0.8") as any;
+    const result = executeAnnotationQuery(items, q);
+    // prefix "a": apple(0.9), apricot(0.7); score>=0.8: only apple
+    expect(result.count).toBe(1);
+    expect(result.indices![0]).toBe(0);
+  });
+
+  it("populates intermediateIndices for marginal CDFs", () => {
+    const q = parseAnnotationQuery(schema, "score>=0.6") as any;
+    const result = executeAnnotationQuery(items, q);
+    // intermediateIndices = all indices (no desc/bool/enum filter), mask says which pass score>=0.6
+    expect(result.intermediateIndices).toBeDefined();
+    expect(result.intermediateIndicesMask).toBeDefined();
+    expect((result.intermediateIndices as any).length).toBe(4);
+  });
+
+  it("missing property values sort to end", () => {
+    const sparseItems = makeItems([
+      { description: "a", score: 0.5 },
+      { description: "b" }, // no score
+      { description: "c", score: 0.3 },
+    ]);
+    const q = parseAnnotationQuery(schema, "<score") as any;
+    const result = executeAnnotationQuery(sparseItems, q);
+    const scores = Array.from(result.indices!).map(
+      (i) => sparseItems[i].values.get("score") as number | undefined,
+    );
+    // b (missing) should be last
+    expect(scores[scores.length - 1]).toBeUndefined();
+  });
+
+  it("computes enumStats", () => {
+    const q = parseAnnotationQuery(schema, "#status=pending") as any;
+    const result = executeAnnotationQuery(items, q);
+    expect(result.enumStats.get("status")?.get(0)).toBe(2); // 2 pending items
+  });
+
+  it("computes boolStats", () => {
+    const q = parseAnnotationQuery(schema, "#verified") as any;
+    const result = executeAnnotationQuery(items, q);
+    expect(result.boolStats.get("verified")?.trueCount).toBe(2);
+    expect(result.boolStats.get("verified")?.falseCount).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// unparseAnnotationQuery
+// ---------------------------------------------------------------------------
+
+describe("unparseAnnotationQuery", () => {
+  const schema = makeSchema();
+
+  it("round-trips sort order", () => {
+    const q = parseAnnotationQuery(schema, ">score") as any;
+    const reparsed = parseAnnotationQuery(
+      schema,
+      unparseAnnotationQuery(q),
+    ) as any;
+    expect(reparsed.sortBy[0]).toEqual({ fieldId: "score", order: ">" });
+  });
+
+  it("round-trips enum constraint", () => {
+    const q = parseAnnotationQuery(schema, "#status=active") as any;
+    const reparsed = parseAnnotationQuery(
+      schema,
+      unparseAnnotationQuery(q),
+    ) as any;
+    expect(reparsed.enumConstraints[0].include).toEqual([1]);
+  });
+
+  it("round-trips bool constraint", () => {
+    const q = parseAnnotationQuery(schema, "-#verified") as any;
+    const reparsed = parseAnnotationQuery(
+      schema,
+      unparseAnnotationQuery(q),
+    ) as any;
+    expect(reparsed.boolConstraints[0].value).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// makeAnnotationNumericalDataSource
+// ---------------------------------------------------------------------------
+
+describe("makeAnnotationNumericalDataSource", () => {
+  const schema = makeSchema();
+  const items = makeItems([{ score: 0.2 }, { score: 0.5 }, { score: 0.8 }]);
+
+  it("exposes numericProps as properties", () => {
+    const ds = makeAnnotationNumericalDataSource(schema, () => items);
+    expect(ds.properties.map((p) => p.id)).toEqual(["score", "count"]);
+  });
+
+  it("fills histograms when query has indices", () => {
+    const ds = makeAnnotationNumericalDataSource(schema, () => items);
+    const q = parseAnnotationQuery(schema, "") as any;
+    const result = executeAnnotationQuery(items, q);
+    const windowBounds: [number, number][] = [
+      [0, 1],
+      [-2147483648, 2147483647],
+    ];
+    const histograms: any[] = [];
+    ds.updateHistograms(result, histograms, windowBounds as any);
+    expect(histograms.length).toBe(2);
+    // sum of histogram bins should equal number of items that have the property
+    const scoreSum = Array.from(histograms[0].histogram as Uint32Array).reduce(
+      (a: number, b: number) => a + b,
+      0,
+    );
+    expect(scoreSum).toBe(3);
+  });
+
+  it("clears histograms when queryResult is undefined", () => {
+    const ds = makeAnnotationNumericalDataSource(schema, () => items);
+    const histograms: any[] = [
+      { window: [0, 1], histogram: new Uint32Array(258) },
+    ];
+    const windowBounds = [[0, 1]];
+    ds.updateHistograms(undefined as any, histograms, windowBounds as any);
+    expect(histograms.length).toBe(0);
+  });
+});

--- a/src/annotation/annotation_query.ts
+++ b/src/annotation/annotation_query.ts
@@ -59,6 +59,8 @@ export interface AnnotationNumericPropSchema {
   dataType: DataType;
   bounds: DataTypeInterval;
   description?: string;
+  /** Whether the result-table column can be toggled from the summary. */
+  columnToggleable?: boolean;
   /** SI base unit for derived/computed properties (e.g. "m", "s", "m^3"). */
   baseUnit?: string;
   /** Annotation types for which this derived property is defined. */
@@ -154,6 +156,7 @@ export function buildAnnotationQuerySchema(
           dataType: DataType.FLOAT32,
           bounds: defaultDataTypeRange[DataType.FLOAT32] as DataTypeInterval,
           description: coord.description,
+          columnToggleable: false,
         });
         usedIds.add(coord.id);
       }
@@ -849,6 +852,7 @@ export function makeAnnotationNumericalDataSource(
       dataType: p.dataType,
       bounds: p.bounds,
       description: p.description,
+      columnToggleable: p.columnToggleable,
       baseUnit: p.baseUnit,
       applicableAnnotationTypes: p.applicableAnnotationTypes,
     }),

--- a/src/annotation/annotation_query.ts
+++ b/src/annotation/annotation_query.ts
@@ -29,6 +29,11 @@ import type {
   QueryParseError,
   SortBy,
 } from "#src/segmentation_display_state/property_map.js";
+import type { SerializablePropertyQueryClause } from "#src/ui/property_query.js";
+import {
+  resolvePropertyQuery,
+  serializePropertyQueryClauses,
+} from "#src/ui/property_query.js";
 import type {
   NumericalPropertyHistogram,
   NumericalSummaryDataSource,
@@ -38,13 +43,7 @@ import type {
 } from "#src/ui/property_summary.js";
 import { DataType } from "#src/util/data_type.js";
 import type { DataTypeInterval } from "#src/util/lerp.js";
-import {
-  clampToInterval,
-  dataTypeCompare,
-  dataTypeValueNextAfter,
-  defaultDataTypeRange,
-  parseDataTypeValue,
-} from "#src/util/lerp.js";
+import { defaultDataTypeRange } from "#src/util/lerp.js";
 
 // ============================================================================
 // Schema types
@@ -328,9 +327,6 @@ export function parseAnnotationQuery(
   schema: AnnotationQuerySchema,
   queryText: string,
 ): AnnotationFilterQuery | { errors: QueryParseError[] } {
-  const parsed = emptyQuery();
-  const errors: QueryParseError[] = [];
-
   const allNumericIds = new Set(
     schema.numericProps.map((p) => p.identifier.toLowerCase()),
   );
@@ -341,300 +337,142 @@ export function parseAnnotationQuery(
     schema.boolProps.map((p) => p.identifier.toLowerCase()),
   );
   const allFieldIds = new Set([...allNumericIds, ...allEnumIds, ...allBoolIds]);
-
-  const tokens = tokenize(queryText);
-  for (const { word, startIndex, endIndex } of tokens) {
-    // Sort token: <field or >field
-    if (word.startsWith("<") || word.startsWith(">")) {
-      const fieldId = word.substring(1).toLowerCase();
-      const order = word[0] as "<" | ">";
+  return resolvePropertyQuery(queryText, {
+    createQuery: emptyQuery,
+    resolveSortField: (clause) => {
+      const fieldId = clause.field.toLowerCase();
       if (
         fieldId !== "description" &&
         fieldId !== "index" &&
         !allFieldIds.has(fieldId)
       ) {
-        errors.push({
-          begin: startIndex + 1,
-          end: endIndex,
-          message: `Unknown sort field: ${fieldId}`,
-        });
-        continue;
+        return {
+          error: {
+            begin: clause.begin + 1,
+            end: clause.end,
+            message: `Unknown sort field: ${fieldId}`,
+          },
+        };
       }
-      const canonId =
-        fieldId === "description" || fieldId === "index"
-          ? fieldId
-          : findCanonicalId(fieldId, schema);
-      if (parsed.sortBy.find((s) => s.fieldId === canonId)) {
-        errors.push({
-          begin: startIndex + 1,
-          end: endIndex,
-          message: `Duplicate sort field: ${fieldId}`,
-        });
-        continue;
-      }
-      parsed.sortBy.push({ fieldId: canonId, order });
-      continue;
-    }
-
-    // Column token: |field
-    if (word.startsWith("|")) {
-      const fieldId = word.substring(1).toLowerCase();
+      return {
+        value:
+          fieldId === "description" || fieldId === "index"
+            ? fieldId
+            : findCanonicalId(fieldId, schema),
+      };
+    },
+    duplicateSortMessage: (clause) =>
+      `Duplicate sort field: ${clause.field.toLowerCase()}`,
+    resolveColumnField: (clause) => {
+      const fieldId = clause.field.toLowerCase();
       if (!allFieldIds.has(fieldId)) {
-        errors.push({
-          begin: startIndex + 1,
-          end: endIndex,
-          message: `Unknown column field: ${fieldId}`,
-        });
-        continue;
+        return {
+          error: {
+            begin: clause.begin + 1,
+            end: clause.end,
+            message: `Unknown column field: ${fieldId}`,
+          },
+        };
       }
-      const canonId = findCanonicalId(fieldId, schema);
-      if (
-        parsed.sortBy.find((s) => s.fieldId === canonId) ||
-        parsed.includeColumns.includes(canonId)
-      ) {
-        continue;
+      return { value: findCanonicalId(fieldId, schema) };
+    },
+    resolveNumericField: (clause) => {
+      const fieldId = clause.field.toLowerCase();
+      const property = schema.numericProps.find(
+        (candidate) => candidate.identifier.toLowerCase() === fieldId,
+      );
+      if (property === undefined) {
+        return {
+          error: {
+            begin: clause.begin,
+            end: clause.end,
+            message: `Unknown or non-numeric field: ${fieldId}`,
+          },
+        };
       }
-      parsed.includeColumns.push(canonId);
-      continue;
-    }
-
-    // Regexp token: /pattern/ — trailing slash is optional
-    if (word.startsWith("/")) {
-      if (parsed.regexp !== undefined) {
-        errors.push({
-          begin: startIndex,
-          end: endIndex,
-          message: "Only one regular expression allowed",
-        });
-        continue;
-      }
-      if (parsed.prefix !== undefined) {
-        errors.push({
-          begin: startIndex,
-          end: endIndex,
-          message: "Prefix cannot be combined with regular expression",
-        });
-        continue;
-      }
-      const pattern =
-        word.endsWith("/") && word.length > 1
-          ? word.slice(1, -1)
-          : word.slice(1);
-      try {
-        parsed.regexp = new RegExp(pattern, "i");
-      } catch {
-        errors.push({
-          begin: startIndex,
-          end: endIndex,
-          message: "Invalid regular expression syntax",
-        });
-      }
-      continue;
-    }
-
-    // Enum/bool constraint: #prop[=label] or -#prop[=label]
-    const enumBoolMatch = word.match(
-      /^(-?)#([a-zA-Z][a-zA-Z0-9_]*)(?:=(.*))?$/,
-    );
-    if (enumBoolMatch !== null) {
-      const negate = enumBoolMatch[1] === "-";
-      const rawId = enumBoolMatch[2].toLowerCase();
-      const valueStr = enumBoolMatch[3];
-
-      if (allBoolIds.has(rawId)) {
-        // Bool constraint
-        if (valueStr !== undefined) {
+      return {
+        value: {
+          fieldId: property.identifier,
+          dataType: property.dataType,
+          bounds: property.bounds,
+        },
+      };
+    },
+    applyCategoricalClause: (query, clause, { errors }) => {
+      const fieldId = clause.field.toLowerCase();
+      if (allBoolIds.has(fieldId)) {
+        if (clause.value !== undefined) {
           errors.push({
-            begin: startIndex,
-            end: endIndex,
-            message: `Bool property ${rawId} does not accept a value; use #${rawId} or -#${rawId}`,
+            begin: clause.begin,
+            end: clause.end,
+            message: `Bool property ${fieldId} does not accept a value; use #${fieldId} or -#${fieldId}`,
           });
-          continue;
+          return;
         }
-        const canonId = findCanonicalId(rawId, schema);
-        let constraint = parsed.boolConstraints.find(
-          (c) => c.fieldId === canonId,
+        const canonicalId = findCanonicalId(fieldId, schema);
+        let constraint = query.boolConstraints.find(
+          (candidate) => candidate.fieldId === canonicalId,
         );
         if (constraint === undefined) {
-          constraint = { fieldId: canonId, value: undefined };
-          parsed.boolConstraints.push(constraint);
+          constraint = { fieldId: canonicalId, value: undefined };
+          query.boolConstraints.push(constraint);
         }
-        constraint.value = !negate;
-        continue;
+        constraint.value = !clause.exclude;
+        return;
       }
-
-      if (allEnumIds.has(rawId)) {
-        const enumSchema = schema.enumProps.find(
-          (p) => p.identifier.toLowerCase() === rawId,
+      if (allEnumIds.has(fieldId)) {
+        const property = schema.enumProps.find(
+          (candidate) => candidate.identifier.toLowerCase() === fieldId,
         )!;
-        const canonId = enumSchema.identifier;
-        let rawEnumValue: number;
-
-        if (valueStr === undefined) {
+        if (clause.value === undefined) {
           errors.push({
-            begin: startIndex,
-            end: endIndex,
-            message: `Enum property ${rawId} requires a value: #${rawId}=label`,
+            begin: clause.begin,
+            end: clause.end,
+            message: `Enum property ${fieldId} requires a value: #${fieldId}=label`,
           });
-          continue;
+          return;
         }
-
-        // Try label lookup (case-insensitive) first
-        const labelIdx = enumSchema.enumLabels.findIndex(
-          (l) => l.toLowerCase() === valueStr.toLowerCase(),
+        const labelIndex = property.enumLabels.findIndex(
+          (label) => label.toLowerCase() === clause.value!.toLowerCase(),
         );
-        if (labelIdx !== -1) {
-          rawEnumValue = enumSchema.enumValues[labelIdx];
-        } else {
-          // Fall back to numeric value
-          const num = Number(valueStr);
-          if (!Number.isFinite(num) || !enumSchema.enumValues.includes(num)) {
-            errors.push({
-              begin: startIndex,
-              end: endIndex,
-              message: `Unknown enum value for ${rawId}: ${valueStr}`,
-            });
-            continue;
-          }
-          rawEnumValue = num;
+        const numericValue = Number(clause.value);
+        const value =
+          labelIndex === -1 ? numericValue : property.enumValues[labelIndex];
+        if (
+          labelIndex === -1 &&
+          (!Number.isFinite(value) || !property.enumValues.includes(value))
+        ) {
+          errors.push({
+            begin: clause.begin,
+            end: clause.end,
+            message: `Unknown enum value for ${fieldId}: ${clause.value}`,
+          });
+          return;
         }
-
-        let constraint = parsed.enumConstraints.find(
-          (c) => c.fieldId === canonId,
+        let constraint = query.enumConstraints.find(
+          (candidate) => candidate.fieldId === property.identifier,
         );
         if (constraint === undefined) {
-          constraint = { fieldId: canonId, include: [], exclude: [] };
-          parsed.enumConstraints.push(constraint);
+          constraint = {
+            fieldId: property.identifier,
+            include: [],
+            exclude: [],
+          };
+          query.enumConstraints.push(constraint);
         }
-        if (negate) {
-          if (!constraint.exclude.includes(rawEnumValue)) {
-            constraint.exclude.push(rawEnumValue);
-          }
-        } else {
-          if (!constraint.include.includes(rawEnumValue)) {
-            constraint.include.push(rawEnumValue);
-          }
-        }
-        continue;
+        const target = clause.exclude ? constraint.exclude : constraint.include;
+        if (!target.includes(value)) target.push(value);
+        return;
       }
-
       errors.push({
-        begin: startIndex,
-        end: endIndex,
-        message: `Unknown property: ${rawId}`,
+        begin: clause.begin,
+        end: clause.end,
+        message: `Unknown property: ${fieldId}`,
       });
-      continue;
-    }
-
-    // Numeric constraint: prop<N, prop<=N, prop=N, prop>=N, prop>N
-    const numericMatch = word.match(
-      /^([a-zA-Z][a-zA-Z0-9_]*)(<|<=|=|>=|>)(-?[0-9.].*)$/,
-    );
-    if (numericMatch !== null) {
-      const rawId = numericMatch[1].toLowerCase();
-      const op = numericMatch[2];
-      const numericSchema = schema.numericProps.find(
-        (p) => p.identifier.toLowerCase() === rawId,
-      );
-      if (numericSchema === undefined) {
-        errors.push({
-          begin: startIndex,
-          end: endIndex,
-          message: `Unknown or non-numeric field: ${rawId}`,
-        });
-        continue;
-      }
-      const canonId = numericSchema.identifier;
-      let value: number;
-      try {
-        value = parseDataTypeValue(
-          numericSchema.dataType,
-          numericMatch[3],
-        ) as number;
-      } catch (e: any) {
-        errors.push({
-          begin: startIndex + numericMatch[1].length + numericMatch[2].length,
-          end: endIndex,
-          message: e.message,
-        });
-        continue;
-      }
-      let constraint = parsed.numericalConstraints.find(
-        (c) => c.fieldId === canonId,
-      );
-      if (constraint === undefined) {
-        constraint = { fieldId: canonId, bounds: numericSchema.bounds };
-        parsed.numericalConstraints.push(constraint);
-      }
-      const origMin = clampToInterval(
-        numericSchema.bounds,
-        constraint.bounds[0],
-      ) as number;
-      const origMax = clampToInterval(
-        numericSchema.bounds,
-        constraint.bounds[1],
-      ) as number;
-      let newMin = origMin;
-      let newMax = origMax;
-      switch (op) {
-        case "<":
-          newMax = dataTypeValueNextAfter(
-            numericSchema.dataType,
-            value,
-            -1,
-          ) as number;
-          break;
-        case "<=":
-          newMax = value;
-          break;
-        case "=":
-          newMin = newMax = value;
-          break;
-        case ">=":
-          newMin = value;
-          break;
-        case ">":
-          newMin = dataTypeValueNextAfter(
-            numericSchema.dataType,
-            value,
-            +1,
-          ) as number;
-          break;
-      }
-      newMin = dataTypeCompare(origMin, newMin) > 0 ? origMin : newMin;
-      newMax = dataTypeCompare(origMax, newMax) < 0 ? origMax : newMax;
-      if (dataTypeCompare(newMin, newMax) > 0) {
-        errors.push({
-          begin: startIndex,
-          end: endIndex,
-          message: "Constraint would not match any values",
-        });
-        continue;
-      }
-      constraint.bounds = [newMin, newMax] as DataTypeInterval;
-      continue;
-    }
-
-    // Prefix token: bare word
-    if (parsed.regexp !== undefined) {
-      errors.push({
-        begin: startIndex,
-        end: endIndex,
-        message: "Prefix cannot be combined with regular expression",
-      });
-      continue;
-    }
-    parsed.prefix =
-      parsed.prefix !== undefined ? `${parsed.prefix} ${word}` : word;
-  }
-
-  if (errors.length > 0) {
-    return { errors };
-  }
-  if (parsed.sortBy.length === 0) {
-    parsed.sortBy.push({ fieldId: "index", order: "<" });
-  }
-  return parsed;
+    },
+    defaultSort: { fieldId: "index", order: "<" },
+    regexpFlags: "i",
+  });
 }
 
 /** Convert an AnnotationFilterQuery back to a query string. */
@@ -642,42 +480,75 @@ export function unparseAnnotationQuery(
   query: AnnotationFilterQuery,
   schemaBoundsMap?: ReadonlyMap<string, readonly [number, number]>,
 ): string {
-  const parts: string[] = [];
+  const clauses: SerializablePropertyQueryClause[] = [];
   for (const { fieldId, order } of query.sortBy) {
     if (fieldId !== "index" || order !== "<") {
-      parts.push(`${order}${fieldId}`);
+      clauses.push({ type: "sort", field: fieldId, order });
     }
   }
   for (const col of query.includeColumns) {
     if (!query.sortBy.find((s) => s.fieldId === col)) {
-      parts.push(`|${col}`);
+      clauses.push({ type: "column", field: col });
     }
   }
   for (const c of query.numericalConstraints) {
     const sb = schemaBoundsMap?.get(c.fieldId);
     const [lo, hi] = c.bounds as [number, number];
     if (sb === undefined || lo > sb[0]) {
-      parts.push(`${c.fieldId}>=${lo}`);
+      clauses.push({
+        type: "comparison",
+        field: c.fieldId,
+        operator: ">=",
+        value: `${lo}`,
+      });
     }
     if (sb === undefined || hi < sb[1]) {
-      parts.push(`${c.fieldId}<=${hi}`);
+      clauses.push({
+        type: "comparison",
+        field: c.fieldId,
+        operator: "<=",
+        value: `${hi}`,
+      });
     }
   }
   for (const c of query.enumConstraints) {
-    for (const v of c.include) parts.push(`#${c.fieldId}=${v}`);
-    for (const v of c.exclude) parts.push(`-#${c.fieldId}=${v}`);
+    for (const value of c.include) {
+      clauses.push({
+        type: "categorical",
+        exclude: false,
+        field: c.fieldId,
+        value: `${value}`,
+      });
+    }
+    for (const value of c.exclude) {
+      clauses.push({
+        type: "categorical",
+        exclude: true,
+        field: c.fieldId,
+        value: `${value}`,
+      });
+    }
   }
   for (const c of query.boolConstraints) {
     if (c.value !== undefined) {
-      parts.push(c.value ? `#${c.fieldId}` : `-#${c.fieldId}`);
+      clauses.push({
+        type: "categorical",
+        exclude: !c.value,
+        field: c.fieldId,
+        value: undefined,
+      });
     }
   }
   if (query.regexp !== undefined) {
-    parts.push(`/${query.regexp.source}/`);
+    clauses.push({
+      type: "regexp",
+      pattern: query.regexp.source,
+      closed: true,
+    });
   } else if (query.prefix !== undefined) {
-    parts.push(query.prefix);
+    clauses.push({ type: "text", value: query.prefix });
   }
-  return parts.join(" ");
+  return serializePropertyQueryClauses(clauses);
 }
 
 // ============================================================================
@@ -1053,29 +924,6 @@ function computeAnnotationPropertyHistogram(
     }
   }
   return { window, histogram };
-}
-
-// ============================================================================
-// Helpers
-// ============================================================================
-
-interface Token {
-  word: string;
-  startIndex: number;
-  endIndex: number;
-}
-
-function tokenize(text: string): Token[] {
-  const tokens: Token[] = [];
-  let i = 0;
-  while (i < text.length) {
-    while (i < text.length && text[i] === " ") ++i;
-    if (i >= text.length) break;
-    const start = i;
-    while (i < text.length && text[i] !== " ") ++i;
-    tokens.push({ word: text.slice(start, i), startIndex: start, endIndex: i });
-  }
-  return tokens;
 }
 
 function findCanonicalId(

--- a/src/annotation/annotation_query.ts
+++ b/src/annotation/annotation_query.ts
@@ -22,8 +22,12 @@
 import type {
   AnnotationNumericPropertySpec,
   AnnotationPropertySpec,
+  AnnotationType,
 } from "#src/annotation/index.js";
-import { propertyTypeDataType } from "#src/annotation/index.js";
+import {
+  annotationTypes,
+  propertyTypeDataType,
+} from "#src/annotation/index.js";
 import type {
   NumericalPropertyConstraint,
   QueryParseError,
@@ -44,6 +48,7 @@ import type {
 import { DataType } from "#src/util/data_type.js";
 import type { DataTypeInterval } from "#src/util/lerp.js";
 import { defaultDataTypeRange } from "#src/util/lerp.js";
+import { formatValueWithUnit, pickDisplayUnit } from "#src/util/si_units.js";
 
 // ============================================================================
 // Schema types
@@ -56,6 +61,8 @@ export interface AnnotationNumericPropSchema {
   description?: string;
   /** SI base unit for derived/computed properties (e.g. "m", "s", "m^3"). */
   baseUnit?: string;
+  /** Annotation types for which this derived property is defined. */
+  applicableAnnotationTypes?: readonly AnnotationType[];
 }
 
 export interface AnnotationEnumPropSchema {
@@ -395,6 +402,7 @@ export function parseAnnotationQuery(
           fieldId: property.identifier,
           dataType: property.dataType,
           bounds: property.bounds,
+          baseUnit: property.baseUnit,
         },
       };
     },
@@ -479,6 +487,7 @@ export function parseAnnotationQuery(
 export function unparseAnnotationQuery(
   query: AnnotationFilterQuery,
   schemaBoundsMap?: ReadonlyMap<string, readonly [number, number]>,
+  schemaBaseUnitMap?: ReadonlyMap<string, string>,
 ): string {
   const clauses: SerializablePropertyQueryClause[] = [];
   for (const { fieldId, order } of query.sortBy) {
@@ -494,12 +503,21 @@ export function unparseAnnotationQuery(
   for (const c of query.numericalConstraints) {
     const sb = schemaBoundsMap?.get(c.fieldId);
     const [lo, hi] = c.bounds as [number, number];
+    const baseUnit = schemaBaseUnitMap?.get(c.fieldId);
+    const displayUnit =
+      baseUnit === undefined || sb === undefined
+        ? undefined
+        : pickDisplayUnit(sb, baseUnit);
+    const formatValue = (value: number) =>
+      displayUnit === undefined
+        ? `${value}`
+        : formatValueWithUnit(value, displayUnit);
     if (sb === undefined || lo > sb[0]) {
       clauses.push({
         type: "comparison",
         field: c.fieldId,
         operator: ">=",
-        value: `${lo}`,
+        value: formatValue(lo),
       });
     }
     if (sb === undefined || hi < sb[1]) {
@@ -507,7 +525,7 @@ export function unparseAnnotationQuery(
         type: "comparison",
         field: c.fieldId,
         operator: "<=",
-        value: `${hi}`,
+        value: formatValue(hi),
       });
     }
   }
@@ -831,11 +849,31 @@ export function makeAnnotationNumericalDataSource(
       dataType: p.dataType,
       bounds: p.bounds,
       description: p.description,
+      baseUnit: p.baseUnit,
+      applicableAnnotationTypes: p.applicableAnnotationTypes,
     }),
   );
 
   return {
     properties,
+    isPropertyApplicable(property, qr) {
+      const applicableTypes = property.applicableAnnotationTypes;
+      if (applicableTypes === undefined) return true;
+      const annotationQr = qr as AnnotationQueryResult | undefined;
+      const typeConstraint = annotationQr?.query.enumConstraints.find(
+        (constraint) => constraint.fieldId === "type",
+      );
+      if (typeConstraint === undefined) return true;
+      const selectedTypes =
+        typeConstraint.include.length === 0
+          ? annotationTypes
+          : typeConstraint.include;
+      return selectedTypes.some(
+        (type) =>
+          !typeConstraint.exclude.includes(type) &&
+          applicableTypes.includes(type),
+      );
+    },
     updateHistograms(qr, histograms, windowBounds) {
       const annotationQr = qr as AnnotationQueryResult | undefined;
       if (annotationQr?.indices === undefined) {

--- a/src/annotation/annotation_query.ts
+++ b/src/annotation/annotation_query.ts
@@ -1,0 +1,1101 @@
+/**
+ * @license
+ * Copyright 2024 Google Inc.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Annotation query engine: parse, execute, and compute histograms for
+// annotation-list filtering/sorting.  Mirrors the segment query engine in
+// segmentation_display_state/property_map.ts but is row-major (each annotation
+// carries its own property values) rather than columnar.
+
+import type {
+  AnnotationNumericPropertySpec,
+  AnnotationPropertySpec,
+} from "#src/annotation/index.js";
+import { propertyTypeDataType } from "#src/annotation/index.js";
+import type {
+  NumericalPropertyConstraint,
+  QueryParseError,
+  SortBy,
+} from "#src/segmentation_display_state/property_map.js";
+import type {
+  NumericalPropertyHistogram,
+  NumericalSummaryDataSource,
+  NumericalSummaryProperty,
+  NumericalSummaryQuery,
+  NumericalSummaryQueryResult,
+} from "#src/ui/property_summary.js";
+import { DataType } from "#src/util/data_type.js";
+import type { DataTypeInterval } from "#src/util/lerp.js";
+import {
+  clampToInterval,
+  dataTypeCompare,
+  dataTypeValueNextAfter,
+  defaultDataTypeRange,
+  parseDataTypeValue,
+} from "#src/util/lerp.js";
+
+// ============================================================================
+// Schema types
+// ============================================================================
+
+export interface AnnotationNumericPropSchema {
+  identifier: string;
+  dataType: DataType;
+  bounds: DataTypeInterval;
+  description?: string;
+  /** SI base unit for derived/computed properties (e.g. "m", "s", "m^3"). */
+  baseUnit?: string;
+}
+
+export interface AnnotationEnumPropSchema {
+  identifier: string;
+  /** Raw numeric enum values (e.g. [0, 1, 2]). */
+  enumValues: number[];
+  /** Human-readable labels corresponding to each enumValue. */
+  enumLabels: string[];
+  description?: string;
+}
+
+export interface AnnotationBoolPropSchema {
+  identifier: string;
+  description?: string;
+}
+
+/** Partitioned schema derived from a deduplicated AnnotationPropertySpec list. */
+export interface AnnotationQuerySchema {
+  /** Plain numeric properties (no enumValues). */
+  numericProps: AnnotationNumericPropSchema[];
+  /** Numeric properties that have enumValues/enumLabels. */
+  enumProps: AnnotationEnumPropSchema[];
+  /** Boolean properties. */
+  boolProps: AnnotationBoolPropSchema[];
+}
+
+/**
+ * Build a query schema from a deduplicated list of annotation property specs.
+ * @param coordDims  Optional coordinate dimensions to add as float32 numeric props.
+ *                   Skipped if their id conflicts with an existing property identifier.
+ */
+export function buildAnnotationQuerySchema(
+  specs: AnnotationPropertySpec[],
+  coordDims?: Array<{ id: string; description?: string }>,
+  typeProp?: AnnotationEnumPropSchema,
+  derivedProps?: AnnotationNumericPropSchema[],
+): AnnotationQuerySchema {
+  const numericProps: AnnotationNumericPropSchema[] = [];
+  const enumProps: AnnotationEnumPropSchema[] = [];
+  const boolProps: AnnotationBoolPropSchema[] = [];
+
+  for (const spec of specs) {
+    if (spec.type === "rgb" || spec.type === "rgba") continue;
+    if (spec.type === "bool") {
+      boolProps.push({
+        identifier: spec.identifier,
+        description: spec.description ?? undefined,
+      });
+      continue;
+    }
+    const numSpec = spec as AnnotationNumericPropertySpec;
+    const dataType = propertyTypeDataType[spec.type]!;
+    const defaultRange = defaultDataTypeRange[dataType] as DataTypeInterval;
+    const bounds: DataTypeInterval = [
+      numSpec.min ?? (defaultRange[0] as number),
+      numSpec.max ?? (defaultRange[1] as number),
+    ] as DataTypeInterval;
+    if (numSpec.enumValues !== undefined && numSpec.enumValues.length > 0) {
+      enumProps.push({
+        identifier: spec.identifier,
+        enumValues: numSpec.enumValues,
+        enumLabels: numSpec.enumLabels ?? numSpec.enumValues.map(String),
+        description: spec.description ?? undefined,
+      });
+    } else {
+      numericProps.push({
+        identifier: spec.identifier,
+        dataType,
+        bounds,
+        description: spec.description ?? undefined,
+      });
+    }
+  }
+  const usedIds = new Set([
+    ...numericProps.map((p) => p.identifier),
+    ...enumProps.map((p) => p.identifier),
+    ...boolProps.map((p) => p.identifier),
+  ]);
+  // Prepend the synthetic annotation-type enum so it appears first in the chips.
+  if (typeProp !== undefined && !usedIds.has(typeProp.identifier)) {
+    enumProps.unshift(typeProp);
+    usedIds.add(typeProp.identifier);
+  }
+  if (coordDims !== undefined) {
+    for (const coord of coordDims) {
+      if (!usedIds.has(coord.id)) {
+        numericProps.push({
+          identifier: coord.id,
+          dataType: DataType.FLOAT32,
+          bounds: defaultDataTypeRange[DataType.FLOAT32] as DataTypeInterval,
+          description: coord.description,
+        });
+        usedIds.add(coord.id);
+      }
+    }
+  }
+  // Append derived (computed) geometric properties (length, volume, ...).
+  if (derivedProps !== undefined) {
+    for (const prop of derivedProps) {
+      if (!usedIds.has(prop.identifier)) {
+        numericProps.push(prop);
+        usedIds.add(prop.identifier);
+      }
+    }
+  }
+  return { numericProps, enumProps, boolProps };
+}
+
+// ============================================================================
+// Query items
+// ============================================================================
+
+/**
+ * One queryable row derived from an annotation.
+ * Values are keyed by property identifier:
+ *  - numeric/enum → number (NaN if not present for that annotation)
+ *  - bool         → boolean (absent if not present)
+ *  - coord dims   → midpoint of the annotation's spatial extent for that dim
+ */
+export interface AnnotationQueryItem {
+  description: string;
+  values: Map<string, number | boolean>;
+  /**
+   * Spatial [min, max] extent per coordinate dimension.
+   * Used for range-overlap filtering and direction-dependent sorting:
+   *   ascending  → sort by min (smallest-start first)
+   *   descending → sort by max (largest-end first)
+   */
+  coordBounds?: Map<string, [number, number]>;
+}
+
+/**
+ * Build AnnotationQueryItems from a flat annotation list.
+ *
+ * @param listElements  Pairs of (annotation, source properties array, optional coord data).
+ */
+export function buildAnnotationQueryItems(
+  listElements: Array<{
+    annotation: { description?: string; properties: any[] };
+    propSpecs: AnnotationPropertySpec[];
+    /** Per-dimension midpoint value for use in histograms. */
+    coordValues?: Map<string, number>;
+    /** Per-dimension [min, max] extent for filtering and sorting. */
+    coordBounds?: Map<string, [number, number]>;
+    /** Raw AnnotationType value (0–4) stored under the "type" field. */
+    annotationType?: number;
+    /** Derived/computed geometric property values (NaN where not applicable). */
+    derivedValues?: Map<string, number>;
+  }>,
+): AnnotationQueryItem[] {
+  return listElements.map(
+    ({
+      annotation,
+      propSpecs,
+      coordValues,
+      coordBounds,
+      annotationType,
+      derivedValues,
+    }) => {
+      const values = new Map<string, number | boolean>();
+      if (coordValues !== undefined) {
+        for (const [id, v] of coordValues) {
+          values.set(id, v);
+        }
+      }
+      if (derivedValues !== undefined) {
+        for (const [id, v] of derivedValues) {
+          values.set(id, v);
+        }
+      }
+      if (annotationType !== undefined) {
+        values.set("type", annotationType);
+      }
+      for (let i = 0; i < propSpecs.length; ++i) {
+        const spec = propSpecs[i];
+        if (spec.type === "rgb" || spec.type === "rgba") continue;
+        const raw = annotation.properties[i];
+        if (raw === undefined || raw === null) continue;
+        if (spec.type === "bool") {
+          values.set(spec.identifier, Boolean(raw));
+        } else {
+          values.set(spec.identifier, Number(raw));
+        }
+      }
+      return { description: annotation.description ?? "", values, coordBounds };
+    },
+  );
+}
+
+// ============================================================================
+// Filter query types
+// ============================================================================
+
+export interface AnnotationEnumConstraint {
+  fieldId: string;
+  /** Include only items whose enum value is in this list (empty = accept all). */
+  include: number[];
+  /** Exclude items whose enum value is in this list. */
+  exclude: number[];
+}
+
+export interface AnnotationBoolConstraint {
+  fieldId: string;
+  /** undefined = no constraint; true = require true; false = require false. */
+  value: boolean | undefined;
+}
+
+export interface AnnotationFilterQuery extends NumericalSummaryQuery {
+  // From NumericalSummaryQuery:
+  //   sortBy: SortBy[]
+  //   includeColumns: string[]
+  //   numericalConstraints: NumericalPropertyConstraint[]
+
+  /** Description prefix filter (case-insensitive). */
+  prefix: string | undefined;
+  /** Description regexp filter. */
+  regexp: RegExp | undefined;
+  enumConstraints: AnnotationEnumConstraint[];
+  boolConstraints: AnnotationBoolConstraint[];
+}
+
+export interface AnnotationQueryResult extends NumericalSummaryQueryResult {
+  // From NumericalSummaryQueryResult:
+  //   query: NumericalSummaryQuery (actually AnnotationFilterQuery)
+  //   indices?: ArrayLike<number>
+  //   intermediateIndices?: ArrayLike<number>
+  //   intermediateIndicesMask?: Uint32Array | Uint16Array | Uint8Array
+
+  query: AnnotationFilterQuery;
+  count: number;
+  total: number;
+  errors: QueryParseError[];
+  /** Per enum property: how many items in `indices` have each raw value. */
+  enumStats: Map<string, Map<number, number>>;
+  /** Per bool property: how many items in `indices` are true vs false. */
+  boolStats: Map<string, { trueCount: number; falseCount: number }>;
+}
+
+// ============================================================================
+// Parser
+// ============================================================================
+
+const emptyQuery = (): AnnotationFilterQuery => ({
+  prefix: undefined,
+  regexp: undefined,
+  numericalConstraints: [],
+  enumConstraints: [],
+  boolConstraints: [],
+  sortBy: [],
+  includeColumns: [],
+});
+
+/**
+ * Parse a free-text annotation query string.
+ *
+ * Grammar (tokens are space-separated):
+ *   <field          sort by `field` ascending
+ *   >field          sort by `field` descending  (field = property id, "description", "index")
+ *   |field          show `field` as a column
+ *   prop<N          numeric constraint (also <=, =, >=, >)
+ *   #prop=label     include only enum values matching label (case-insensitive)
+ *   -#prop=label    exclude enum values matching label
+ *   #prop           require bool property to be true
+ *   -#prop          require bool property to be false
+ *   /re/            description regexp
+ *   word            description prefix
+ */
+export function parseAnnotationQuery(
+  schema: AnnotationQuerySchema,
+  queryText: string,
+): AnnotationFilterQuery | { errors: QueryParseError[] } {
+  const parsed = emptyQuery();
+  const errors: QueryParseError[] = [];
+
+  const allNumericIds = new Set(
+    schema.numericProps.map((p) => p.identifier.toLowerCase()),
+  );
+  const allEnumIds = new Set(
+    schema.enumProps.map((p) => p.identifier.toLowerCase()),
+  );
+  const allBoolIds = new Set(
+    schema.boolProps.map((p) => p.identifier.toLowerCase()),
+  );
+  const allFieldIds = new Set([...allNumericIds, ...allEnumIds, ...allBoolIds]);
+
+  const tokens = tokenize(queryText);
+  for (const { word, startIndex, endIndex } of tokens) {
+    // Sort token: <field or >field
+    if (word.startsWith("<") || word.startsWith(">")) {
+      const fieldId = word.substring(1).toLowerCase();
+      const order = word[0] as "<" | ">";
+      if (
+        fieldId !== "description" &&
+        fieldId !== "index" &&
+        !allFieldIds.has(fieldId)
+      ) {
+        errors.push({
+          begin: startIndex + 1,
+          end: endIndex,
+          message: `Unknown sort field: ${fieldId}`,
+        });
+        continue;
+      }
+      const canonId =
+        fieldId === "description" || fieldId === "index"
+          ? fieldId
+          : findCanonicalId(fieldId, schema);
+      if (parsed.sortBy.find((s) => s.fieldId === canonId)) {
+        errors.push({
+          begin: startIndex + 1,
+          end: endIndex,
+          message: `Duplicate sort field: ${fieldId}`,
+        });
+        continue;
+      }
+      parsed.sortBy.push({ fieldId: canonId, order });
+      continue;
+    }
+
+    // Column token: |field
+    if (word.startsWith("|")) {
+      const fieldId = word.substring(1).toLowerCase();
+      if (!allFieldIds.has(fieldId)) {
+        errors.push({
+          begin: startIndex + 1,
+          end: endIndex,
+          message: `Unknown column field: ${fieldId}`,
+        });
+        continue;
+      }
+      const canonId = findCanonicalId(fieldId, schema);
+      if (
+        parsed.sortBy.find((s) => s.fieldId === canonId) ||
+        parsed.includeColumns.includes(canonId)
+      ) {
+        continue;
+      }
+      parsed.includeColumns.push(canonId);
+      continue;
+    }
+
+    // Regexp token: /pattern/ — trailing slash is optional
+    if (word.startsWith("/")) {
+      if (parsed.regexp !== undefined) {
+        errors.push({
+          begin: startIndex,
+          end: endIndex,
+          message: "Only one regular expression allowed",
+        });
+        continue;
+      }
+      if (parsed.prefix !== undefined) {
+        errors.push({
+          begin: startIndex,
+          end: endIndex,
+          message: "Prefix cannot be combined with regular expression",
+        });
+        continue;
+      }
+      const pattern =
+        word.endsWith("/") && word.length > 1
+          ? word.slice(1, -1)
+          : word.slice(1);
+      try {
+        parsed.regexp = new RegExp(pattern, "i");
+      } catch {
+        errors.push({
+          begin: startIndex,
+          end: endIndex,
+          message: "Invalid regular expression syntax",
+        });
+      }
+      continue;
+    }
+
+    // Enum/bool constraint: #prop[=label] or -#prop[=label]
+    const enumBoolMatch = word.match(
+      /^(-?)#([a-zA-Z][a-zA-Z0-9_]*)(?:=(.*))?$/,
+    );
+    if (enumBoolMatch !== null) {
+      const negate = enumBoolMatch[1] === "-";
+      const rawId = enumBoolMatch[2].toLowerCase();
+      const valueStr = enumBoolMatch[3];
+
+      if (allBoolIds.has(rawId)) {
+        // Bool constraint
+        if (valueStr !== undefined) {
+          errors.push({
+            begin: startIndex,
+            end: endIndex,
+            message: `Bool property ${rawId} does not accept a value; use #${rawId} or -#${rawId}`,
+          });
+          continue;
+        }
+        const canonId = findCanonicalId(rawId, schema);
+        let constraint = parsed.boolConstraints.find(
+          (c) => c.fieldId === canonId,
+        );
+        if (constraint === undefined) {
+          constraint = { fieldId: canonId, value: undefined };
+          parsed.boolConstraints.push(constraint);
+        }
+        constraint.value = !negate;
+        continue;
+      }
+
+      if (allEnumIds.has(rawId)) {
+        const enumSchema = schema.enumProps.find(
+          (p) => p.identifier.toLowerCase() === rawId,
+        )!;
+        const canonId = enumSchema.identifier;
+        let rawEnumValue: number;
+
+        if (valueStr === undefined) {
+          errors.push({
+            begin: startIndex,
+            end: endIndex,
+            message: `Enum property ${rawId} requires a value: #${rawId}=label`,
+          });
+          continue;
+        }
+
+        // Try label lookup (case-insensitive) first
+        const labelIdx = enumSchema.enumLabels.findIndex(
+          (l) => l.toLowerCase() === valueStr.toLowerCase(),
+        );
+        if (labelIdx !== -1) {
+          rawEnumValue = enumSchema.enumValues[labelIdx];
+        } else {
+          // Fall back to numeric value
+          const num = Number(valueStr);
+          if (!Number.isFinite(num) || !enumSchema.enumValues.includes(num)) {
+            errors.push({
+              begin: startIndex,
+              end: endIndex,
+              message: `Unknown enum value for ${rawId}: ${valueStr}`,
+            });
+            continue;
+          }
+          rawEnumValue = num;
+        }
+
+        let constraint = parsed.enumConstraints.find(
+          (c) => c.fieldId === canonId,
+        );
+        if (constraint === undefined) {
+          constraint = { fieldId: canonId, include: [], exclude: [] };
+          parsed.enumConstraints.push(constraint);
+        }
+        if (negate) {
+          if (!constraint.exclude.includes(rawEnumValue)) {
+            constraint.exclude.push(rawEnumValue);
+          }
+        } else {
+          if (!constraint.include.includes(rawEnumValue)) {
+            constraint.include.push(rawEnumValue);
+          }
+        }
+        continue;
+      }
+
+      errors.push({
+        begin: startIndex,
+        end: endIndex,
+        message: `Unknown property: ${rawId}`,
+      });
+      continue;
+    }
+
+    // Numeric constraint: prop<N, prop<=N, prop=N, prop>=N, prop>N
+    const numericMatch = word.match(
+      /^([a-zA-Z][a-zA-Z0-9_]*)(<|<=|=|>=|>)(-?[0-9.].*)$/,
+    );
+    if (numericMatch !== null) {
+      const rawId = numericMatch[1].toLowerCase();
+      const op = numericMatch[2];
+      const numericSchema = schema.numericProps.find(
+        (p) => p.identifier.toLowerCase() === rawId,
+      );
+      if (numericSchema === undefined) {
+        errors.push({
+          begin: startIndex,
+          end: endIndex,
+          message: `Unknown or non-numeric field: ${rawId}`,
+        });
+        continue;
+      }
+      const canonId = numericSchema.identifier;
+      let value: number;
+      try {
+        value = parseDataTypeValue(
+          numericSchema.dataType,
+          numericMatch[3],
+        ) as number;
+      } catch (e: any) {
+        errors.push({
+          begin: startIndex + numericMatch[1].length + numericMatch[2].length,
+          end: endIndex,
+          message: e.message,
+        });
+        continue;
+      }
+      let constraint = parsed.numericalConstraints.find(
+        (c) => c.fieldId === canonId,
+      );
+      if (constraint === undefined) {
+        constraint = { fieldId: canonId, bounds: numericSchema.bounds };
+        parsed.numericalConstraints.push(constraint);
+      }
+      const origMin = clampToInterval(
+        numericSchema.bounds,
+        constraint.bounds[0],
+      ) as number;
+      const origMax = clampToInterval(
+        numericSchema.bounds,
+        constraint.bounds[1],
+      ) as number;
+      let newMin = origMin;
+      let newMax = origMax;
+      switch (op) {
+        case "<":
+          newMax = dataTypeValueNextAfter(
+            numericSchema.dataType,
+            value,
+            -1,
+          ) as number;
+          break;
+        case "<=":
+          newMax = value;
+          break;
+        case "=":
+          newMin = newMax = value;
+          break;
+        case ">=":
+          newMin = value;
+          break;
+        case ">":
+          newMin = dataTypeValueNextAfter(
+            numericSchema.dataType,
+            value,
+            +1,
+          ) as number;
+          break;
+      }
+      newMin = dataTypeCompare(origMin, newMin) > 0 ? origMin : newMin;
+      newMax = dataTypeCompare(origMax, newMax) < 0 ? origMax : newMax;
+      if (dataTypeCompare(newMin, newMax) > 0) {
+        errors.push({
+          begin: startIndex,
+          end: endIndex,
+          message: "Constraint would not match any values",
+        });
+        continue;
+      }
+      constraint.bounds = [newMin, newMax] as DataTypeInterval;
+      continue;
+    }
+
+    // Prefix token: bare word
+    if (parsed.regexp !== undefined) {
+      errors.push({
+        begin: startIndex,
+        end: endIndex,
+        message: "Prefix cannot be combined with regular expression",
+      });
+      continue;
+    }
+    parsed.prefix =
+      parsed.prefix !== undefined ? `${parsed.prefix} ${word}` : word;
+  }
+
+  if (errors.length > 0) {
+    return { errors };
+  }
+  if (parsed.sortBy.length === 0) {
+    parsed.sortBy.push({ fieldId: "index", order: "<" });
+  }
+  return parsed;
+}
+
+/** Convert an AnnotationFilterQuery back to a query string. */
+export function unparseAnnotationQuery(
+  query: AnnotationFilterQuery,
+  schemaBoundsMap?: ReadonlyMap<string, readonly [number, number]>,
+): string {
+  const parts: string[] = [];
+  for (const { fieldId, order } of query.sortBy) {
+    if (fieldId !== "index" || order !== "<") {
+      parts.push(`${order}${fieldId}`);
+    }
+  }
+  for (const col of query.includeColumns) {
+    if (!query.sortBy.find((s) => s.fieldId === col)) {
+      parts.push(`|${col}`);
+    }
+  }
+  for (const c of query.numericalConstraints) {
+    const sb = schemaBoundsMap?.get(c.fieldId);
+    const [lo, hi] = c.bounds as [number, number];
+    if (sb === undefined || lo > sb[0]) {
+      parts.push(`${c.fieldId}>=${lo}`);
+    }
+    if (sb === undefined || hi < sb[1]) {
+      parts.push(`${c.fieldId}<=${hi}`);
+    }
+  }
+  for (const c of query.enumConstraints) {
+    for (const v of c.include) parts.push(`#${c.fieldId}=${v}`);
+    for (const v of c.exclude) parts.push(`-#${c.fieldId}=${v}`);
+  }
+  for (const c of query.boolConstraints) {
+    if (c.value !== undefined) {
+      parts.push(c.value ? `#${c.fieldId}` : `-#${c.fieldId}`);
+    }
+  }
+  if (query.regexp !== undefined) {
+    parts.push(`/${query.regexp.source}/`);
+  } else if (query.prefix !== undefined) {
+    parts.push(query.prefix);
+  }
+  return parts.join(" ");
+}
+
+// ============================================================================
+// Query executor
+// ============================================================================
+
+function makeIndicesArray(
+  length: number,
+): Uint32Array | Uint16Array | Uint8Array {
+  if (length <= 0xff) return new Uint8Array(length);
+  if (length <= 0xffff) return new Uint16Array(length);
+  return new Uint32Array(length);
+}
+
+/**
+ * Execute an annotation filter query against a list of items.
+ *
+ * Returns a result with:
+ *   - `indices`              sorted flat indices of items that pass all constraints
+ *   - `intermediateIndices`  indices passing desc/enum/bool but not numeric (for marginal CDFs)
+ *   - `intermediateIndicesMask`  bitmask per intermediate index for numeric constraints
+ *   - `enumStats`, `boolStats`  counts within the final `indices`
+ */
+export function executeAnnotationQuery(
+  items: AnnotationQueryItem[],
+  query: AnnotationFilterQuery,
+  coordFieldIds?: ReadonlySet<string>,
+): AnnotationQueryResult {
+  const n = items.length;
+  const allIndices = new Uint32Array(n);
+  for (let i = 0; i < n; ++i) allIndices[i] = i;
+
+  // 1. Description filter
+  let indices: Uint32Array | Uint16Array | Uint8Array = allIndices;
+  const { prefix, regexp } = query;
+  if (prefix !== undefined || regexp !== undefined) {
+    const lower = prefix !== undefined ? prefix.toLowerCase() : undefined;
+    indices = filterIndices(indices, (i) => {
+      const desc = items[i].description;
+      if (lower !== undefined && !desc.toLowerCase().startsWith(lower))
+        return false;
+      if (regexp !== undefined && regexp.test(desc) === false) return false;
+      return true;
+    });
+  }
+
+  // 2. Bool constraints
+  for (const { fieldId, value } of query.boolConstraints) {
+    if (value === undefined) continue;
+    indices = filterIndices(indices, (i) => {
+      const v = items[i].values.get(fieldId);
+      if (typeof v !== "boolean") return false;
+      return v === value;
+    });
+  }
+
+  // 3. Enum constraints
+  for (const { fieldId, include, exclude } of query.enumConstraints) {
+    const hasInclude = include.length > 0;
+    const hasExclude = exclude.length > 0;
+    if (!hasInclude && !hasExclude) continue;
+    indices = filterIndices(indices, (i) => {
+      const v = items[i].values.get(fieldId);
+      if (typeof v !== "number") return false;
+      if (hasInclude && !include.includes(v)) return false;
+      if (hasExclude && exclude.includes(v)) return false;
+      return true;
+    });
+  }
+
+  // 4. Numeric constraints — build intermediateIndicesMask and filter
+  let intermediateIndices: Uint32Array | Uint16Array | Uint8Array | undefined;
+  let intermediateIndicesMask:
+    | Uint32Array
+    | Uint16Array
+    | Uint8Array
+    | undefined;
+  const { numericalConstraints } = query;
+  if (numericalConstraints.length > 0) {
+    const numConstraints = numericalConstraints.length;
+    const fullMask = 2 ** numConstraints - 1;
+    const mask = makeIndicesArray(indices.length);
+    for (let ci = 0; ci < numConstraints; ++ci) {
+      const { fieldId, bounds } = numericalConstraints[ci];
+      const [lo, hi] = bounds as [number, number];
+      const bit = 2 ** ci;
+      const isCoord = coordFieldIds?.has(fieldId) ?? false;
+      for (let j = 0; j < indices.length; ++j) {
+        const item = items[indices[j]];
+        let passes: boolean;
+        if (isCoord) {
+          const cb = item.coordBounds?.get(fieldId);
+          // Overlap: annotation covers [cb[0], cb[1]], filter window is [lo, hi].
+          passes = cb !== undefined ? cb[0] <= hi && cb[1] >= lo : false;
+        } else {
+          const v = item.values.get(fieldId);
+          passes = typeof v === "number" && v >= lo && v <= hi;
+        }
+        if (passes) {
+          (mask as Uint32Array)[j] |= bit;
+        }
+      }
+    }
+    intermediateIndices = indices;
+    intermediateIndicesMask = mask;
+    const filtered = new Uint32Array(indices.length);
+    let outLen = 0;
+    for (let j = 0; j < indices.length; ++j) {
+      if ((mask as Uint32Array)[j] === fullMask) {
+        filtered[outLen++] = indices[j];
+      }
+    }
+    indices = filtered.subarray(0, outLen) as Uint32Array;
+  }
+
+  // 5. Sort
+  const finalIndices = sortAnnotationIndices(
+    indices,
+    items,
+    query.sortBy,
+    coordFieldIds,
+  );
+
+  // 6. Compute enum/bool stats from final result
+  const enumStats = new Map<string, Map<number, number>>();
+  for (const { fieldId } of query.enumConstraints.length > 0
+    ? query.enumConstraints
+    : []) {
+    const counts = new Map<number, number>();
+    for (let j = 0; j < finalIndices.length; ++j) {
+      const v = items[finalIndices[j]].values.get(fieldId);
+      if (typeof v === "number") {
+        counts.set(v, (counts.get(v) ?? 0) + 1);
+      }
+    }
+    enumStats.set(fieldId, counts);
+  }
+  const boolStats = new Map<
+    string,
+    { trueCount: number; falseCount: number }
+  >();
+  for (const { fieldId } of query.boolConstraints) {
+    let trueCount = 0;
+    let falseCount = 0;
+    for (let j = 0; j < finalIndices.length; ++j) {
+      const v = items[finalIndices[j]].values.get(fieldId);
+      if (v === true) ++trueCount;
+      else if (v === false) ++falseCount;
+    }
+    boolStats.set(fieldId, { trueCount, falseCount });
+  }
+
+  return {
+    query,
+    indices: finalIndices,
+    intermediateIndices,
+    intermediateIndicesMask: intermediateIndicesMask as
+      | Uint32Array
+      | Uint16Array
+      | Uint8Array
+      | undefined,
+    count: finalIndices.length,
+    total: n,
+    errors: [],
+    enumStats,
+    boolStats,
+  };
+}
+
+function filterIndices(
+  indices: Uint32Array | Uint16Array | Uint8Array,
+  pred: (i: number) => boolean,
+): Uint32Array | Uint16Array | Uint8Array {
+  const out = new Uint32Array(indices.length);
+  let len = 0;
+  for (let j = 0; j < indices.length; ++j) {
+    if (pred(indices[j])) out[len++] = indices[j];
+  }
+  return out.subarray(0, len);
+}
+
+function sortAnnotationIndices(
+  indices: Uint32Array | Uint16Array | Uint8Array,
+  items: AnnotationQueryItem[],
+  sortBy: SortBy[],
+  coordFieldIds?: ReadonlySet<string>,
+): Uint32Array {
+  // Make a mutable copy of indices as Uint32Array for sort.
+  const arr =
+    indices instanceof Uint32Array ? indices.slice() : new Uint32Array(indices);
+
+  if (
+    sortBy.length === 0 ||
+    (sortBy.length === 1 &&
+      sortBy[0].fieldId === "index" &&
+      sortBy[0].order === "<")
+  ) {
+    // Default: preserve original order (sort by index ascending).
+    return arr;
+  }
+
+  // Stable sort by first sortBy entry (compound sorting is a future optimization).
+  const { fieldId, order } = sortBy[0];
+  const sign = order === "<" ? 1 : -1;
+
+  if (fieldId === "index") {
+    arr.sort();
+    if (order === ">") arr.reverse();
+    return arr;
+  }
+
+  if (fieldId === "description") {
+    const arrCopy = Array.from(arr);
+    arrCopy.sort((a, b) => {
+      const da = items[a].description;
+      const db = items[b].description;
+      if (da < db) return -sign;
+      if (da > db) return sign;
+      return a - b; // stable by index
+    });
+    return new Uint32Array(arrCopy);
+  }
+
+  // Sort by property or coordinate value.
+  const isCoord = coordFieldIds?.has(fieldId) ?? false;
+  const useMax = isCoord && order === ">";
+  const arrCopy = Array.from(arr);
+  arrCopy.sort((a, b) => {
+    let na: number, nb: number;
+    if (isCoord) {
+      // Ascending: sort by minimum extent (smallest-start first).
+      // Descending: sort by maximum extent (largest-end first).
+      const aRange = items[a].coordBounds?.get(fieldId);
+      const bRange = items[b].coordBounds?.get(fieldId);
+      na = aRange !== undefined ? (useMax ? aRange[1] : aRange[0]) : NaN;
+      nb = bRange !== undefined ? (useMax ? bRange[1] : bRange[0]) : NaN;
+    } else {
+      const va = items[a].values.get(fieldId);
+      const vb = items[b].values.get(fieldId);
+      const toNum = (v: number | boolean | undefined) =>
+        typeof v === "number" ? v : typeof v === "boolean" ? (v ? 1 : 0) : NaN;
+      na = toNum(va);
+      nb = toNum(vb);
+    }
+    // Missing values sort to end.
+    if (isNaN(na) && isNaN(nb)) return a - b;
+    if (isNaN(na)) return 1;
+    if (isNaN(nb)) return -1;
+    const cmp = na - nb;
+    if (cmp !== 0) return cmp * sign;
+    return a - b; // stable by index
+  });
+  return new Uint32Array(arrCopy);
+}
+
+// ============================================================================
+// NumericalSummaryDataSource adapter
+// ============================================================================
+
+/**
+ * Creates a NumericalSummaryDataSource for use with NumericalPropertiesSummary.
+ * `getItems` is called on every histogram update, so it can return a fresh
+ * array after annotation-list rebuilds without recreating the data source.
+ */
+export function makeAnnotationNumericalDataSource(
+  schema: AnnotationQuerySchema,
+  getItems: () => AnnotationQueryItem[],
+): NumericalSummaryDataSource {
+  // Cache per-property histograms with their freshness key.
+  interface AnnotationHistogramCache {
+    queryResult: AnnotationQueryResult | undefined;
+    window: DataTypeInterval;
+    histogram: NumericalPropertyHistogram;
+  }
+  const cache: AnnotationHistogramCache[] = [];
+
+  const properties: NumericalSummaryProperty[] = schema.numericProps.map(
+    (p) => ({
+      id: p.identifier,
+      dataType: p.dataType,
+      bounds: p.bounds,
+      description: p.description,
+    }),
+  );
+
+  return {
+    properties,
+    updateHistograms(qr, histograms, windowBounds) {
+      const annotationQr = qr as AnnotationQueryResult | undefined;
+      if (annotationQr?.indices === undefined) {
+        histograms.length = 0;
+        return;
+      }
+      const numProps = schema.numericProps.length;
+      histograms.length = numProps;
+      for (let pi = 0; pi < numProps; ++pi) {
+        const prop = schema.numericProps[pi];
+        const window = windowBounds[pi];
+        const cached = cache[pi];
+        if (
+          cached !== undefined &&
+          cached.queryResult === annotationQr &&
+          cached.window[0] === window[0] &&
+          cached.window[1] === window[1]
+        ) {
+          histograms[pi] = cached.histogram;
+          continue;
+        }
+        const histogram = computeAnnotationPropertyHistogram(
+          prop.identifier,
+          getItems(),
+          annotationQr,
+          window,
+        );
+        cache[pi] = { queryResult: annotationQr, window, histogram };
+        histograms[pi] = histogram;
+      }
+    },
+  };
+}
+
+/** Compute a histogram for one numeric annotation property. */
+function computeAnnotationPropertyHistogram(
+  propId: string,
+  items: AnnotationQueryItem[],
+  queryResult: AnnotationQueryResult,
+  window: DataTypeInterval,
+): NumericalPropertyHistogram {
+  const numBins = 256;
+  const [min, max] = window as [number, number];
+  const multiplier = max <= min ? 0 : numBins / (max - min);
+  const histogram = new Uint32Array(numBins + 2);
+
+  const { numericalConstraints } = queryResult.query;
+  const constraintIndex = numericalConstraints.findIndex(
+    (c) => c.fieldId === propId,
+  );
+
+  if (constraintIndex === -1) {
+    // Unconstrained: compute from final result set.
+    const indices = queryResult.indices!;
+    for (let j = 0; j < indices.length; ++j) {
+      const v = items[indices[j]].values.get(propId);
+      if (typeof v === "number" && !Number.isNaN(v)) {
+        ++histogram[
+          (Math.min(numBins - 1, Math.max(-1, (v - min) * multiplier)) + 1) >>>
+            0
+        ];
+      }
+    }
+  } else {
+    // Constrained: compute marginal histogram from intermediateIndices.
+    const { intermediateIndices, intermediateIndicesMask } = queryResult;
+    if (
+      intermediateIndices === undefined ||
+      intermediateIndicesMask === undefined
+    ) {
+      return { window, histogram };
+    }
+    const numConstraints = numericalConstraints.length;
+    const requiredBits = 2 ** numConstraints - 1 - 2 ** constraintIndex;
+    for (let j = 0; j < intermediateIndices.length; ++j) {
+      if ((intermediateIndicesMask[j] & requiredBits) === requiredBits) {
+        const v = items[intermediateIndices[j]].values.get(propId);
+        if (typeof v === "number" && !Number.isNaN(v)) {
+          ++histogram[
+            (Math.min(numBins - 1, Math.max(-1, (v - min) * multiplier)) +
+              1) >>>
+              0
+          ];
+        }
+      }
+    }
+  }
+  return { window, histogram };
+}
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+interface Token {
+  word: string;
+  startIndex: number;
+  endIndex: number;
+}
+
+function tokenize(text: string): Token[] {
+  const tokens: Token[] = [];
+  let i = 0;
+  while (i < text.length) {
+    while (i < text.length && text[i] === " ") ++i;
+    if (i >= text.length) break;
+    const start = i;
+    while (i < text.length && text[i] !== " ") ++i;
+    tokens.push({ word: text.slice(start, i), startIndex: start, endIndex: i });
+  }
+  return tokens;
+}
+
+function findCanonicalId(
+  lowerCaseId: string,
+  schema: AnnotationQuerySchema,
+): string {
+  for (const p of schema.numericProps) {
+    if (p.identifier.toLowerCase() === lowerCaseId) return p.identifier;
+  }
+  for (const p of schema.enumProps) {
+    if (p.identifier.toLowerCase() === lowerCaseId) return p.identifier;
+  }
+  for (const p of schema.boolProps) {
+    if (p.identifier.toLowerCase() === lowerCaseId) return p.identifier;
+  }
+  return lowerCaseId;
+}
+
+// ============================================================================
+// Re-exports for convenience
+// ============================================================================
+
+export type { NumericalPropertyConstraint, QueryParseError, SortBy };

--- a/src/annotation/frontend_source.ts
+++ b/src/annotation/frontend_source.ts
@@ -37,10 +37,12 @@ import {
   AnnotationType,
   annotationTypeHandlers,
   annotationTypes,
+  deserializeAnnotation,
   makeAnnotationId,
   makeAnnotationPropertySerializers,
 } from "#src/annotation/index.js";
 import { getAnnotationTypeRenderHandler } from "#src/annotation/type_handler.js";
+import { ChunkState } from "#src/chunk_manager/base.js";
 import type { ChunkManager } from "#src/chunk_manager/frontend.js";
 import { Chunk, ChunkSource } from "#src/chunk_manager/frontend.js";
 import { getObjectKey } from "#src/segmentation_display_state/base.js";
@@ -1032,6 +1034,100 @@ export class MultiscaleAnnotationSource
     reference.dispose();
 
     this.localUpdates.delete(id);
+  }
+
+  /**
+   * Decodes the annotations currently loaded into frontend memory (i.e. those
+   * available for rendering) into `Annotation` objects, up to `limit`.
+   *
+   * Annotations are read from the packed geometry buffers held by the loaded
+   * (GPU-resident) spatial-index and segment-filtered chunks, plus the temporary
+   * chunk holding local uncommitted edits; the same annotation can appear in
+   * several chunks/levels, so ids are deduplicated.  The distinct-id scan is
+   * bounded (`10 * limit`) so a very large source does not spend unbounded time
+   * here on each refresh.
+   *
+   * This is the enumeration counterpart of the local `AnnotationSource`'s
+   * iterator: it lets the annotation list display the visible subset of a
+   * `MultiscaleAnnotationSource` without an async per-annotation fetch.
+   */
+  getLoadedAnnotations(limit: number): {
+    annotations: Annotation[];
+    totalLoaded: number;
+    truncated: boolean;
+    totalLoadedIsLowerBound: boolean;
+  } {
+    const annotations: Annotation[] = [];
+    const seen = new Set<AnnotationId>();
+    const serializers = this.annotationPropertySerializers;
+    const scanCeiling = Number.isFinite(limit) ? limit * 10 : Infinity;
+    let scanExceeded = false;
+
+    // Returns false to abort the whole scan once the dedup ceiling is reached.
+    const visit = (data: AnnotationGeometryData | undefined): boolean => {
+      if (data === undefined) return true;
+      const { serializedAnnotations } = data;
+      const { typeToIds } = serializedAnnotations;
+      for (const annotationType of annotationTypes) {
+        const ids = typeToIds[annotationType];
+        if (ids === undefined) continue;
+        for (let i = 0, n = ids.length; i < n; ++i) {
+          const id = ids[i];
+          if (seen.has(id)) continue;
+          seen.add(id);
+          if (annotations.length < limit) {
+            annotations.push(
+              deserializeAnnotation(
+                serializedAnnotations,
+                serializers[annotationType],
+                annotationType,
+                i,
+              ),
+            );
+          }
+          if (seen.size >= scanCeiling) {
+            scanExceeded = true;
+            return false;
+          }
+        }
+      }
+      return true;
+    };
+
+    const visitChunks = (
+      chunks: Iterable<{
+        state: ChunkState;
+        data: AnnotationGeometryData | undefined;
+      }>,
+    ): boolean => {
+      for (const chunk of chunks) {
+        if (chunk.state !== ChunkState.GPU_MEMORY) continue;
+        if (!visit(chunk.data)) return false;
+      }
+      return true;
+    };
+
+    let scanning = true;
+    for (const chunkSource of this.spatiallyIndexedSources) {
+      if (!scanning) break;
+      scanning = visitChunks(chunkSource.chunks.values());
+    }
+    for (const chunkSource of this.segmentFilteredSources) {
+      if (!scanning) break;
+      scanning = visitChunks(chunkSource.chunks.values());
+    }
+    // The temporary chunk (local uncommitted edits) is always considered loaded.
+    if (scanning) {
+      visit(this.temporary.data);
+    }
+
+    const totalLoaded = seen.size;
+    return {
+      annotations,
+      totalLoaded,
+      truncated: scanExceeded || annotations.length < totalLoaded,
+      totalLoadedIsLowerBound: scanExceeded,
+    };
   }
 
   // FIXME

--- a/src/annotation/index.spec.ts
+++ b/src/annotation/index.spec.ts
@@ -1,0 +1,182 @@
+/**
+ * @license
+ * Copyright 2026 Google Inc.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it } from "vitest";
+import type {
+  Annotation,
+  AnnotationPropertySpec,
+  AxisAlignedBoundingBox,
+  Ellipsoid,
+  Line,
+  Point,
+  PolyLine,
+} from "#src/annotation/index.js";
+import {
+  AnnotationSerializer,
+  AnnotationType,
+  deserializeAnnotation,
+  makeAnnotationPropertySerializers,
+} from "#src/annotation/index.js";
+
+function expectVecClose(actual: Float32Array, expected: Float32Array) {
+  expect(actual.length).toBe(expected.length);
+  for (let i = 0; i < expected.length; ++i) {
+    expect(actual[i]).toBeCloseTo(expected[i], 6);
+  }
+}
+
+describe("deserializeAnnotation", () => {
+  it("round-trips mixed annotation types with properties, including polyline", () => {
+    const rank = 4;
+    const propertySpecs: AnnotationPropertySpec[] = [
+      {
+        identifier: "score",
+        type: "float32",
+        default: 0,
+        description: undefined,
+      },
+      {
+        identifier: "label",
+        type: "int32",
+        default: 0,
+        description: undefined,
+      },
+      {
+        identifier: "flag",
+        type: "bool",
+        default: 0,
+        description: undefined,
+      },
+    ];
+    const propertySerializers = makeAnnotationPropertySerializers(
+      rank,
+      propertySpecs,
+    );
+
+    const point: Point = {
+      id: "pt-1",
+      type: AnnotationType.POINT,
+      point: Float32Array.of(1.25, -2, 3, 4.5),
+      properties: [1.25, 7, true],
+      description: "p",
+    };
+    const line: Line = {
+      id: "ln-1",
+      type: AnnotationType.LINE,
+      pointA: Float32Array.of(0, 1, 2, 3),
+      pointB: Float32Array.of(4, 5, 6, 7),
+      properties: [2.5, 8, false],
+      description: "l",
+    };
+    const bbox: AxisAlignedBoundingBox = {
+      id: "bx-1",
+      type: AnnotationType.AXIS_ALIGNED_BOUNDING_BOX,
+      pointA: Float32Array.of(1, 2, 3, 4),
+      pointB: Float32Array.of(5, 6, 7, 8),
+      properties: [3.5, 9, true],
+      description: "b",
+    };
+    const ellipsoid: Ellipsoid = {
+      id: "el-1",
+      type: AnnotationType.ELLIPSOID,
+      center: Float32Array.of(2, 3, 4, 5),
+      radii: Float32Array.of(0.5, 1.5, 2.5, 3.5),
+      properties: [4.5, 10, false],
+      description: "e",
+    };
+    const polylineA: PolyLine = {
+      id: "pl-1",
+      type: AnnotationType.POLYLINE,
+      points: [
+        Float32Array.of(0, 0, 0, 0),
+        Float32Array.of(1, 2, 3, 4),
+        Float32Array.of(2, 4, 6, 8),
+      ],
+      properties: [5.5, 11, true],
+      description: "pa",
+    };
+    const polylineB: PolyLine = {
+      id: "pl-2",
+      type: AnnotationType.POLYLINE,
+      points: [Float32Array.of(4, 3, 2, 1), Float32Array.of(8, 7, 6, 5)],
+      properties: [6.5, 12, false],
+      description: "pb",
+    };
+
+    const source: Annotation[] = [
+      point,
+      line,
+      bbox,
+      ellipsoid,
+      polylineA,
+      polylineB,
+    ];
+    const serializer = new AnnotationSerializer(propertySerializers);
+    for (const annotation of source) {
+      serializer.add(annotation);
+    }
+    const serialized = serializer.serialize();
+
+    const roundTrip = (original: Annotation) => {
+      const index = serialized.typeToIdMaps[original.type].get(original.id)!;
+      return deserializeAnnotation(
+        serialized,
+        propertySerializers[original.type],
+        original.type,
+        index,
+      );
+    };
+
+    const decodedPoint = roundTrip(point) as Point;
+    expect(decodedPoint.id).toBe(point.id);
+    expectVecClose(decodedPoint.point, point.point);
+    expect(decodedPoint.properties).toEqual(point.properties);
+
+    const decodedLine = roundTrip(line) as Line;
+    expect(decodedLine.id).toBe(line.id);
+    expectVecClose(decodedLine.pointA, line.pointA);
+    expectVecClose(decodedLine.pointB, line.pointB);
+    expect(decodedLine.properties).toEqual(line.properties);
+
+    const decodedBbox = roundTrip(bbox) as AxisAlignedBoundingBox;
+    expect(decodedBbox.id).toBe(bbox.id);
+    expectVecClose(decodedBbox.pointA, bbox.pointA);
+    expectVecClose(decodedBbox.pointB, bbox.pointB);
+    expect(decodedBbox.properties).toEqual(bbox.properties);
+
+    const decodedEllipsoid = roundTrip(ellipsoid) as Ellipsoid;
+    expect(decodedEllipsoid.id).toBe(ellipsoid.id);
+    expectVecClose(decodedEllipsoid.center, ellipsoid.center);
+    expectVecClose(decodedEllipsoid.radii, ellipsoid.radii);
+    expect(decodedEllipsoid.properties).toEqual(ellipsoid.properties);
+
+    const decodedPolylineA = roundTrip(polylineA) as PolyLine;
+    expect(decodedPolylineA.id).toBe(polylineA.id);
+    expect(decodedPolylineA.points.length).toBe(polylineA.points.length);
+    for (let i = 0; i < polylineA.points.length; ++i) {
+      expectVecClose(decodedPolylineA.points[i], polylineA.points[i]);
+    }
+    expect(decodedPolylineA.properties).toEqual(polylineA.properties);
+
+    const decodedPolylineB = roundTrip(polylineB) as PolyLine;
+    expect(decodedPolylineB.id).toBe(polylineB.id);
+    expect(decodedPolylineB.points.length).toBe(polylineB.points.length);
+    for (let i = 0; i < polylineB.points.length; ++i) {
+      expectVecClose(decodedPolylineB.points[i], polylineB.points[i]);
+    }
+    expect(decodedPolylineB.properties).toEqual(polylineB.properties);
+  });
+});

--- a/src/annotation/index.ts
+++ b/src/annotation/index.ts
@@ -1922,6 +1922,63 @@ function serializeAnnotations(
   };
 }
 
+/**
+ * Reconstructs a single `Annotation` (id + geometry + properties) from a packed
+ * `SerializedAnnotations` buffer.  This is the inverse of `serializeAnnotations`
+ * and reuses the per-type `deserialize` handlers and the property serializer's
+ * `deserialize`; it performs no async fetch, so it can decode annotations that
+ * were loaded only for rendering (e.g. from a `MultiscaleAnnotationSource`).
+ *
+ * @param serialized - the packed buffer + index metadata.
+ * @param propertySerializer - `annotationPropertySerializers[annotationType]`.
+ * @param annotationType - which type block to read from.
+ * @param index - the annotation's index within that type, in `[0, typeToSize[type])`.
+ */
+export function deserializeAnnotation(
+  serialized: SerializedAnnotations,
+  propertySerializer: AnnotationPropertySerializer,
+  annotationType: AnnotationType,
+  index: number,
+): Annotation {
+  const { rank } = propertySerializer;
+  const isLittleEndian = ENDIANNESS === Endianness.LITTLE;
+  const { typeToOffset, typeToIds, typeToSize, typeToInstanceCounts } =
+    serialized;
+  const { data } = serialized;
+  const dv = new DataView(data.buffer, data.byteOffset, data.byteLength);
+  const handler = annotationTypeHandlers[annotationType];
+  const id = typeToIds[annotationType][index];
+  const baseOffset = typeToOffset[annotationType];
+  const instanceStride = propertySerializer.propertyGroupBytes[0];
+  const count = typeToSize[annotationType];
+  // For polylines the geometry is stored as a variable number of point-pair
+  // instances; `typeToInstanceCounts[type][index]` is the starting instance.
+  // For all other types there is exactly one instance per annotation.
+  const instanceIndex =
+    annotationType === AnnotationType.POLYLINE
+      ? typeToInstanceCounts[annotationType][index]
+      : index;
+  const annotation = handler.deserialize(
+    dv,
+    baseOffset + instanceIndex * instanceStride,
+    isLittleEndian,
+    rank,
+    id,
+    instanceStride,
+  );
+  const properties: any[] = [];
+  propertySerializer.deserialize(
+    dv,
+    baseOffset,
+    instanceIndex,
+    count,
+    isLittleEndian,
+    properties,
+  );
+  annotation.properties = properties;
+  return annotation;
+}
+
 export class AnnotationSerializer {
   annotations: [
     Point[],

--- a/src/annotation/renderlayer.ts
+++ b/src/annotation/renderlayer.ts
@@ -354,6 +354,11 @@ export class AnnotationLayer extends RefCounted {
     this.registerDisposer(
       this.transform.changed.add(this.redrawNeeded.dispatch),
     );
+    this.registerDisposer(
+      this.state.displayState.filteredAnnotationIds.changed.add(
+        this.handleChangeAffectingBuffer,
+      ),
+    );
   }
 
   get gl() {
@@ -372,11 +377,18 @@ export class AnnotationLayer extends RefCounted {
           );
         }
         this.generation = generation;
+        const segFilt = segmentationFilter(this.segmentationStates.value);
+        const filteredIds = this.state.displayState.filteredAnnotationIds.value;
+        const filter =
+          filteredIds !== null || segFilt !== undefined
+            ? (annotation: AnnotationBase) => {
+                if (filteredIds !== null && !filteredIds.has(annotation.id))
+                  return false;
+                return segFilt === undefined || segFilt(annotation);
+              }
+            : undefined;
         const serializedAnnotations = (this.serializedAnnotations =
-          serializeAnnotationSet(
-            source,
-            segmentationFilter(this.segmentationStates.value),
-          ));
+          serializeAnnotationSet(source, filter));
         buffer.setData(this.serializedAnnotations.data);
         this.numPickIds = computeNumPickIds(serializedAnnotations);
       }

--- a/src/layer/annotation/index.ts
+++ b/src/layer/annotation/index.ts
@@ -109,6 +109,8 @@ const POINTS_JSON_KEY = "points";
 const ANNOTATIONS_JSON_KEY = "annotations";
 const ANNOTATION_PROPERTIES_JSON_KEY = "annotationProperties";
 const ANNOTATION_LIST_COLUMNS_KEY = "annotationListColumns";
+const ANNOTATION_LIST_TYPE_COLUMN_VISIBLE_KEY =
+  "annotationListTypeColumnVisible";
 const ANNOTATION_LIST_SORT_KEY = "annotationListSort";
 const ANNOTATION_LIST_QUERY_KEY = "annotationListQuery";
 const ANNOTATION_RELATIONSHIPS_JSON_KEY = "annotationRelationships";
@@ -550,6 +552,9 @@ export class AnnotationUserLayer extends Base {
     if (shownColumns !== undefined) {
       this.annotationListShownColumns.value = shownColumns;
     }
+    this.annotationListTypeColumnVisible.restoreState(
+      specification[ANNOTATION_LIST_TYPE_COLUMN_VISIBLE_KEY],
+    );
     const sortJson = verifyOptionalObjectProperty(
       specification,
       ANNOTATION_LIST_SORT_KEY,
@@ -850,6 +855,8 @@ export class AnnotationUserLayer extends Base {
     if (shownColumns.length > 0) {
       x[ANNOTATION_LIST_COLUMNS_KEY] = shownColumns;
     }
+    x[ANNOTATION_LIST_TYPE_COLUMN_VISIBLE_KEY] =
+      this.annotationListTypeColumnVisible.toJSON();
     const sortState = this.annotationListSortState.value;
     if (sortState !== null) {
       x[ANNOTATION_LIST_SORT_KEY] = sortState;

--- a/src/layer/annotation/index.ts
+++ b/src/layer/annotation/index.ts
@@ -108,6 +108,9 @@ import { Tab } from "#src/widget/tab_view.js";
 const POINTS_JSON_KEY = "points";
 const ANNOTATIONS_JSON_KEY = "annotations";
 const ANNOTATION_PROPERTIES_JSON_KEY = "annotationProperties";
+const ANNOTATION_LIST_COLUMNS_KEY = "annotationListColumns";
+const ANNOTATION_LIST_SORT_KEY = "annotationListSort";
+const ANNOTATION_LIST_QUERY_KEY = "annotationListQuery";
 const ANNOTATION_RELATIONSHIPS_JSON_KEY = "annotationRelationships";
 const CROSS_SECTION_RENDER_SCALE_JSON_KEY = "crossSectionAnnotationSpacing";
 const PROJECTION_RENDER_SCALE_JSON_KEY = "projectionAnnotationSpacing";
@@ -167,6 +170,7 @@ const FILTER_BY_SEGMENTATION_JSON_KEY = "filterBySegmentation";
 const IGNORE_NULL_SEGMENT_FILTER_JSON_KEY = "ignoreNullSegmentFilter";
 const CODE_VISIBLE_KEY = "codeVisible";
 const HIDE_INACTIVE_SHADER_CONTROLS_JSON_KEY = "hideInactiveShaderControls";
+const LIST_LOADED_ANNOTATIONS_JSON_KEY = "listLoadedAnnotations";
 
 class LinkedSegmentationLayers extends RefCounted {
   changed = new NullarySignal();
@@ -509,6 +513,9 @@ export class AnnotationUserLayer extends Base {
     super.restoreState(specification);
     this.linkedSegmentationLayers.restoreState(specification);
     this.codeVisible.restoreState(specification[CODE_VISIBLE_KEY]);
+    this.listLoadedAnnotations.restoreState(
+      specification[LIST_LOADED_ANNOTATIONS_JSON_KEY],
+    );
     this.hideInactiveShaderControls.restoreState(
       specification[HIDE_INACTIVE_SHADER_CONTROLS_JSON_KEY],
     );
@@ -535,6 +542,34 @@ export class AnnotationUserLayer extends Base {
     this.annotationDisplayState.shaderControls.restoreState(
       specification[SHADER_CONTROLS_JSON_KEY],
     );
+    const shownColumns = verifyOptionalObjectProperty(
+      specification,
+      ANNOTATION_LIST_COLUMNS_KEY,
+      verifyStringArray,
+    );
+    if (shownColumns !== undefined) {
+      this.annotationListShownColumns.value = shownColumns;
+    }
+    const sortJson = verifyOptionalObjectProperty(
+      specification,
+      ANNOTATION_LIST_SORT_KEY,
+      verifyObject,
+    );
+    if (sortJson !== undefined) {
+      const propertyId = verifyString(sortJson["propertyId"]);
+      const order = verifyString(sortJson["order"]);
+      if (order === "asc" || order === "desc") {
+        this.annotationListSortState.value = { propertyId, order };
+      }
+    }
+    const queryText = verifyOptionalObjectProperty(
+      specification,
+      ANNOTATION_LIST_QUERY_KEY,
+      verifyString,
+    );
+    if (queryText !== undefined) {
+      this.annotationListQuery.value = queryText;
+    }
   }
 
   getLegacyDataSourceSpecifications(
@@ -786,6 +821,7 @@ export class AnnotationUserLayer extends Base {
     x[CROSS_SECTION_RENDER_SCALE_JSON_KEY] =
       this.annotationCrossSectionRenderScaleTarget.toJSON();
     x[CODE_VISIBLE_KEY] = this.codeVisible.toJSON();
+    x[LIST_LOADED_ANNOTATIONS_JSON_KEY] = this.listLoadedAnnotations.toJSON();
     x[HIDE_INACTIVE_SHADER_CONTROLS_JSON_KEY] =
       this.hideInactiveShaderControls.toJSON();
     x[PROJECTION_RENDER_SCALE_JSON_KEY] =
@@ -810,6 +846,18 @@ export class AnnotationUserLayer extends Base {
     x[SHADER_CONTROLS_JSON_KEY] =
       this.annotationDisplayState.shaderControls.toJSON();
     Object.assign(x, this.linkedSegmentationLayers.toJSON());
+    const shownColumns = this.annotationListShownColumns.value;
+    if (shownColumns.length > 0) {
+      x[ANNOTATION_LIST_COLUMNS_KEY] = shownColumns;
+    }
+    const sortState = this.annotationListSortState.value;
+    if (sortState !== null) {
+      x[ANNOTATION_LIST_SORT_KEY] = sortState;
+    }
+    const queryText = this.annotationListQuery.value;
+    if (queryText !== "") {
+      x[ANNOTATION_LIST_QUERY_KEY] = queryText;
+    }
     return x;
   }
 

--- a/src/segmentation_display_state/frontend.ts
+++ b/src/segmentation_display_state/frontend.ts
@@ -853,12 +853,10 @@ export class SegmentWidgetWithExtraColumnsFactory extends SegmentWidgetFactory<S
     const label = document.createElement("span");
     label.textContent = id;
     label.classList.add("neuroglancer-segment-list-header-label");
-    label.classList.add("neuroglancer-segment-list-header-label");
     if (id === "label") {
       parent.style.textAlign = "left";
     }
     const sortIcon = document.createElement("span");
-    sortIcon.classList.add("neuroglancer-segment-list-header-label-sort");
     label.appendChild(sortIcon);
     sortIcon.textContent = "▲";
     const width = measureElementClone(label).width;

--- a/src/segmentation_display_state/property_map.spec.ts
+++ b/src/segmentation_display_state/property_map.spec.ts
@@ -20,6 +20,7 @@ import {
   parseSegmentQuery,
   PreprocessedSegmentPropertyMap,
   SegmentPropertyMap,
+  unparseSegmentQuery,
 } from "#src/segmentation_display_state/property_map.js";
 import { DataType } from "#src/util/data_type.js";
 
@@ -412,5 +413,11 @@ describe("parseSegmentQuery", () => {
         ],
       }
     `);
+  });
+
+  test("serializes regular expressions with canonical delimiters", () => {
+    const query = parseSegmentQuery(map, "/foo/");
+    if ("errors" in query) throw new Error("Expected a valid query");
+    expect(unparseSegmentQuery(map, query)).toBe("/foo/");
   });
 });

--- a/src/segmentation_display_state/property_map.ts
+++ b/src/segmentation_display_state/property_map.ts
@@ -17,6 +17,11 @@
 import type { ChunkManager } from "#src/chunk_manager/frontend.js";
 import { ChunkSource } from "#src/chunk_manager/frontend.js";
 import type { IndexedSegmentProperty } from "#src/segmentation_display_state/base.js";
+import type { SerializablePropertyQueryClause } from "#src/ui/property_query.js";
+import {
+  resolvePropertyQuery,
+  serializePropertyQueryClauses,
+} from "#src/ui/property_query.js";
 import type { Uint64OrderedSet } from "#src/uint64_ordered_set.js";
 import type { Uint64Set } from "#src/uint64_set.js";
 import type {
@@ -32,11 +37,9 @@ import { murmurHash3_x86_32Hash64Bits_Bigint } from "#src/util/hash.js";
 import { parseUint64 } from "#src/util/json.js";
 import type { DataTypeInterval } from "#src/util/lerp.js";
 import {
-  clampToInterval,
   dataTypeCompare,
   dataTypeIntervalEqual,
   dataTypeValueNextAfter,
-  parseDataTypeValue,
 } from "#src/util/lerp.js";
 import { getObjectId } from "#src/util/object_id.js";
 import { defaultStringCompare } from "#src/util/string.js";
@@ -514,262 +517,112 @@ export function parseSegmentQuery(
     const ids = Array.from(idSet).sort(bigintCompare);
     return { ids };
   }
-  const parsed: FilterQuery = {
-    regexp: undefined,
-    prefix: undefined,
-    includeTags: [],
-    excludeTags: [],
-    numericalConstraints: [],
-    sortBy: [],
-    includeColumns: [],
-  };
   const properties = db?.segmentPropertyMap.inlineProperties?.properties;
   const tags = db?.tags;
   const tagNames = tags?.tags || [];
   const lowerCaseTags = tagNames.map((x) => x.toLowerCase());
   const labels = db?.labels;
-  const errors: QueryParseError[] = [];
-  let nextStartIndex: number;
-  for (
-    let startIndex = 0;
-    startIndex < queryString.length;
-    startIndex = nextStartIndex
-  ) {
-    let endIndex = queryString.indexOf(" ", startIndex);
-    if (endIndex === -1) {
-      nextStartIndex = endIndex = queryString.length;
-    } else {
-      nextStartIndex = endIndex + 1;
-    }
-    const word = queryString.substring(startIndex, endIndex);
-    if (word.length === 0) continue;
-    const checkTag = (tag: string, begin: number) => {
-      const lowerCaseTag = tag.toLowerCase();
-      const tagIndex = lowerCaseTags.indexOf(lowerCaseTag);
-      if (tagIndex === -1) {
-        errors.push({ begin, end: endIndex, message: `Invalid tag: ${tag}` });
-        return undefined;
-      }
-      tag = tagNames[tagIndex];
-      if (
-        parsed.includeTags.includes(tag) ||
-        parsed.excludeTags.includes(tag)
-      ) {
-        errors.push({ begin, end: endIndex, message: `Duplicate tag: ${tag}` });
-        return undefined;
-      }
-      return tag;
-    };
-    if (word.startsWith("#")) {
-      const tag = checkTag(word.substring(1), startIndex + 1);
-      if (tag !== undefined) {
-        parsed.includeTags.push(tag);
-      }
-      continue;
-    }
-    if (word.startsWith("-#")) {
-      const tag = checkTag(word.substring(2), startIndex + 2);
-      if (tag !== undefined) {
-        parsed.excludeTags.push(tag);
-      }
-      continue;
-    }
-    if (word.startsWith("<") || word.startsWith(">")) {
-      let fieldId = word.substring(1).toLowerCase();
-      if (fieldId !== "id" && fieldId !== "label") {
-        const property = properties?.find(
-          (p) =>
-            p.id.toLowerCase() === fieldId &&
-            (p.type === "number" || p.type === "label" || p.type === "string"),
-        );
-        if (property === undefined) {
-          errors.push({
-            begin: startIndex + 1,
-            end: endIndex,
-            message: `Invalid field: ${fieldId}`,
-          });
-          continue;
-        }
-        fieldId = property.id;
-      }
-      if (parsed.sortBy.find((x) => x.fieldId === fieldId) !== undefined) {
-        errors.push({
-          begin: startIndex + 1,
-          end: endIndex,
-          message: `Duplicate sort field: ${fieldId}`,
-        });
-        continue;
-      }
-      parsed.sortBy.push({ order: word[0] as "<" | ">", fieldId });
-      continue;
-    }
-    if (word.startsWith("|")) {
-      let fieldId = word.substring(1).toLowerCase();
-      if (fieldId === "id" || fieldId === "label") continue;
+  return resolvePropertyQuery(queryString, {
+    createQuery: (): FilterQuery => ({
+      regexp: undefined,
+      prefix: undefined,
+      includeTags: [],
+      excludeTags: [],
+      numericalConstraints: [],
+      sortBy: [],
+      includeColumns: [],
+    }),
+    resolveSortField: (clause) => {
+      const fieldId = clause.field.toLowerCase();
+      if (fieldId === "id" || fieldId === "label") return { value: fieldId };
       const property = properties?.find(
-        (p) =>
-          p.id.toLowerCase() === fieldId &&
-          (p.type === "number" || p.type === "string"),
+        (candidate) =>
+          candidate.id.toLowerCase() === fieldId &&
+          (candidate.type === "number" ||
+            candidate.type === "label" ||
+            candidate.type === "string"),
       );
-      if (property === undefined) {
-        errors.push({
-          begin: startIndex + 1,
-          end: endIndex,
-          message: `Invalid field: ${fieldId}`,
-        });
-        continue;
-      }
-      fieldId = property.id;
-      if (
-        parsed.sortBy.find((x) => x.fieldId === fieldId) ||
-        parsed.includeColumns.find((x) => x === fieldId)
-      ) {
-        // Ignore duplicate column.
-        continue;
-      }
-      parsed.includeColumns.push(fieldId);
-      continue;
-    }
-    if (word.startsWith("/")) {
-      if (parsed.regexp !== undefined) {
-        errors.push({
-          begin: startIndex,
-          end: endIndex,
-          message: "Only one regular expression allowed",
-        });
-        continue;
-      }
-      if (parsed.prefix !== undefined) {
-        errors.push({
-          begin: startIndex,
-          end: endIndex,
-          message: "Prefix cannot be combined with regular expression",
-        });
-        continue;
-      }
-      if (labels === undefined && tagNames.length == 0) {
-        errors.push({
-          begin: startIndex,
-          end: endIndex,
-          message: "No label property",
-        });
-        continue;
-      }
-      try {
-        parsed.regexp = new RegExp(word.substring(1));
-      } catch {
-        errors.push({
-          begin: startIndex,
-          end: endIndex,
-          message: "Invalid regular expression syntax",
-        });
-      }
-      continue;
-    }
-    const constraintMatch = word.match(
-      /^([a-zA-Z][a-zA-Z0-9_]*)(<|<=|=|>=|>)(-?[0-9.].*)$/,
-    );
-    if (constraintMatch !== null) {
-      let fieldId = constraintMatch[1].toLowerCase();
-      const op = constraintMatch[2];
+      return property === undefined
+        ? {
+            error: {
+              begin: clause.begin + 1,
+              end: clause.end,
+              message: `Invalid field: ${fieldId}`,
+            },
+          }
+        : { value: property.id };
+    },
+    resolveColumnField: (clause) => {
+      const fieldId = clause.field.toLowerCase();
+      if (fieldId === "id" || fieldId === "label") return { ignore: true };
+      const property = properties?.find(
+        (candidate) =>
+          candidate.id.toLowerCase() === fieldId &&
+          (candidate.type === "number" || candidate.type === "string"),
+      );
+      return property === undefined
+        ? {
+            error: {
+              begin: clause.begin + 1,
+              end: clause.end,
+              message: `Invalid field: ${fieldId}`,
+            },
+          }
+        : { value: property.id };
+    },
+    resolveNumericField: (clause) => {
+      const fieldId = clause.field.toLowerCase();
       const property = db?.numericalProperties.find(
-        (p) => p.id.toLowerCase() === fieldId,
+        (candidate) => candidate.id.toLowerCase() === fieldId,
       );
-      if (property === undefined) {
+      return property === undefined
+        ? {
+            error: {
+              begin: clause.begin,
+              end: clause.begin + fieldId.length,
+              message: `Invalid numerical field: ${fieldId}`,
+            },
+          }
+        : {
+            value: {
+              fieldId: property.id,
+              dataType: property.dataType,
+              bounds: property.bounds,
+            },
+          };
+    },
+    applyCategoricalClause: (query, clause, { errors }) => {
+      const tagText =
+        clause.value === undefined
+          ? clause.field
+          : `${clause.field}=${clause.value}`;
+      const tagIndex = lowerCaseTags.indexOf(tagText.toLowerCase());
+      const begin = clause.begin + (clause.exclude ? 2 : 1);
+      if (tagIndex === -1) {
         errors.push({
-          begin: startIndex,
-          end: startIndex + fieldId.length,
-          message: `Invalid numerical field: ${fieldId}`,
+          begin,
+          end: clause.end,
+          message: `Invalid tag: ${tagText}`,
         });
-        continue;
+        return;
       }
-      fieldId = property.id;
-      let value: number;
-      try {
-        value = parseDataTypeValue(
-          property.dataType,
-          constraintMatch[3],
-        ) as number;
-      } catch (e) {
+      const tag = tagNames[tagIndex];
+      if (query.includeTags.includes(tag) || query.excludeTags.includes(tag)) {
         errors.push({
-          begin:
-            startIndex + constraintMatch[1].length + constraintMatch[2].length,
-          end: endIndex,
-          message: e.message,
+          begin,
+          end: clause.end,
+          message: `Duplicate tag: ${tag}`,
         });
-        continue;
+        return;
       }
-      let constraint = parsed.numericalConstraints.find(
-        (c) => c.fieldId === fieldId,
-      );
-      if (constraint === undefined) {
-        constraint = { fieldId, bounds: property.bounds };
-        parsed.numericalConstraints.push(constraint);
-      }
-      const origMin = clampToInterval(property.bounds, constraint.bounds[0]);
-      const origMax = clampToInterval(property.bounds, constraint.bounds[1]);
-      let newMax = origMax;
-      let newMin = origMin;
-      switch (op) {
-        case "<":
-          newMax = dataTypeValueNextAfter(property.dataType, value, -1);
-          break;
-        case "<=":
-          newMax = value;
-          break;
-        case "=":
-          newMax = newMin = value;
-          break;
-        case ">=":
-          newMin = value;
-          break;
-        case ">":
-          newMin = dataTypeValueNextAfter(property.dataType, value, +1);
-          break;
-      }
-      newMin = dataTypeCompare(origMin, newMin) > 0 ? origMin : newMin;
-      newMax = dataTypeCompare(origMax, newMax) < 0 ? origMax : newMax;
-      if (dataTypeCompare(newMin, newMax) > 0) {
-        errors.push({
-          begin: startIndex,
-          end: endIndex,
-          message: "Constraint would not match any values",
-        });
-        continue;
-      }
-      constraint.bounds = [newMin, newMax] as DataTypeInterval;
-      continue;
-    }
-    if (parsed.regexp !== undefined) {
-      errors.push({
-        begin: startIndex,
-        end: endIndex,
-        message: "Prefix cannot be combined with regular expression",
-      });
-      continue;
-    }
-    if (labels === undefined && tagNames.length == 0) {
-      errors.push({
-        begin: startIndex,
-        end: endIndex,
-        message: "No label property",
-      });
-      continue;
-    }
-    if (parsed.prefix !== undefined) {
-      parsed.prefix += ` ${word}`;
-    } else {
-      parsed.prefix = word;
-    }
-  }
-  if (errors.length > 0) {
-    return { errors };
-  }
-  if (parsed.sortBy.length === 0) {
-    // Add default sort order.
-    parsed.sortBy.push({ fieldId: getDefaultSortField(db), order: "<" });
-  }
-  return parsed;
+      (clause.exclude ? query.excludeTags : query.includeTags).push(tag);
+    },
+    defaultSort: { fieldId: getDefaultSortField(db), order: "<" },
+    textUnavailableError:
+      labels === undefined && tagNames.length === 0
+        ? "No label property"
+        : undefined,
+  });
 }
 
 export interface TagCount {
@@ -1169,21 +1022,29 @@ export function unparseSegmentQuery(
   if (ids !== undefined) {
     return ids.map((x) => x.toString()).join(", ");
   }
-  let queryString = "";
+  const clauses: SerializablePropertyQueryClause[] = [];
   query = query as FilterQuery;
   const { prefix, regexp } = query;
   if (prefix !== undefined) {
-    queryString = prefix;
+    clauses.push({ type: "text", value: prefix });
   } else if (regexp !== undefined) {
-    queryString = `/${regexp}`;
+    clauses.push({ type: "regexp", pattern: regexp.source, closed: true });
   }
   for (const tag of query.includeTags) {
-    if (queryString.length > 0) queryString += " ";
-    queryString += `#${tag}`;
+    clauses.push({
+      type: "categorical",
+      exclude: false,
+      field: tag,
+      value: undefined,
+    });
   }
   for (const tag of query.excludeTags) {
-    if (queryString.length > 0) queryString += " ";
-    queryString += `-#${tag}`;
+    clauses.push({
+      type: "categorical",
+      exclude: true,
+      field: tag,
+      value: undefined,
+    });
   }
   for (const constraint of query.numericalConstraints) {
     const { fieldId, bounds } = constraint;
@@ -1193,12 +1054,15 @@ export function unparseSegmentQuery(
       continue;
     }
     if (dataTypeCompare(min, max) === 0) {
-      if (queryString.length > 0) queryString += " ";
-      queryString += `${fieldId}=${min}`;
+      clauses.push({
+        type: "comparison",
+        field: fieldId,
+        operator: "=",
+        value: `${min}`,
+      });
       continue;
     }
     if (dataTypeCompare(min, property.bounds[0]) > 0) {
-      if (queryString.length > 0) queryString += " ";
       const beforeMin = dataTypeValueNextAfter(property.dataType, min, -1);
       const minString = min.toString();
       const beforeMinString = beforeMin.toString();
@@ -1206,13 +1070,22 @@ export function unparseSegmentQuery(
         property.dataType !== DataType.FLOAT32 ||
         minString.length <= beforeMinString.length
       ) {
-        queryString += `${fieldId}>=${minString}`;
+        clauses.push({
+          type: "comparison",
+          field: fieldId,
+          operator: ">=",
+          value: minString,
+        });
       } else {
-        queryString += `${fieldId}>${beforeMinString}`;
+        clauses.push({
+          type: "comparison",
+          field: fieldId,
+          operator: ">",
+          value: beforeMinString,
+        });
       }
     }
     if (dataTypeCompare(max, property.bounds[1]) < 0) {
-      if (queryString.length > 0) queryString += " ";
       const afterMax = dataTypeValueNextAfter(property.dataType, max, +1);
       const maxString = max.toString();
       const afterMaxString = afterMax.toString();
@@ -1220,9 +1093,19 @@ export function unparseSegmentQuery(
         property.dataType !== DataType.FLOAT32 ||
         maxString.length <= afterMaxString.length
       ) {
-        queryString += `${fieldId}<=${maxString}`;
+        clauses.push({
+          type: "comparison",
+          field: fieldId,
+          operator: "<=",
+          value: maxString,
+        });
       } else {
-        queryString += `${fieldId}<${afterMaxString}`;
+        clauses.push({
+          type: "comparison",
+          field: fieldId,
+          operator: "<",
+          value: afterMaxString,
+        });
       }
     }
   }
@@ -1234,14 +1117,12 @@ export function unparseSegmentQuery(
     }
   }
   for (const s of sortBy) {
-    if (queryString.length > 0) queryString += " ";
-    queryString += `${s.order}${s.fieldId}`;
+    clauses.push({ type: "sort", field: s.fieldId, order: s.order });
   }
   for (const fieldId of query.includeColumns) {
-    if (queryString.length > 0) queryString += " ";
-    queryString += `|${fieldId}`;
+    clauses.push({ type: "column", field: fieldId });
   }
-  return queryString;
+  return serializePropertyQueryClauses(clauses);
 }
 
 export function forEachQueryResultSegmentId(

--- a/src/ui/annotation_properties.ts
+++ b/src/ui/annotation_properties.ts
@@ -32,6 +32,29 @@ import { makeIcon } from "#src/widget/icon.js";
 export type AnnotationColorKey = AnnotationColorPropertySpec["type"];
 export type AnnotationPropertyType = AnnotationPropertySpec["type"];
 
+export const SET_ENUM_PROPERTY_TOOL_ID = "setEnumProperty";
+
+// Deterministic, locale-independent tool id for the keybindable tool that sets
+// an annotation's enum property to a specific value.  Defined here (a neutral
+// leaf module) so that both the tool registration in
+// `src/layer/annotation/index.ts` and the schema-editor keybind button in
+// `src/ui/annotation_schema_tab.ts` produce identical ids, letting bindings
+// round-trip through saved state.
+export function setEnumPropertyToolJson(
+  propertyIdentifier: string,
+  enumValue: number,
+) {
+  return `${SET_ENUM_PROPERTY_TOOL_ID}_${propertyIdentifier}_${String(enumValue)}`;
+}
+
+export const TOGGLE_BOOL_PROPERTY_TOOL_ID = "toggleBoolProperty";
+
+// Deterministic tool id for the keybindable tool that toggles a boolean
+// annotation property on the currently-selected annotation.
+export function toggleBoolPropertyToolJson(propertyIdentifier: string) {
+  return `${TOGGLE_BOOL_PROPERTY_TOOL_ID}_${propertyIdentifier}`;
+}
+
 export const ANNOTATION_TYPES: AnnotationPropertyType[] = [
   "bool",
   "rgb",

--- a/src/ui/annotations.css
+++ b/src/ui/annotations.css
@@ -114,6 +114,7 @@
 
 /* Property column headers */
 .neuroglancer-annotation-property-header {
+  font-family: monospace;
   display: flex;
   align-items: center;
   gap: 1px;
@@ -122,10 +123,13 @@
 }
 
 .neuroglancer-annotation-property-header-name {
-  font-size: 0.85em;
   color: rgba(255, 255, 255, 0.6);
   overflow: hidden;
   text-overflow: ellipsis;
+}
+
+.neuroglancer-annotation-type-header {
+  font-family: monospace;
 }
 
 /* Per-annotation property value cells in the annotation list */

--- a/src/ui/annotations.css
+++ b/src/ui/annotations.css
@@ -129,25 +129,6 @@
   text-overflow: ellipsis;
 }
 
-.neuroglancer-annotation-property-sort-btn {
-  flex-shrink: 0;
-  background: none;
-  border: none;
-  color: rgba(255, 255, 255, 0.25);
-  cursor: pointer;
-  padding: 0 1px;
-  font-size: 9px;
-  line-height: 1;
-}
-
-.neuroglancer-annotation-property-sort-btn:hover {
-  color: rgba(255, 255, 255, 0.75);
-}
-
-.neuroglancer-annotation-property-sort-btn[data-active="true"] {
-  color: #4e9ac0;
-}
-
 /* Per-annotation property value cells in the annotation list */
 .neuroglancer-annotation-list-property-value {
   font-family: monospace;
@@ -491,39 +472,6 @@ input.neuroglancer-segment-list-entry-id {
 /* Query input */
 .neuroglancer-annotation-query-container {
   padding: 3px 4px;
-  border-bottom: 1px solid #2a2a2a;
-}
-
-.neuroglancer-annotation-query {
-  width: 100%;
-  box-sizing: border-box;
-  background: rgba(255, 255, 255, 0.05);
-  border: 1px solid #555;
-  color: #ccc;
-  padding: 2px 4px;
-  font-size: 12px;
-  font-family: monospace;
-}
-
-.neuroglancer-annotation-query:focus {
-  outline: none;
-  border-color: #4e9ac0;
-}
-
-/* Query statistics: count/total and enum/bool chip grid */
-.neuroglancer-annotation-query-statistics {
-  padding: 2px 4px;
-  font-size: 11px;
-  color: rgba(255, 255, 255, 0.5);
-  border-bottom: 1px solid #2a2a2a;
-}
-
-.neuroglancer-annotation-query-count {
-  padding: 1px 0;
-}
-
-/* Numerical properties summary container */
-.neuroglancer-annotation-numerical-summary {
   border-bottom: 1px solid #2a2a2a;
 }
 

--- a/src/ui/annotations.css
+++ b/src/ui/annotations.css
@@ -56,6 +56,7 @@
   display: grid;
   padding-bottom: 2px;
   justify-content: start;
+  background-color: #111;
 }
 
 .neuroglancer-annotation-coordinate {
@@ -110,6 +111,50 @@
 
 .neuroglancer-annotation-hover.neuroglancer-annotation-selected {
   background-color: #969;
+}
+
+/* Property column headers */
+.neuroglancer-annotation-property-header {
+  display: flex;
+  align-items: center;
+  gap: 1px;
+  white-space: nowrap;
+  overflow: hidden;
+}
+
+.neuroglancer-annotation-property-header-name {
+  font-size: 0.85em;
+  color: rgba(255, 255, 255, 0.6);
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.neuroglancer-annotation-property-sort-btn {
+  flex-shrink: 0;
+  background: none;
+  border: none;
+  color: rgba(255, 255, 255, 0.25);
+  cursor: pointer;
+  padding: 0 1px;
+  font-size: 9px;
+  line-height: 1;
+}
+
+.neuroglancer-annotation-property-sort-btn:hover {
+  color: rgba(255, 255, 255, 0.75);
+}
+
+.neuroglancer-annotation-property-sort-btn[data-active="true"] {
+  color: #4e9ac0;
+}
+
+/* Per-annotation property value cells in the annotation list */
+.neuroglancer-annotation-list-property-value {
+  font-family: monospace;
+  font-size: 0.9em;
+  text-align: right;
+  color: rgba(255, 255, 255, 0.6);
+  padding-right: 4px;
 }
 
 .neuroglancer-annotation-dragging {
@@ -193,7 +238,10 @@ div.neuroglancer-annotation-details-description {
 
 .neuroglancer-annotations-view-dimension {
   font-family: monospace;
-  text-align: right;
+  display: flex;
+  align-items: center;
+  gap: 1px;
+  white-space: nowrap;
 }
 
 .neuroglancer-annotations-view-dimension-name {
@@ -438,4 +486,78 @@ input.neuroglancer-segment-list-entry-id {
   border-radius: 3px;
   color: #ccc;
   font-size: small;
+}
+
+/* Query input */
+.neuroglancer-annotation-query-container {
+  padding: 3px 4px;
+  border-bottom: 1px solid #2a2a2a;
+}
+
+.neuroglancer-annotation-query {
+  width: 100%;
+  box-sizing: border-box;
+  background: rgba(255, 255, 255, 0.05);
+  border: 1px solid #555;
+  color: #ccc;
+  padding: 2px 4px;
+  font-size: 12px;
+  font-family: monospace;
+}
+
+.neuroglancer-annotation-query:focus {
+  outline: none;
+  border-color: #4e9ac0;
+}
+
+/* Query statistics: count/total and enum/bool chip grid */
+.neuroglancer-annotation-query-statistics {
+  padding: 2px 4px;
+  font-size: 11px;
+  color: rgba(255, 255, 255, 0.5);
+  border-bottom: 1px solid #2a2a2a;
+}
+
+.neuroglancer-annotation-query-count {
+  padding: 1px 0;
+}
+
+/* Numerical properties summary container */
+.neuroglancer-annotation-numerical-summary {
+  border-bottom: 1px solid #2a2a2a;
+}
+
+/* Warning shown when measurable annotations exist but dimensions lack units */
+.neuroglancer-annotation-derived-warning {
+  padding: 2px 4px;
+  font-size: 11px;
+  color: #e0b020;
+  cursor: help;
+  border-bottom: 1px solid #2a2a2a;
+}
+
+.neuroglancer-annotation-loaded-notice {
+  padding: 2px 4px;
+  font-size: 11px;
+  color: rgba(255, 255, 255, 0.72);
+  border-bottom: 1px solid #2a2a2a;
+}
+
+/* Inline enum/bool value chips shown in the description row */
+.neuroglancer-annotation-inline-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 3px;
+  margin-top: 2px;
+}
+
+.neuroglancer-annotation-inline-chip {
+  background: rgba(255, 255, 255, 0.06);
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  border-radius: 2px;
+  padding: 0 4px;
+  font-size: 10px;
+  color: rgba(255, 255, 255, 0.5);
+  cursor: default;
+  white-space: nowrap;
 }

--- a/src/ui/annotations.css
+++ b/src/ui/annotations.css
@@ -56,7 +56,6 @@
   display: grid;
   padding-bottom: 2px;
   justify-content: start;
-  background-color: #111;
 }
 
 .neuroglancer-annotation-coordinate {
@@ -467,12 +466,6 @@ input.neuroglancer-segment-list-entry-id {
   border-radius: 3px;
   color: #ccc;
   font-size: small;
-}
-
-/* Query input */
-.neuroglancer-annotation-query-container {
-  padding: 3px 4px;
-  border-bottom: 1px solid #2a2a2a;
 }
 
 /* Warning shown when measurable annotations exist but dimensions lack units */

--- a/src/ui/annotations.ts
+++ b/src/ui/annotations.ts
@@ -120,6 +120,7 @@ import { createBoundedNumberInputElement } from "#src/ui/bounded_number_input.js
 import { getDefaultAnnotationListBindings } from "#src/ui/default_input_event_bindings.js";
 import {
   bindPropertyListSortControl,
+  createPropertyListQueryContainer,
   createPropertyListQueryInput,
   createPropertyListStatisticsShell,
   type PropertyListSortDirection,
@@ -132,7 +133,7 @@ import type {
 } from "#src/ui/property_summary.js";
 import {
   NumericalPropertiesSummary,
-  renderIncludeExcludeChips,
+  renderCategoricalPropertiesSummary,
 } from "#src/ui/property_summary.js";
 import {
   LegacyTool,
@@ -577,7 +578,10 @@ export class AnnotationLayerView extends Tab {
         this.updateAttachedAnnotationLayerStates(),
       ),
     );
-    this.headerRow.classList.add("neuroglancer-annotation-list-header");
+    this.headerRow.classList.add(
+      "neuroglancer-annotation-list-header",
+      "neuroglancer-property-list-header",
+    );
 
     const toolbox = document.createElement("div");
     toolbox.className = "neuroglancer-annotation-toolbox";
@@ -681,15 +685,11 @@ export class AnnotationLayerView extends Tab {
     toolbox.appendChild(navRow);
     this.element.appendChild(toolbox);
     // Query input
-    const queryInputContainer = document.createElement("div");
-    queryInputContainer.classList.add(
-      "neuroglancer-annotation-query-container",
-    );
     const queryInput = (this.queryInput = createPropertyListQueryInput({
       placeholder:
         "Filter: text, /regexp/, #bool, #enum=label, prop<N, <sort, |col",
     }));
-    queryInputContainer.appendChild(queryInput);
+    const queryInputContainer = createPropertyListQueryContainer(queryInput);
     {
       const checkbox = this.registerDisposer(
         new TrackableBooleanCheckbox(this.layer.listLoadedAnnotations),
@@ -704,7 +704,9 @@ export class AnnotationLayerView extends Tab {
     }
     this.element.appendChild(queryInputContainer);
 
-    this.queryStatisticsElement.style.display = "none";
+    this.queryStatisticsElement.classList.add(
+      "neuroglancer-property-list-status",
+    );
     this.categoricalSummaryContainer.style.display = "none";
     this.numericalSummaryContainer.style.display = "none";
     this.derivedWarningElement.classList.add(
@@ -725,6 +727,7 @@ export class AnnotationLayerView extends Tab {
     this.element.append(
       this.queryStatistics.root,
       this.queryStatistics.separator,
+      this.queryStatisticsElement,
     );
 
     const debouncedQuery = this.registerCancellable(
@@ -1267,7 +1270,6 @@ export class AnnotationLayerView extends Tab {
 
   private updateStatisticsVisibility() {
     const visible = [
-      this.queryStatisticsElement,
       this.categoricalSummaryContainer,
       this.numericalSummaryContainer,
       this.derivedWarningElement,
@@ -1342,7 +1344,12 @@ export class AnnotationLayerView extends Tab {
         p.bounds as [number, number],
       ]),
     );
-    const text = unparseAnnotationQuery(q, schemaBoundsMap);
+    const schemaBaseUnitMap = new Map(
+      this.annotationQuerySchema.numericProps
+        .filter((p) => p.baseUnit !== undefined)
+        .map((p) => [p.identifier, p.baseUnit!]),
+    );
+    const text = unparseAnnotationQuery(q, schemaBoundsMap, schemaBaseUnitMap);
     this.queryInput.value = text;
     this.annotationQueryText.value = text;
     // After writing all state into text, the separate GUI constraint arrays are
@@ -1391,16 +1398,10 @@ export class AnnotationLayerView extends Tab {
     removeChildren(queryStatisticsElement);
     const schema = this.annotationQuerySchema;
     const hasProps = schema.enumProps.length > 0 || schema.boolProps.length > 0;
-    if (result.total === 0 && !hasProps) {
-      queryStatisticsElement.style.display = "none";
-      this.updateStatisticsVisibility();
-      return;
-    }
     if (result.count < result.total) {
       queryStatisticsElement.textContent = `${result.count} / ${result.total} annotations`;
-      queryStatisticsElement.style.display = "";
     } else {
-      queryStatisticsElement.style.display = "none";
+      queryStatisticsElement.textContent = `${result.total} annotations`;
     }
     if (!hasProps) {
       this.updateStatisticsVisibility();
@@ -1528,21 +1529,18 @@ export class AnnotationLayerView extends Tab {
         },
       });
     }
-    const chipsEl = renderIncludeExcludeChips(chips);
     const { categoricalSummaryContainer } = this;
     removeChildren(categoricalSummaryContainer);
-    if (chipsEl !== undefined) {
-      const numCategorical = schema.enumProps.length + schema.boolProps.length;
-      const details = document.createElement("details");
-      details.classList.add("neuroglancer-segment-query-result-numerical-list");
-      details.open = this.categoricalDetailsOpen;
-      details.addEventListener("toggle", () => {
-        this.categoricalDetailsOpen = details.open;
-      });
-      const summary = document.createElement("summary");
-      summary.textContent = `${numCategorical} categorical propert${numCategorical > 1 ? "ies" : "y"}`;
-      details.appendChild(summary);
-      details.appendChild(chipsEl);
+    const numCategorical = schema.enumProps.length + schema.boolProps.length;
+    const details = renderCategoricalPropertiesSummary({
+      chips,
+      propertyCount: numCategorical,
+      open: this.categoricalDetailsOpen,
+      onToggle: (open) => {
+        this.categoricalDetailsOpen = open;
+      },
+    });
+    if (details !== undefined) {
       categoricalSummaryContainer.appendChild(details);
       categoricalSummaryContainer.style.display = "";
     } else {
@@ -1743,7 +1741,10 @@ export class AnnotationLayerView extends Tab {
       ...allSpecs.map((s) => `${s.identifier}:${s.type}`),
       ...globalCoordNames.map((n) => `g:${n}`),
       ...localCoordNames.map((n) => `l:${n}`),
-      ...derivedSchemas.map((s) => `d:${s.identifier}:${s.baseUnit}`),
+      ...derivedSchemas.map(
+        (s) =>
+          `d:${s.identifier}:${s.baseUnit}:${s.applicableAnnotationTypes?.join(",")}`,
+      ),
     ].join(",");
     if (schemaKey !== this.annotationQuerySchemaKey) {
       this.annotationQuerySchemaKey = schemaKey;

--- a/src/ui/annotations.ts
+++ b/src/ui/annotations.ts
@@ -118,6 +118,12 @@ import {
 } from "#src/ui/annotation_properties.js";
 import { createBoundedNumberInputElement } from "#src/ui/bounded_number_input.js";
 import { getDefaultAnnotationListBindings } from "#src/ui/default_input_event_bindings.js";
+import {
+  bindPropertyListSortControl,
+  createPropertyListQueryInput,
+  createPropertyListStatisticsShell,
+  type PropertyListSortDirection,
+} from "#src/ui/property_list.js";
 import type {
   IncludeExcludeChip,
   NumericalSummaryDataSource,
@@ -467,7 +473,8 @@ export class AnnotationLayerView extends Tab {
   private annotationQuerySchemaKey = "";
   private coordDimNames: string[] = [];
   private derivedAnalysis: DerivedAnalysisResult | undefined;
-  private queryStatisticsElement = document.createElement("div");
+  private queryStatistics = createPropertyListStatisticsShell();
+  private queryStatisticsElement = this.queryStatistics.count;
   private categoricalSummaryContainer = document.createElement("div");
   private categoricalDetailsOpen = false;
   private numericalSummaryContainer = document.createElement("div");
@@ -678,13 +685,10 @@ export class AnnotationLayerView extends Tab {
     queryInputContainer.classList.add(
       "neuroglancer-annotation-query-container",
     );
-    const queryInput = (this.queryInput = document.createElement("input"));
-    queryInput.type = "text";
-    queryInput.classList.add("neuroglancer-annotation-query");
-    queryInput.placeholder =
-      "Filter: text, /regexp/, #bool, #enum=label, prop<N, <sort, |col";
-    queryInput.autocomplete = "off";
-    queryInput.spellcheck = false;
+    const queryInput = (this.queryInput = createPropertyListQueryInput({
+      placeholder:
+        "Filter: text, /regexp/, #bool, #enum=label, prop<N, <sort, |col",
+    }));
     queryInputContainer.appendChild(queryInput);
     {
       const checkbox = this.registerDisposer(
@@ -700,34 +704,28 @@ export class AnnotationLayerView extends Tab {
     }
     this.element.appendChild(queryInputContainer);
 
-    this.queryStatisticsElement.classList.add(
-      "neuroglancer-annotation-query-statistics",
-    );
     this.queryStatisticsElement.style.display = "none";
-    this.element.appendChild(this.queryStatisticsElement);
-
-    this.categoricalSummaryContainer.classList.add(
-      "neuroglancer-annotation-numerical-summary",
-    );
     this.categoricalSummaryContainer.style.display = "none";
-    this.element.appendChild(this.categoricalSummaryContainer);
-
-    this.numericalSummaryContainer.classList.add(
-      "neuroglancer-annotation-numerical-summary",
-    );
     this.numericalSummaryContainer.style.display = "none";
-    this.element.appendChild(this.numericalSummaryContainer);
     this.derivedWarningElement.classList.add(
       "neuroglancer-annotation-derived-warning",
     );
     this.derivedWarningElement.textContent = "⚠ measurements unavailable";
     this.derivedWarningElement.style.display = "none";
-    this.element.appendChild(this.derivedWarningElement);
     this.loadedNoticeElement.classList.add(
       "neuroglancer-annotation-loaded-notice",
     );
     this.loadedNoticeElement.style.display = "none";
-    this.element.appendChild(this.loadedNoticeElement);
+    this.queryStatistics.content.append(
+      this.categoricalSummaryContainer,
+      this.numericalSummaryContainer,
+      this.derivedWarningElement,
+      this.loadedNoticeElement,
+    );
+    this.element.append(
+      this.queryStatistics.root,
+      this.queryStatistics.separator,
+    );
 
     const debouncedQuery = this.registerCancellable(
       debounce(() => {
@@ -1165,6 +1163,50 @@ export class AnnotationLayerView extends Tab {
     this.forceUpdateView();
   }
 
+  private getSortDirection(
+    fieldId: string,
+  ): PropertyListSortDirection | undefined {
+    if (this.sortState?.propertyId !== fieldId) return undefined;
+    return this.sortState.order === "asc" ? "ascending" : "descending";
+  }
+
+  private setSortDirection(
+    fieldId: string,
+    direction: PropertyListSortDirection | undefined,
+  ) {
+    this.sortState =
+      direction === undefined
+        ? undefined
+        : {
+            propertyId: fieldId,
+            order: direction === "ascending" ? "asc" : "desc",
+          };
+    this.layer.annotationListSortState.value = this.sortState ?? null;
+    this.writeCurrentStateToQueryText({
+      sortBy:
+        direction === undefined
+          ? []
+          : [
+              {
+                fieldId,
+                order: direction === "ascending" ? "<" : ">",
+              },
+            ],
+    });
+    ++this.curColumnConfigGeneration;
+    this.forceUpdateView();
+  }
+
+  private bindSortControl(label: HTMLElement, fieldId: string) {
+    return bindPropertyListSortControl({
+      label,
+      fieldId,
+      allowClear: true,
+      getDirection: () => this.getSortDirection(fieldId),
+      onChange: (direction) => this.setSortDirection(fieldId, direction),
+    });
+  }
+
   private createPropertyColumnHeader(
     identifier: string,
     label: string = identifier,
@@ -1177,53 +1219,7 @@ export class AnnotationLayerView extends Tab {
     name.textContent = label;
     if (description) name.title = description;
     header.appendChild(name);
-    const curOrder =
-      this.sortState?.propertyId === identifier
-        ? this.sortState.order
-        : undefined;
-    const sortBtn = document.createElement("button");
-    sortBtn.classList.add("neuroglancer-annotation-property-sort-btn");
-    sortBtn.textContent =
-      curOrder === "asc" ? "▲" : curOrder === "desc" ? "▼" : "↕";
-    sortBtn.title =
-      curOrder === "asc"
-        ? `Sort ${identifier} descending (click again to clear)`
-        : curOrder === "desc"
-          ? `Clear sort on ${identifier}`
-          : `Sort ${identifier} ascending`;
-    if (curOrder !== undefined) sortBtn.dataset.active = "true";
-    sortBtn.addEventListener("click", (e) => {
-      e.stopPropagation();
-      e.preventDefault();
-      const cur =
-        this.sortState?.propertyId === identifier
-          ? this.sortState.order
-          : undefined;
-      if (cur === undefined) {
-        this.sortState = { propertyId: identifier, order: "asc" };
-      } else if (cur === "asc") {
-        this.sortState = { propertyId: identifier, order: "desc" };
-      } else {
-        this.sortState = undefined;
-      }
-      this.layer.annotationListSortState.value = this.sortState ?? null;
-      this.writeCurrentStateToQueryText({
-        sortBy: this.sortState
-          ? [
-              {
-                fieldId: this.sortState.propertyId,
-                order:
-                  this.sortState.order === "asc"
-                    ? ("<" as const)
-                    : (">" as const),
-              },
-            ]
-          : [],
-      });
-      ++this.curColumnConfigGeneration;
-      this.forceUpdateView();
-    });
-    header.appendChild(sortBtn);
+    this.bindSortControl(header, identifier);
     return header;
   }
 
@@ -1233,6 +1229,7 @@ export class AnnotationLayerView extends Tab {
     removeChildren(this.numericalSummaryContainer);
     if (this.annotationQuerySchema.numericProps.length === 0) {
       this.numericalSummaryContainer.style.display = "none";
+      this.updateStatisticsVisibility();
       return;
     }
     const dataSource = makeAnnotationNumericalDataSource(
@@ -1253,6 +1250,7 @@ export class AnnotationLayerView extends Tab {
       this.numericalSummaryContainer.appendChild(summary.listElement);
       this.numericalSummaryContainer.style.display = "";
     }
+    this.updateStatisticsVisibility();
   }
 
   private updateDerivedWarning(warning: string | undefined) {
@@ -1264,6 +1262,18 @@ export class AnnotationLayerView extends Tab {
       el.style.display = "";
       el.title = warning;
     }
+    this.updateStatisticsVisibility();
+  }
+
+  private updateStatisticsVisibility() {
+    const visible = [
+      this.queryStatisticsElement,
+      this.categoricalSummaryContainer,
+      this.numericalSummaryContainer,
+      this.derivedWarningElement,
+      this.loadedNoticeElement,
+    ].some((element) => element.style.display !== "none");
+    this.queryStatistics.setVisible(visible);
   }
 
   private syncNumericalBounds() {
@@ -1383,16 +1393,19 @@ export class AnnotationLayerView extends Tab {
     const hasProps = schema.enumProps.length > 0 || schema.boolProps.length > 0;
     if (result.total === 0 && !hasProps) {
       queryStatisticsElement.style.display = "none";
+      this.updateStatisticsVisibility();
       return;
     }
-    queryStatisticsElement.style.display = "";
     if (result.count < result.total) {
-      const countEl = document.createElement("div");
-      countEl.classList.add("neuroglancer-annotation-query-count");
-      countEl.textContent = `${result.count} / ${result.total} annotations`;
-      queryStatisticsElement.appendChild(countEl);
+      queryStatisticsElement.textContent = `${result.count} / ${result.total} annotations`;
+      queryStatisticsElement.style.display = "";
+    } else {
+      queryStatisticsElement.style.display = "none";
     }
-    if (!hasProps) return;
+    if (!hasProps) {
+      this.updateStatisticsVisibility();
+      return;
+    }
     const items = this.annotationQueryItems;
     const indices = result.indices!;
     const chips: IncludeExcludeChip[] = [];
@@ -1535,6 +1548,7 @@ export class AnnotationLayerView extends Tab {
     } else {
       categoricalSummaryContainer.style.display = "none";
     }
+    this.updateStatisticsVisibility();
   }
 
   private updateView() {
@@ -1555,60 +1569,13 @@ export class AnnotationLayerView extends Tab {
 
       removeChildren(headerRow);
 
-      // Symbol column header: cycling sort button for annotation type.
       const TYPE_FIELD = "type";
-      const typeOrder =
-        this.sortState?.propertyId === TYPE_FIELD
-          ? this.sortState.order
-          : undefined;
       const symbolHeader = document.createElement("div");
       symbolHeader.style.gridColumn = "symbol";
       symbolHeader.style.display = "flex";
       symbolHeader.style.alignItems = "center";
       symbolHeader.style.justifyContent = "center";
-      const typeSortBtn = document.createElement("button");
-      typeSortBtn.classList.add("neuroglancer-annotation-property-sort-btn");
-      typeSortBtn.textContent =
-        typeOrder === "asc" ? "▲" : typeOrder === "desc" ? "▼" : "↕";
-      typeSortBtn.title =
-        typeOrder === "asc"
-          ? "Sort by type descending"
-          : typeOrder === "desc"
-            ? "Clear sort by type"
-            : "Sort by type ascending";
-      if (typeOrder !== undefined) typeSortBtn.dataset.active = "true";
-      typeSortBtn.addEventListener("click", (e) => {
-        e.stopPropagation();
-        e.preventDefault();
-        const cur =
-          this.sortState?.propertyId === TYPE_FIELD
-            ? this.sortState.order
-            : undefined;
-        if (cur === undefined) {
-          this.sortState = { propertyId: TYPE_FIELD, order: "asc" };
-        } else if (cur === "asc") {
-          this.sortState = { propertyId: TYPE_FIELD, order: "desc" };
-        } else {
-          this.sortState = undefined;
-        }
-        this.layer.annotationListSortState.value = this.sortState ?? null;
-        this.writeCurrentStateToQueryText({
-          sortBy: this.sortState
-            ? [
-                {
-                  fieldId: TYPE_FIELD,
-                  order:
-                    this.sortState.order === "asc"
-                      ? ("<" as const)
-                      : (">" as const),
-                },
-              ]
-            : [],
-        });
-        ++this.curColumnConfigGeneration;
-        this.forceUpdateView();
-      });
-      symbolHeader.appendChild(typeSortBtn);
+      this.bindSortControl(symbolHeader, TYPE_FIELD);
       headerRow.appendChild(symbolHeader);
       let i = 0;
       let gridTemplate = "[symbol] 2ch";
@@ -1631,54 +1598,7 @@ export class AnnotationLayerView extends Tab {
         );
         dimWidget.appendChild(name);
         dimWidget.appendChild(scale);
-        // Cycling sort button for this coordinate column.
-        const curOrder =
-          this.sortState?.propertyId === dimName
-            ? this.sortState.order
-            : undefined;
-        const sortBtn = document.createElement("button");
-        sortBtn.classList.add("neuroglancer-annotation-property-sort-btn");
-        sortBtn.textContent =
-          curOrder === "asc" ? "▲" : curOrder === "desc" ? "▼" : "↕";
-        sortBtn.title =
-          curOrder === "asc"
-            ? `Sort by ${dimName} descending`
-            : curOrder === "desc"
-              ? `Clear sort by ${dimName}`
-              : `Sort by ${dimName} ascending`;
-        if (curOrder !== undefined) sortBtn.dataset.active = "true";
-        sortBtn.addEventListener("click", (e) => {
-          e.stopPropagation();
-          e.preventDefault();
-          const cur =
-            this.sortState?.propertyId === dimName
-              ? this.sortState.order
-              : undefined;
-          if (cur === undefined) {
-            this.sortState = { propertyId: dimName, order: "asc" };
-          } else if (cur === "asc") {
-            this.sortState = { propertyId: dimName, order: "desc" };
-          } else {
-            this.sortState = undefined;
-          }
-          this.layer.annotationListSortState.value = this.sortState ?? null;
-          this.writeCurrentStateToQueryText({
-            sortBy: this.sortState
-              ? [
-                  {
-                    fieldId: this.sortState.propertyId,
-                    order:
-                      this.sortState.order === "asc"
-                        ? ("<" as const)
-                        : (">" as const),
-                  },
-                ]
-              : [],
-          });
-          ++this.curColumnConfigGeneration;
-          this.forceUpdateView();
-        });
-        dimWidget.appendChild(sortBtn);
+        this.bindSortControl(dimWidget, dimName);
         dimWidget.style.gridColumn = `dim ${i + 1}`;
         this.setColumnWidth(
           i,

--- a/src/ui/annotations.ts
+++ b/src/ui/annotations.ts
@@ -20,16 +20,38 @@
 
 import svg_help from "ikonate/icons/help.svg?raw";
 import "#src/ui/annotations.css";
-import { throttle } from "lodash-es";
+import { debounce, throttle } from "lodash-es";
+import type { DerivedAnalysisResult } from "#src/annotation/annotation_derived_properties.js";
+import {
+  analyzeDerivedProperties,
+  prettyUnit,
+} from "#src/annotation/annotation_derived_properties.js";
 import {
   AnnotationDisplayState,
   AnnotationLayerState,
 } from "#src/annotation/annotation_layer_state.js";
+import type {
+  AnnotationBoolConstraint,
+  AnnotationEnumConstraint,
+  AnnotationFilterQuery,
+  AnnotationQueryItem,
+  AnnotationQueryResult,
+  AnnotationQuerySchema,
+} from "#src/annotation/annotation_query.js";
+import {
+  buildAnnotationQueryItems,
+  buildAnnotationQuerySchema,
+  executeAnnotationQuery,
+  makeAnnotationNumericalDataSource,
+  parseAnnotationQuery,
+  unparseAnnotationQuery,
+} from "#src/annotation/annotation_query.js";
 import { MultiscaleAnnotationSource } from "#src/annotation/frontend_source.js";
 import type {
   Annotation,
   AnnotationId,
   AnnotationNumericPropertySpec,
+  AnnotationPropertySpec,
   AnnotationReference,
   AxisAlignedBoundingBox,
   Ellipsoid,
@@ -72,9 +94,11 @@ import {
   registerCallbackWhenSegmentationDisplayStateChanged,
   SegmentWidgetFactory,
 } from "#src/segmentation_display_state/frontend.js";
+import type { NumericalPropertyConstraint } from "#src/segmentation_display_state/property_map.js";
 import {
   ElementVisibilityFromTrackableBoolean,
   TrackableBoolean,
+  TrackableBooleanCheckbox,
 } from "#src/trackable_boolean.js";
 import type { WatchableValueInterface } from "#src/trackable_value.js";
 import {
@@ -94,6 +118,16 @@ import {
 } from "#src/ui/annotation_properties.js";
 import { createBoundedNumberInputElement } from "#src/ui/bounded_number_input.js";
 import { getDefaultAnnotationListBindings } from "#src/ui/default_input_event_bindings.js";
+import type {
+  IncludeExcludeChip,
+  NumericalSummaryDataSource,
+  NumericalSummaryQuery,
+  NumericalSummaryQueryResult,
+} from "#src/ui/property_summary.js";
+import {
+  NumericalPropertiesSummary,
+  renderIncludeExcludeChips,
+} from "#src/ui/property_summary.js";
 import {
   LegacyTool,
   makeToolButton,
@@ -116,6 +150,7 @@ import {
   KeyboardEventBinder,
   registerActionListener,
 } from "#src/util/keyboard_bindings.js";
+import type { DataTypeInterval } from "#src/util/lerp.js";
 import * as matrix from "#src/util/matrix.js";
 import { MouseEventBinder } from "#src/util/mouse_bindings.js";
 import { nearlyEqual } from "#src/util/number.js";
@@ -134,6 +169,8 @@ import { makeMoveToButton } from "#src/widget/move_to_button.js";
 import { Tab } from "#src/widget/tab_view.js";
 import type { VirtualListSource } from "#src/widget/virtual_list.js";
 import { VirtualList } from "#src/widget/virtual_list.js";
+
+const MULTISCALE_LIST_CAP = 5000;
 
 export class MergedAnnotationStates
   extends RefCounted
@@ -295,7 +332,10 @@ export class AnnotationLayerView extends Tab {
     render: (index: number) => this.render(index),
     changed: new Signal<(splices: ArraySpliceOp[]) => void>(),
   };
-  private virtualList = new VirtualList({ source: this.virtualListSource });
+  private virtualList = new VirtualList({
+    source: this.virtualListSource,
+    horizontalScroll: true,
+  });
   private listElements: {
     state: AnnotationLayerState;
     annotation: Annotation;
@@ -354,9 +394,30 @@ export class AnnotationLayerView extends Tab {
         refCounted.registerDisposer(
           source.childrenReordered.add(this.forceUpdateView),
         );
+      } else if (source instanceof MultiscaleAnnotationSource) {
+        // Non-local source: the list can show the currently-loaded (rendered)
+        // annotations when the user opts in.  Rebuild (debounced) as the set of
+        // loaded chunks changes, but only while the toggle is on and visible.
+        const debouncedRefresh = animationFrameDebounce(() => {
+          if (this.visible && this.layer.listLoadedAnnotations.value) {
+            this.forceUpdateView();
+          }
+        });
+        refCounted.registerDisposer(
+          source.chunkManager.chunkQueueManager.visibleChunksChanged.add(
+            debouncedRefresh,
+          ),
+        );
+        refCounted.registerDisposer(debouncedRefresh.cancel);
       }
       refCounted.registerDisposer(
         state.transform.changed.add(this.forceUpdateView),
+      );
+      refCounted.registerDisposer(
+        source.properties.changed.add(() => {
+          ++this.curColumnConfigGeneration;
+          this.forceUpdateView();
+        }),
       );
       newAttachedAnnotationStates.set(state, {
         refCounted,
@@ -367,6 +428,7 @@ export class AnnotationLayerView extends Tab {
     }
     this.attachedAnnotationStates = newAttachedAnnotationStates;
     attachedAnnotationStates.clear();
+    this.updateListLoadedAnnotationsToggleVisibility();
     this.updateCoordinateSpace();
     this.forceUpdateView();
   }
@@ -382,6 +444,53 @@ export class AnnotationLayerView extends Tab {
   private prevCoordinateSpaceGeneration = -1;
   private columnWidths: number[] = [];
   private gridTemplate = "";
+  // Property column state
+  private shownPropertyIds = new Set<string>();
+  private sortState: { propertyId: string; order: "asc" | "desc" } | undefined =
+    undefined;
+  private curColumnConfigGeneration = 0;
+  private prevColumnConfigGeneration = -1;
+  private numDimColumns = 0;
+  private shownColumns: readonly AnnotationListColumn[] = [];
+  private idToFlatIndex = new Map<string, number>();
+  private annotationQueryText = new WatchableValue<string>("");
+  private queryInput!: HTMLInputElement;
+  private annotationNumericalConstraints: NumericalPropertyConstraint[] = [];
+  private annotationEnumConstraints: AnnotationEnumConstraint[] = [];
+  private annotationBoolConstraints: AnnotationBoolConstraint[] = [];
+  private annotationQueryResult = new WatchableValue<
+    AnnotationQueryResult | undefined
+  >(undefined);
+  private annotationQueryItems: AnnotationQueryItem[] = [];
+  private annotationQuerySchema: AnnotationQuerySchema =
+    buildAnnotationQuerySchema([]);
+  private annotationQuerySchemaKey = "";
+  private coordDimNames: string[] = [];
+  private derivedAnalysis: DerivedAnalysisResult | undefined;
+  private queryStatisticsElement = document.createElement("div");
+  private categoricalSummaryContainer = document.createElement("div");
+  private categoricalDetailsOpen = false;
+  private numericalSummaryContainer = document.createElement("div");
+  private derivedWarningElement = document.createElement("div");
+  private loadedNoticeElement = document.createElement("div");
+  private listLoadedAnnotationsLabel = document.createElement("label");
+  private loadedAnnotationCounts = {
+    shown: 0,
+    total: 0,
+    totalIsLowerBound: false,
+  };
+  private numericalPropertiesSummary: NumericalPropertiesSummary | undefined;
+  private numericalDataSource: NumericalSummaryDataSource | undefined;
+  private numericalBoundsInitialized = false;
+
+  private updateListLoadedAnnotationsToggleVisibility() {
+    const hasNonLocalSource = this.annotationStates.states.some(
+      (state) => !(state.source instanceof AnnotationSource),
+    );
+    this.listLoadedAnnotationsLabel.style.display = hasNonLocalSource
+      ? ""
+      : "none";
+  }
 
   private updateCoordinateSpace() {
     const localCoordinateSpace = this.layer.localCoordinateSpace.value;
@@ -564,10 +673,81 @@ export class AnnotationLayerView extends Tab {
     );
     toolbox.appendChild(navRow);
     this.element.appendChild(toolbox);
+    // Query input
+    const queryInputContainer = document.createElement("div");
+    queryInputContainer.classList.add(
+      "neuroglancer-annotation-query-container",
+    );
+    const queryInput = (this.queryInput = document.createElement("input"));
+    queryInput.type = "text";
+    queryInput.classList.add("neuroglancer-annotation-query");
+    queryInput.placeholder =
+      "Filter: text, /regexp/, #bool, #enum=label, prop<N, <sort, |col";
+    queryInput.autocomplete = "off";
+    queryInput.spellcheck = false;
+    queryInputContainer.appendChild(queryInput);
+    {
+      const checkbox = this.registerDisposer(
+        new TrackableBooleanCheckbox(this.layer.listLoadedAnnotations),
+      );
+      const label = this.listLoadedAnnotationsLabel;
+      label.appendChild(document.createTextNode("List rendered annotations"));
+      label.title =
+        "Shows currently-rendered annotations from non-local sources by decoding loaded chunk data.";
+      label.appendChild(checkbox.element);
+      label.style.display = "none";
+      queryInputContainer.appendChild(label);
+    }
+    this.element.appendChild(queryInputContainer);
 
-    this.element.appendChild(this.headerRow);
+    this.queryStatisticsElement.classList.add(
+      "neuroglancer-annotation-query-statistics",
+    );
+    this.queryStatisticsElement.style.display = "none";
+    this.element.appendChild(this.queryStatisticsElement);
+
+    this.categoricalSummaryContainer.classList.add(
+      "neuroglancer-annotation-numerical-summary",
+    );
+    this.categoricalSummaryContainer.style.display = "none";
+    this.element.appendChild(this.categoricalSummaryContainer);
+
+    this.numericalSummaryContainer.classList.add(
+      "neuroglancer-annotation-numerical-summary",
+    );
+    this.numericalSummaryContainer.style.display = "none";
+    this.element.appendChild(this.numericalSummaryContainer);
+    this.derivedWarningElement.classList.add(
+      "neuroglancer-annotation-derived-warning",
+    );
+    this.derivedWarningElement.textContent = "⚠ measurements unavailable";
+    this.derivedWarningElement.style.display = "none";
+    this.element.appendChild(this.derivedWarningElement);
+    this.loadedNoticeElement.classList.add(
+      "neuroglancer-annotation-loaded-notice",
+    );
+    this.loadedNoticeElement.style.display = "none";
+    this.element.appendChild(this.loadedNoticeElement);
+
+    const debouncedQuery = this.registerCancellable(
+      debounce(() => {
+        this.forceUpdateView();
+      }, 200),
+    );
+    queryInput.addEventListener("input", () => {
+      this.annotationQueryText.value = queryInput.value;
+      debouncedQuery();
+    });
+
+    // Ensure NumericalPropertiesSummary is disposed on cleanup.
+    this.registerDisposer(() => {
+      this.numericalPropertiesSummary?.dispose();
+      this.numericalPropertiesSummary = undefined;
+    });
+
     const { virtualList } = this;
     virtualList.element.classList.add("neuroglancer-annotation-list");
+    virtualList.header.appendChild(this.headerRow);
     this.element.appendChild(virtualList.element);
     this.virtualList.element.addEventListener("mouseleave", () => {
       this.displayState.hoverState.value = undefined;
@@ -598,10 +778,36 @@ export class AnnotationLayerView extends Tab {
         this.updateView();
       }),
     );
+    // Initialize column/sort/query state from persisted layer values.
+    for (const id of this.layer.annotationListShownColumns.value) {
+      this.shownPropertyIds.add(id);
+    }
+    const persistedSort = this.layer.annotationListSortState.value;
+    if (persistedSort !== null) {
+      this.sortState = persistedSort;
+    }
+    const persistedQuery = this.layer.annotationListQuery.value;
+    if (persistedQuery !== "") {
+      this.annotationQueryText.value = persistedQuery;
+      this.queryInput.value = persistedQuery;
+    }
+    // Keep layer.annotationListQuery in sync whenever the text box changes.
+    this.registerDisposer(
+      this.annotationQueryText.changed.add(() => {
+        this.layer.annotationListQuery.value = this.annotationQueryText.value;
+      }),
+    );
+    this.registerDisposer(
+      this.layer.listLoadedAnnotations.changed.add(this.forceUpdateView),
+    );
     this.updateCoordinateSpace();
     this.updateAttachedAnnotationLayerStates();
+    this.updateListLoadedAnnotationsToggleVisibility();
     this.updateSelectionView();
     this.setupListReorder();
+    this.registerDisposer(() => {
+      this.layer.annotationListOrder = undefined;
+    });
   }
 
   private findStateForAnnotationId(
@@ -765,13 +971,19 @@ export class AnnotationLayerView extends Tab {
     id: AnnotationId,
     scrollIntoView = false,
   ): HTMLElement | undefined {
+    if (this.idToFlatIndex.size > 0) {
+      const listIndex = this.idToFlatIndex.get(id);
+      if (listIndex === undefined) return undefined;
+      if (scrollIntoView) this.virtualList.scrollItemIntoView(listIndex);
+      return this.virtualList.getItemElement(listIndex);
+    }
     const attached = this.attachedAnnotationStates.get(state);
     if (attached === undefined) return undefined;
     const index = attached.idToIndex.get(id);
     if (index === undefined) return undefined;
     const listIndex = attached.listOffset + index;
     if (scrollIntoView) {
-      this.virtualList.scrollItemIntoView(index);
+      this.virtualList.scrollItemIntoView(listIndex);
     }
     return this.virtualList.getItemElement(listIndex);
   }
@@ -867,7 +1079,18 @@ export class AnnotationLayerView extends Tab {
       gridTemplate,
       globalDimensionIndices,
       localDimensionIndices,
+      shownColumns,
+      numDimColumns,
     } = this;
+    // Fill per-annotation derived values into the (shared) column descriptors.
+    const derivedValues = this.derivedAnalysis?.valuesByAnnotationId.get(
+      annotation.id,
+    );
+    const columns = shownColumns.map((c) =>
+      c.baseUnit !== undefined
+        ? { ...c, derivedValue: derivedValues?.get(c.identifier) }
+        : c,
+    );
     const [element, elementColumnWidths] = makeAnnotationListElement(
       layer,
       annotation,
@@ -875,6 +1098,9 @@ export class AnnotationLayerView extends Tab {
       gridTemplate,
       globalDimensionIndices,
       localDimensionIndices,
+      columns.length > 0
+        ? { columns, dimColumnCount: numDimColumns }
+        : undefined,
     );
     for (const [column, width] of elementColumnWidths.entries()) {
       this.setColumnWidth(column, width);
@@ -905,36 +1131,497 @@ export class AnnotationLayerView extends Tab {
     );
   }
 
+  private getAllPropertySpecs(): AnnotationPropertySpec[] {
+    const seen = new Set<string>();
+    const result: AnnotationPropertySpec[] = [];
+    for (const [state] of this.attachedAnnotationStates) {
+      for (const prop of state.source.properties.value) {
+        if (
+          !seen.has(prop.identifier) &&
+          prop.type !== "rgb" &&
+          prop.type !== "rgba"
+        ) {
+          seen.add(prop.identifier);
+          result.push(prop);
+        }
+      }
+    }
+    return result;
+  }
+
+  private togglePropertyColumn(fieldId: string) {
+    const { shownPropertyIds } = this;
+    if (shownPropertyIds.has(fieldId)) {
+      shownPropertyIds.delete(fieldId);
+      if (this.sortState?.propertyId === fieldId) {
+        this.sortState = undefined;
+        this.layer.annotationListSortState.value = null;
+      }
+    } else {
+      shownPropertyIds.add(fieldId);
+    }
+    this.layer.annotationListShownColumns.value = [...shownPropertyIds];
+    ++this.curColumnConfigGeneration;
+    this.forceUpdateView();
+  }
+
+  private createPropertyColumnHeader(
+    identifier: string,
+    label: string = identifier,
+    description?: string,
+  ): HTMLDivElement {
+    const header = document.createElement("div");
+    header.classList.add("neuroglancer-annotation-property-header");
+    const name = document.createElement("span");
+    name.classList.add("neuroglancer-annotation-property-header-name");
+    name.textContent = label;
+    if (description) name.title = description;
+    header.appendChild(name);
+    const curOrder =
+      this.sortState?.propertyId === identifier
+        ? this.sortState.order
+        : undefined;
+    const sortBtn = document.createElement("button");
+    sortBtn.classList.add("neuroglancer-annotation-property-sort-btn");
+    sortBtn.textContent =
+      curOrder === "asc" ? "▲" : curOrder === "desc" ? "▼" : "↕";
+    sortBtn.title =
+      curOrder === "asc"
+        ? `Sort ${identifier} descending (click again to clear)`
+        : curOrder === "desc"
+          ? `Clear sort on ${identifier}`
+          : `Sort ${identifier} ascending`;
+    if (curOrder !== undefined) sortBtn.dataset.active = "true";
+    sortBtn.addEventListener("click", (e) => {
+      e.stopPropagation();
+      e.preventDefault();
+      const cur =
+        this.sortState?.propertyId === identifier
+          ? this.sortState.order
+          : undefined;
+      if (cur === undefined) {
+        this.sortState = { propertyId: identifier, order: "asc" };
+      } else if (cur === "asc") {
+        this.sortState = { propertyId: identifier, order: "desc" };
+      } else {
+        this.sortState = undefined;
+      }
+      this.layer.annotationListSortState.value = this.sortState ?? null;
+      this.writeCurrentStateToQueryText({
+        sortBy: this.sortState
+          ? [
+              {
+                fieldId: this.sortState.propertyId,
+                order:
+                  this.sortState.order === "asc"
+                    ? ("<" as const)
+                    : (">" as const),
+              },
+            ]
+          : [],
+      });
+      ++this.curColumnConfigGeneration;
+      this.forceUpdateView();
+    });
+    header.appendChild(sortBtn);
+    return header;
+  }
+
+  private rebuildNumericalSummary() {
+    this.numericalPropertiesSummary?.dispose();
+    this.numericalPropertiesSummary = undefined;
+    removeChildren(this.numericalSummaryContainer);
+    if (this.annotationQuerySchema.numericProps.length === 0) {
+      this.numericalSummaryContainer.style.display = "none";
+      return;
+    }
+    const dataSource = makeAnnotationNumericalDataSource(
+      this.annotationQuerySchema,
+      () => this.annotationQueryItems,
+    );
+    this.numericalDataSource = dataSource;
+    this.numericalBoundsInitialized = false;
+    const summary = new NumericalPropertiesSummary(
+      dataSource,
+      this.annotationQueryResult as unknown as WatchableValueInterface<
+        NumericalSummaryQueryResult | undefined
+      >,
+      this.setNumericalSummaryQuery,
+    );
+    this.numericalPropertiesSummary = summary;
+    if (summary.listElement !== undefined) {
+      this.numericalSummaryContainer.appendChild(summary.listElement);
+      this.numericalSummaryContainer.style.display = "";
+    }
+  }
+
+  private updateDerivedWarning(warning: string | undefined) {
+    const el = this.derivedWarningElement;
+    if (warning === undefined) {
+      el.style.display = "none";
+      el.title = "";
+    } else {
+      el.style.display = "";
+      el.title = warning;
+    }
+  }
+
+  private syncNumericalBounds() {
+    const { numericalDataSource, numericalPropertiesSummary } = this;
+    if (!numericalDataSource || !numericalPropertiesSummary) return;
+    const items = this.annotationQueryItems;
+    const { properties } = numericalDataSource;
+    const windowWatchable = numericalPropertiesSummary.bounds.window;
+    let windowUpdated = false;
+    for (let i = 0; i < properties.length; i++) {
+      const prop = properties[i];
+      let min = Infinity;
+      let max = -Infinity;
+      for (const item of items) {
+        const v = item.values.get(prop.id);
+        if (typeof v === "number" && !Number.isNaN(v)) {
+          if (v < min) min = v;
+          if (v > max) max = v;
+        }
+      }
+      if (!isFinite(min) || !isFinite(max)) continue;
+      const newBounds = [min, max] as [number, number];
+      prop.bounds = newBounds;
+      // Keep schema bounds in sync so parseAnnotationQuery accepts constraint
+      // values within the actual data range (not the initial [0,1] default).
+      const schemaProp = this.annotationQuerySchema.numericProps[i];
+      if (schemaProp !== undefined) {
+        schemaProp.bounds = newBounds as DataTypeInterval;
+      }
+      if (!this.numericalBoundsInitialized) {
+        windowWatchable.value[i] = newBounds;
+        windowUpdated = true;
+      }
+    }
+    if (!this.numericalBoundsInitialized && windowUpdated) {
+      this.numericalBoundsInitialized = true;
+      windowWatchable.changed.dispatch();
+    }
+  }
+
+  /**
+   * Write the effective filter/sort state back to the text query box so GUI
+   * interactions are visible to the user (mirrors segment-properties behaviour).
+   * `overrides` replaces specific fields; all others come from the last result's
+   * query (preserving prefix/regexp and any already-written constraints).
+   */
+  private writeCurrentStateToQueryText(
+    overrides: Partial<AnnotationFilterQuery>,
+  ) {
+    const lastQuery = this.annotationQueryResult.value?.query as
+      | AnnotationFilterQuery
+      | undefined;
+    const q: AnnotationFilterQuery = {
+      prefix: lastQuery?.prefix,
+      regexp: lastQuery?.regexp,
+      numericalConstraints: lastQuery?.numericalConstraints ?? [],
+      enumConstraints: lastQuery?.enumConstraints ?? [],
+      boolConstraints: lastQuery?.boolConstraints ?? [],
+      sortBy: lastQuery?.sortBy ?? [],
+      includeColumns: [],
+      ...overrides,
+    };
+    const schemaBoundsMap = new Map(
+      this.annotationQuerySchema.numericProps.map((p) => [
+        p.identifier,
+        p.bounds as [number, number],
+      ]),
+    );
+    const text = unparseAnnotationQuery(q, schemaBoundsMap);
+    this.queryInput.value = text;
+    this.annotationQueryText.value = text;
+    // After writing all state into text, the separate GUI constraint arrays are
+    // no longer needed — the text parse will reconstruct them in updateView().
+    this.annotationNumericalConstraints = [];
+    this.annotationEnumConstraints = [];
+    this.annotationBoolConstraints = [];
+  }
+
+  private setNumericalSummaryQuery = (query: NumericalSummaryQuery) => {
+    this.writeCurrentStateToQueryText({
+      numericalConstraints: query.numericalConstraints,
+      sortBy: query.sortBy,
+    });
+    // Merge includeColumns: keep non-numeric shown columns, update numeric ones.
+    const numericIds = new Set(
+      this.annotationQuerySchema.numericProps.map((p) => p.identifier),
+    );
+    const newShown = new Set<string>();
+    for (const id of this.shownPropertyIds) {
+      if (!numericIds.has(id)) newShown.add(id);
+    }
+    for (const id of query.includeColumns) {
+      newShown.add(id);
+    }
+    this.shownPropertyIds = newShown;
+    this.layer.annotationListShownColumns.value = [...newShown];
+    // Sync sortBy → sortState (first non-index/description sort).
+    const firstSort = query.sortBy.find(
+      (s) => s.fieldId !== "index" && s.fieldId !== "description",
+    );
+    this.sortState =
+      firstSort !== undefined
+        ? {
+            propertyId: firstSort.fieldId,
+            order: firstSort.order === "<" ? "asc" : "desc",
+          }
+        : undefined;
+    this.layer.annotationListSortState.value = this.sortState ?? null;
+    ++this.curColumnConfigGeneration;
+    this.forceUpdateView();
+  };
+
+  private updateQueryStatistics(result: AnnotationQueryResult) {
+    const { queryStatisticsElement } = this;
+    removeChildren(queryStatisticsElement);
+    const schema = this.annotationQuerySchema;
+    const hasProps = schema.enumProps.length > 0 || schema.boolProps.length > 0;
+    if (result.total === 0 && !hasProps) {
+      queryStatisticsElement.style.display = "none";
+      return;
+    }
+    queryStatisticsElement.style.display = "";
+    if (result.count < result.total) {
+      const countEl = document.createElement("div");
+      countEl.classList.add("neuroglancer-annotation-query-count");
+      countEl.textContent = `${result.count} / ${result.total} annotations`;
+      queryStatisticsElement.appendChild(countEl);
+    }
+    if (!hasProps) return;
+    const items = this.annotationQueryItems;
+    const indices = result.indices!;
+    const chips: IncludeExcludeChip[] = [];
+    const lastQuery = this.annotationQueryResult.value?.query as
+      | AnnotationFilterQuery
+      | undefined;
+    for (const prop of schema.enumProps) {
+      const constraint = lastQuery?.enumConstraints.find(
+        (c) => c.fieldId === prop.identifier,
+      );
+      const counts = new Map<number, number>();
+      for (let j = 0; j < indices.length; ++j) {
+        const v = items[indices[j]].values.get(prop.identifier);
+        if (typeof v === "number") counts.set(v, (counts.get(v) ?? 0) + 1);
+      }
+      for (let vi = 0; vi < prop.enumValues.length; ++vi) {
+        const val = prop.enumValues[vi];
+        const label = prop.enumLabels[vi];
+        const count = counts.get(val) ?? 0;
+        const fieldId = prop.identifier;
+        const isConstrained =
+          (constraint?.include.includes(val) ?? false) ||
+          (constraint?.exclude.includes(val) ?? false);
+        if (count === 0 && !isConstrained) continue;
+        chips.push({
+          key: `${fieldId}=${val}`,
+          headerLabel: fieldId,
+          label: `=${label}`,
+          headerActive: this.shownPropertyIds.has(fieldId),
+          onHeaderClick: () => this.togglePropertyColumn(fieldId),
+          count,
+          totalCount: result.count,
+          included: constraint?.include.includes(val) ?? false,
+          excluded: constraint?.exclude.includes(val) ?? false,
+          onToggle: (target, value) => {
+            const curEnumConstraints =
+              (
+                this.annotationQueryResult.value?.query as
+                  | AnnotationFilterQuery
+                  | undefined
+              )?.enumConstraints ?? [];
+            const existing = curEnumConstraints.find(
+              (c) => c.fieldId === fieldId,
+            );
+            let newInc = existing?.include ?? [];
+            let newExc = existing?.exclude ?? [];
+            if (target === "include") {
+              newInc = value
+                ? [...newInc, val]
+                : newInc.filter((v) => v !== val);
+              if (value) newExc = newExc.filter((v) => v !== val);
+            } else {
+              newExc = value
+                ? [...newExc, val]
+                : newExc.filter((v) => v !== val);
+              if (value) newInc = newInc.filter((v) => v !== val);
+            }
+            let newEnumConstraints: AnnotationEnumConstraint[];
+            if (newInc.length === 0 && newExc.length === 0) {
+              newEnumConstraints = curEnumConstraints.filter(
+                (c) => c.fieldId !== fieldId,
+              );
+            } else {
+              newEnumConstraints = [
+                ...curEnumConstraints.filter((c) => c.fieldId !== fieldId),
+                { fieldId, include: newInc, exclude: newExc },
+              ];
+            }
+            this.writeCurrentStateToQueryText({
+              enumConstraints: newEnumConstraints,
+            });
+            this.forceUpdateView();
+          },
+        });
+      }
+    }
+    for (const prop of schema.boolProps) {
+      const constraint = lastQuery?.boolConstraints.find(
+        (c) => c.fieldId === prop.identifier,
+      );
+      let trueCount = 0;
+      for (let j = 0; j < indices.length; ++j) {
+        const v = items[indices[j]].values.get(prop.identifier);
+        if (v === true) ++trueCount;
+      }
+      const fieldId = prop.identifier;
+      chips.push({
+        key: `${fieldId}`,
+        headerLabel: fieldId,
+        label: "",
+        headerActive: this.shownPropertyIds.has(fieldId),
+        onHeaderClick: () => this.togglePropertyColumn(fieldId),
+        count: trueCount,
+        totalCount: result.count,
+        included: constraint?.value === true,
+        excluded: constraint?.value === false,
+        onToggle: (target, value) => {
+          const curBoolConstraints =
+            (
+              this.annotationQueryResult.value?.query as
+                | AnnotationFilterQuery
+                | undefined
+            )?.boolConstraints ?? [];
+          let newBoolConstraints: AnnotationBoolConstraint[];
+          if (value) {
+            const boolValue = target === "include";
+            newBoolConstraints = [
+              ...curBoolConstraints.filter((c) => c.fieldId !== fieldId),
+              { fieldId, value: boolValue },
+            ];
+          } else {
+            newBoolConstraints = curBoolConstraints.filter(
+              (c) => c.fieldId !== fieldId,
+            );
+          }
+          this.writeCurrentStateToQueryText({
+            boolConstraints: newBoolConstraints,
+          });
+          this.forceUpdateView();
+        },
+      });
+    }
+    const chipsEl = renderIncludeExcludeChips(chips);
+    const { categoricalSummaryContainer } = this;
+    removeChildren(categoricalSummaryContainer);
+    if (chipsEl !== undefined) {
+      const numCategorical = schema.enumProps.length + schema.boolProps.length;
+      const details = document.createElement("details");
+      details.classList.add("neuroglancer-segment-query-result-numerical-list");
+      details.open = this.categoricalDetailsOpen;
+      details.addEventListener("toggle", () => {
+        this.categoricalDetailsOpen = details.open;
+      });
+      const summary = document.createElement("summary");
+      summary.textContent = `${numCategorical} categorical propert${numCategorical > 1 ? "ies" : "y"}`;
+      details.appendChild(summary);
+      details.appendChild(chipsEl);
+      categoricalSummaryContainer.appendChild(details);
+      categoricalSummaryContainer.style.display = "";
+    } else {
+      categoricalSummaryContainer.style.display = "none";
+    }
+  }
+
   private updateView() {
     if (!this.visible) {
       return;
     }
     if (
-      this.curCoordinateSpaceGeneration !== this.prevCoordinateSpaceGeneration
+      this.curCoordinateSpaceGeneration !==
+        this.prevCoordinateSpaceGeneration ||
+      this.curColumnConfigGeneration !== this.prevColumnConfigGeneration
     ) {
       this.updated = false;
       const { columnWidths } = this;
       columnWidths.length = 0;
       const { headerRow } = this;
-      const symbolPlaceholder = document.createElement("div");
-      symbolPlaceholder.style.gridColumn = "symbol";
-
       const deletePlaceholder = document.createElement("div");
       deletePlaceholder.style.gridColumn = "delete";
 
       removeChildren(headerRow);
-      headerRow.appendChild(symbolPlaceholder);
+
+      // Symbol column header: cycling sort button for annotation type.
+      const TYPE_FIELD = "type";
+      const typeOrder =
+        this.sortState?.propertyId === TYPE_FIELD
+          ? this.sortState.order
+          : undefined;
+      const symbolHeader = document.createElement("div");
+      symbolHeader.style.gridColumn = "symbol";
+      symbolHeader.style.display = "flex";
+      symbolHeader.style.alignItems = "center";
+      symbolHeader.style.justifyContent = "center";
+      const typeSortBtn = document.createElement("button");
+      typeSortBtn.classList.add("neuroglancer-annotation-property-sort-btn");
+      typeSortBtn.textContent =
+        typeOrder === "asc" ? "▲" : typeOrder === "desc" ? "▼" : "↕";
+      typeSortBtn.title =
+        typeOrder === "asc"
+          ? "Sort by type descending"
+          : typeOrder === "desc"
+            ? "Clear sort by type"
+            : "Sort by type ascending";
+      if (typeOrder !== undefined) typeSortBtn.dataset.active = "true";
+      typeSortBtn.addEventListener("click", (e) => {
+        e.stopPropagation();
+        e.preventDefault();
+        const cur =
+          this.sortState?.propertyId === TYPE_FIELD
+            ? this.sortState.order
+            : undefined;
+        if (cur === undefined) {
+          this.sortState = { propertyId: TYPE_FIELD, order: "asc" };
+        } else if (cur === "asc") {
+          this.sortState = { propertyId: TYPE_FIELD, order: "desc" };
+        } else {
+          this.sortState = undefined;
+        }
+        this.layer.annotationListSortState.value = this.sortState ?? null;
+        this.writeCurrentStateToQueryText({
+          sortBy: this.sortState
+            ? [
+                {
+                  fieldId: TYPE_FIELD,
+                  order:
+                    this.sortState.order === "asc"
+                      ? ("<" as const)
+                      : (">" as const),
+                },
+              ]
+            : [],
+        });
+        ++this.curColumnConfigGeneration;
+        this.forceUpdateView();
+      });
+      symbolHeader.appendChild(typeSortBtn);
+      headerRow.appendChild(symbolHeader);
       let i = 0;
       let gridTemplate = "[symbol] 2ch";
       const addDimension = (
         coordinateSpace: CoordinateSpace,
         dimIndex: number,
       ) => {
+        const dimName = coordinateSpace.names[dimIndex];
         const dimWidget = document.createElement("div");
         dimWidget.classList.add("neuroglancer-annotations-view-dimension");
         const name = document.createElement("span");
         name.classList.add("neuroglancer-annotations-view-dimension-name");
-        name.textContent = coordinateSpace.names[dimIndex];
+        name.textContent = dimName;
         const scale = document.createElement("scale");
         scale.classList.add("neuroglancer-annotations-view-dimension-scale");
         scale.textContent = formatScaleWithUnitAsString(
@@ -944,10 +1631,58 @@ export class AnnotationLayerView extends Tab {
         );
         dimWidget.appendChild(name);
         dimWidget.appendChild(scale);
+        // Cycling sort button for this coordinate column.
+        const curOrder =
+          this.sortState?.propertyId === dimName
+            ? this.sortState.order
+            : undefined;
+        const sortBtn = document.createElement("button");
+        sortBtn.classList.add("neuroglancer-annotation-property-sort-btn");
+        sortBtn.textContent =
+          curOrder === "asc" ? "▲" : curOrder === "desc" ? "▼" : "↕";
+        sortBtn.title =
+          curOrder === "asc"
+            ? `Sort by ${dimName} descending`
+            : curOrder === "desc"
+              ? `Clear sort by ${dimName}`
+              : `Sort by ${dimName} ascending`;
+        if (curOrder !== undefined) sortBtn.dataset.active = "true";
+        sortBtn.addEventListener("click", (e) => {
+          e.stopPropagation();
+          e.preventDefault();
+          const cur =
+            this.sortState?.propertyId === dimName
+              ? this.sortState.order
+              : undefined;
+          if (cur === undefined) {
+            this.sortState = { propertyId: dimName, order: "asc" };
+          } else if (cur === "asc") {
+            this.sortState = { propertyId: dimName, order: "desc" };
+          } else {
+            this.sortState = undefined;
+          }
+          this.layer.annotationListSortState.value = this.sortState ?? null;
+          this.writeCurrentStateToQueryText({
+            sortBy: this.sortState
+              ? [
+                  {
+                    fieldId: this.sortState.propertyId,
+                    order:
+                      this.sortState.order === "asc"
+                        ? ("<" as const)
+                        : (">" as const),
+                  },
+                ]
+              : [],
+          });
+          ++this.curColumnConfigGeneration;
+          this.forceUpdateView();
+        });
+        dimWidget.appendChild(sortBtn);
         dimWidget.style.gridColumn = `dim ${i + 1}`;
         this.setColumnWidth(
           i,
-          scale.textContent.length + name.textContent.length + 3,
+          scale.textContent.length + name.textContent.length + 5,
         );
         gridTemplate += ` [dim] var(--neuroglancer-column-${i}-width)`;
         ++i;
@@ -962,24 +1697,90 @@ export class AnnotationLayerView extends Tab {
       for (const localDim of this.localDimensionIndices) {
         addDimension(localCoordinateSpace, localDim);
       }
+      this.numDimColumns = i;
+
+      // Property column headers for each toggled-on property (stored or derived).
+      const shownColumns: AnnotationListColumn[] = [];
+      for (const propId of this.shownPropertyIds) {
+        let spec: AnnotationPropertySpec | undefined;
+        for (const [state] of this.attachedAnnotationStates) {
+          const found = state.source.properties.value.find(
+            (p) => p.identifier === propId,
+          );
+          if (found !== undefined) {
+            spec = found;
+            break;
+          }
+        }
+        let column: AnnotationListColumn | undefined;
+        let label = propId;
+        let description: string | undefined;
+        if (spec !== undefined) {
+          if (spec.type === "rgb" || spec.type === "rgba") continue;
+          column = { identifier: propId, spec };
+          description = spec.description ?? undefined;
+        } else {
+          // Derived (computed) geometric property.
+          const derived = this.derivedAnalysis?.schemas.find(
+            (s) => s.identifier === propId,
+          );
+          if (derived === undefined) continue;
+          column = { identifier: propId, baseUnit: derived.baseUnit ?? "" };
+          label = `${propId} (${prettyUnit(derived.baseUnit ?? "")})`;
+          description = derived.description;
+        }
+        const propColIdx = shownColumns.length;
+        shownColumns.push(column);
+        const propHeader = this.createPropertyColumnHeader(
+          propId,
+          label,
+          description,
+        );
+        propHeader.style.gridColumn = `prop ${propColIdx + 1}`;
+        headerRow.appendChild(propHeader);
+        const colIdx = this.numDimColumns + propColIdx;
+        this.setColumnWidth(colIdx, label.length + 2);
+        gridTemplate += ` [prop] var(--neuroglancer-column-${colIdx}-width)`;
+      }
+      this.shownColumns = shownColumns;
+
       headerRow.appendChild(deletePlaceholder);
       gridTemplate += " [delete] 2ch";
       this.gridTemplate = gridTemplate;
       headerRow.style.gridTemplateColumns = gridTemplate;
       this.prevCoordinateSpaceGeneration = this.curCoordinateSpaceGeneration;
+      this.prevColumnConfigGeneration = this.curColumnConfigGeneration;
     }
     if (this.updated) {
       return;
     }
 
     let isMutable = false;
+    this.loadedAnnotationCounts.shown = 0;
+    this.loadedAnnotationCounts.total = 0;
+    this.loadedAnnotationCounts.totalIsLowerBound = false;
     const { listElements } = this;
     listElements.length = 0;
     for (const [state, info] of this.attachedAnnotationStates) {
-      if (!state.source.readonly) isMutable = true;
       if (state.chunkTransform.value.error !== undefined) continue;
       const { source } = state;
-      const annotations = Array.from(source);
+      let annotations: Annotation[];
+      if (source instanceof AnnotationSource) {
+        annotations = Array.from(source);
+        if (!source.readonly) isMutable = true;
+      } else if (
+        source instanceof MultiscaleAnnotationSource &&
+        this.layer.listLoadedAnnotations.value
+      ) {
+        const loaded = source.getLoadedAnnotations(MULTISCALE_LIST_CAP);
+        annotations = loaded.annotations;
+        this.loadedAnnotationCounts.shown += loaded.annotations.length;
+        this.loadedAnnotationCounts.total += loaded.totalLoaded;
+        this.loadedAnnotationCounts.totalIsLowerBound ||=
+          loaded.totalLoadedIsLowerBound;
+      } else {
+        annotations = [];
+      }
       info.annotations = annotations;
       const { idToIndex } = info;
       idToIndex.clear();
@@ -990,8 +1791,222 @@ export class AnnotationLayerView extends Tab {
         listElements.push({ state, annotation });
       }
     }
+    // Build annotation query schema (rebuild when property specs or coordinate dims change).
+    const allSpecs = this.getAllPropertySpecs();
+    const globalCoordSpace = this.layer.manager.root.coordinateSpace.value;
+    const localCoordSpace = this.layer.localCoordinateSpace.value;
+    const globalCoordNames = this.globalDimensionIndices.map(
+      (i) => globalCoordSpace.names[i],
+    );
+    const localCoordNames = this.localDimensionIndices.map(
+      (i) => localCoordSpace.names[i],
+    );
+    // Compute derived geometric properties (length, volume, ...) live from the
+    // loaded annotations' geometry, taking the coordinate transform into account.
+    this.derivedAnalysis = analyzeDerivedProperties({
+      annotations: listElements.flatMap(({ state, annotation }) => {
+        const chunkTransform = state.chunkTransform.value;
+        if (chunkTransform.error !== undefined) return [];
+        return [{ id: annotation.id, annotation, chunkTransform }];
+      }),
+      globalCoordinateSpace: globalCoordSpace,
+      localCoordinateSpace: localCoordSpace,
+      globalDimensionIndices: this.globalDimensionIndices,
+      localDimensionIndices: this.localDimensionIndices,
+    });
+    const derivedSchemas = this.derivedAnalysis.schemas;
+    this.updateDerivedWarning(this.derivedAnalysis.warning);
+    // Publish to the shared display state so the selection-details panel (rendered
+    // by the layer, not this view) can show the same derived metrics.
+    this.displayState.derivedProperties = this.derivedAnalysis;
+    const schemaKey = [
+      ...allSpecs.map((s) => `${s.identifier}:${s.type}`),
+      ...globalCoordNames.map((n) => `g:${n}`),
+      ...localCoordNames.map((n) => `l:${n}`),
+      ...derivedSchemas.map((s) => `d:${s.identifier}:${s.baseUnit}`),
+    ].join(",");
+    if (schemaKey !== this.annotationQuerySchemaKey) {
+      this.annotationQuerySchemaKey = schemaKey;
+      this.coordDimNames = [...globalCoordNames, ...localCoordNames];
+      const coordDims = this.coordDimNames.map((name) => ({
+        id: name,
+        description: `${name} coordinate`,
+      }));
+      this.annotationQuerySchema = buildAnnotationQuerySchema(
+        allSpecs,
+        coordDims,
+        {
+          identifier: "type",
+          enumValues: [0, 1, 2, 3, 4],
+          enumLabels: ["point", "line", "bbox", "ellipsoid", "polyline"],
+        },
+        derivedSchemas,
+      );
+      this.rebuildNumericalSummary();
+      // Derived schema set changed (relevance / units): refresh column headers
+      // on the next pass so shown derived columns get correct unit labels.
+      ++this.curColumnConfigGeneration;
+    }
+    this.annotationQueryItems = buildAnnotationQueryItems(
+      listElements.map(({ annotation, state }) => {
+        const chunkTransform = state.chunkTransform
+          .value as ChunkTransformParameters;
+        const { globalToRenderLayerDimensions, localToRenderLayerDimensions } =
+          chunkTransform.modelTransform;
+        // Collect all non-vector geometry positions for this annotation.
+        const positions: Float32Array[] = [];
+        let ellipsoidRadii: Float32Array | undefined;
+        visitTransformedAnnotationGeometry(
+          annotation,
+          chunkTransform,
+          (pos, isVector) => {
+            if (!isVector) {
+              positions.push(new Float32Array(pos));
+            } else if (positions.length === 1) {
+              // Only the ELLIPSOID emits a vector (its radii), right after its center.
+              ellipsoidRadii = new Float32Array(pos);
+            }
+          },
+        );
+        const coordValues = new Map<string, number>();
+        const coordBounds = new Map<string, [number, number]>();
+        if (positions.length > 0) {
+          const addCoordDim = (
+            viewDims: number[],
+            layerDimsMap: readonly number[],
+            names: string[],
+          ) => {
+            for (let vi = 0; vi < viewDims.length; vi++) {
+              const ld = layerDimsMap[viewDims[vi]];
+              if (ld === -1) continue;
+              const name = names[vi];
+              let minVal = Infinity;
+              let maxVal = -Infinity;
+              for (const pos of positions) {
+                const v = pos[ld];
+                if (v < minVal) minVal = v;
+                if (v > maxVal) maxVal = v;
+              }
+              // Extend ELLIPSOID bounds by its (transformed) radii.
+              if (ellipsoidRadii !== undefined) {
+                const r = Math.abs(ellipsoidRadii[ld]);
+                minVal -= r;
+                maxVal += r;
+              }
+              coordValues.set(name, (minVal + maxVal) / 2);
+              coordBounds.set(name, [minVal, maxVal]);
+            }
+          };
+          addCoordDim(
+            this.globalDimensionIndices,
+            globalToRenderLayerDimensions,
+            globalCoordNames,
+          );
+          addCoordDim(
+            this.localDimensionIndices,
+            localToRenderLayerDimensions,
+            localCoordNames,
+          );
+        }
+        return {
+          annotation: {
+            description: annotation.description ?? undefined,
+            properties: annotation.properties,
+          },
+          propSpecs: state.source.properties.value as AnnotationPropertySpec[],
+          coordValues,
+          coordBounds,
+          annotationType: annotation.type,
+          derivedValues: this.derivedAnalysis?.valuesByAnnotationId.get(
+            annotation.id,
+          ),
+        };
+      }),
+    );
+    this.syncNumericalBounds();
+    // Parse text query for filter/sort tokens.
+    const queryText = this.annotationQueryText.value;
+    let parsedTextQuery: AnnotationFilterQuery | undefined;
+    if (queryText.trim() !== "") {
+      const parsed = parseAnnotationQuery(
+        this.annotationQuerySchema,
+        queryText,
+      );
+      if (!("errors" in parsed)) parsedTextQuery = parsed;
+    }
+    // Build effective query: merge text constraints + GUI constraints + sort + columns.
+    const sortBy =
+      parsedTextQuery?.sortBy ??
+      (this.sortState !== undefined
+        ? [
+            {
+              fieldId: this.sortState.propertyId,
+              order:
+                this.sortState.order === "asc"
+                  ? ("<" as const)
+                  : (">" as const),
+            },
+          ]
+        : [{ fieldId: "index", order: "<" as const }]);
+    const effectiveQuery: AnnotationFilterQuery = {
+      prefix: parsedTextQuery?.prefix,
+      regexp: parsedTextQuery?.regexp,
+      numericalConstraints: mergeAnnotationConstraints(
+        parsedTextQuery?.numericalConstraints ?? [],
+        this.annotationNumericalConstraints,
+      ),
+      enumConstraints: mergeAnnotationConstraints(
+        parsedTextQuery?.enumConstraints ?? [],
+        this.annotationEnumConstraints,
+      ),
+      boolConstraints: mergeAnnotationConstraints(
+        parsedTextQuery?.boolConstraints ?? [],
+        this.annotationBoolConstraints,
+      ),
+      sortBy,
+      includeColumns: [...this.shownPropertyIds],
+    };
+    const coordFieldIds = new Set(this.coordDimNames);
+    const queryResult = executeAnnotationQuery(
+      this.annotationQueryItems,
+      effectiveQuery,
+      coordFieldIds,
+    );
+    this.annotationQueryResult.value = queryResult;
+    // Reorder listElements according to query result.
+    const { indices } = queryResult;
+    const savedElements = listElements.slice();
+    listElements.length = 0;
+    for (let k = 0; k < indices!.length; ++k) {
+      listElements.push(savedElements[indices![k]]);
+    }
+    // Update viewport rendering filter: only show query-matching annotations in 3D/2D views.
+    {
+      const filteredIds =
+        queryResult.count < queryResult.total
+          ? new Set(listElements.map((el) => el.annotation.id))
+          : null;
+      for (const [state] of this.attachedAnnotationStates) {
+        state.displayState.filteredAnnotationIds.value = filteredIds;
+      }
+    }
+    // Build idToFlatIndex only when sorting or filtering is active.
+    this.idToFlatIndex.clear();
+    const isQueryOrSortActive =
+      queryResult.count < queryResult.total ||
+      sortBy.some((s) => s.fieldId !== "index") ||
+      queryText.trim() !== "";
+    if (isQueryOrSortActive) {
+      for (let k = 0; k < listElements.length; k++) {
+        this.idToFlatIndex.set(listElements[k].annotation.id, k);
+      }
+    }
     const oldLength = this.virtualListSource.length;
-    this.updateListLength();
+    if (queryResult.count < queryResult.total) {
+      this.virtualListSource.length = listElements.length;
+    } else {
+      this.updateListLength();
+    }
     this.virtualListSource.changed!.dispatch([
       {
         retainCount: 0,
@@ -999,10 +2014,25 @@ export class AnnotationLayerView extends Tab {
         insertCount: listElements.length,
       },
     ]);
+    {
+      const { shown, total, totalIsLowerBound } = this.loadedAnnotationCounts;
+      const showNotice =
+        this.layer.listLoadedAnnotations.value &&
+        (total > shown || (totalIsLowerBound && total > 0));
+      if (showNotice) {
+        const totalText = totalIsLowerBound ? `>=${total}` : `${total}`;
+        this.loadedNoticeElement.textContent = `Showing first ${shown} of ${totalText} loaded annotations - narrow the view or filter to see specific ones.`;
+        this.loadedNoticeElement.style.display = "";
+      } else {
+        this.loadedNoticeElement.style.display = "none";
+      }
+    }
+    this.updateQueryStatistics(queryResult);
     this.mutableControls.style.display = isMutable ? "contents" : "none";
     // The prev/next navigation only applies to editable (local) annotation
     // lists, so hide it for readonly sources such as precomputed annotations.
     this.navRow.style.display = isMutable ? "" : "none";
+    this.layer.annotationListOrder = this.listElements;
     this.resetOnUpdate();
   }
 
@@ -1016,91 +2046,36 @@ export class AnnotationLayerView extends Tab {
   }
 
   private addAnnotationElement(
-    annotation: Annotation,
-    state: AnnotationLayerState,
+    _annotation: Annotation,
+    _state: AnnotationLayerState,
   ) {
     if (!this.visible) {
       this.updated = false;
       return;
     }
-    if (!this.updated) {
-      this.updateView();
-      return;
-    }
-    const info = this.attachedAnnotationStates.get(state);
-    if (info !== undefined) {
-      const index = info.annotations.length;
-      info.annotations.push(annotation);
-      info.idToIndex.set(annotation.id, index);
-      const spliceStart = info.listOffset + index;
-      this.listElements.splice(spliceStart, 0, { state, annotation });
-      this.updateListLength();
-      this.virtualListSource.changed!.dispatch([
-        { retainCount: spliceStart, deleteCount: 0, insertCount: 1 },
-      ]);
-    }
-    this.resetOnUpdate();
+    this.forceUpdateView();
   }
 
   private updateAnnotationElement(
-    annotation: Annotation,
-    state: AnnotationLayerState,
+    _annotation: Annotation,
+    _state: AnnotationLayerState,
   ) {
     if (!this.visible) {
       this.updated = false;
       return;
     }
-    if (!this.updated) {
-      this.updateView();
-      return;
-    }
-    const info = this.attachedAnnotationStates.get(state);
-    if (info !== undefined) {
-      const index = info.idToIndex.get(annotation.id);
-      if (index !== undefined) {
-        const updateStart = info.listOffset + index;
-        info.annotations[index] = annotation;
-        this.listElements[updateStart].annotation = annotation;
-        this.virtualListSource.changed!.dispatch([
-          { retainCount: updateStart, deleteCount: 1, insertCount: 1 },
-        ]);
-      }
-    }
-    this.resetOnUpdate();
+    this.forceUpdateView();
   }
 
   private deleteAnnotationElement(
-    annotationId: string,
-    state: AnnotationLayerState,
+    _annotationId: string,
+    _state: AnnotationLayerState,
   ) {
     if (!this.visible) {
       this.updated = false;
       return;
     }
-    if (!this.updated) {
-      this.updateView();
-      return;
-    }
-    const info = this.attachedAnnotationStates.get(state);
-    if (info !== undefined) {
-      const { idToIndex } = info;
-      const index = idToIndex.get(annotationId);
-      if (index !== undefined) {
-        const spliceStart = info.listOffset + index;
-        const { annotations } = info;
-        annotations.splice(index, 1);
-        idToIndex.delete(annotationId);
-        for (let i = index, length = annotations.length; i < length; ++i) {
-          idToIndex.set(annotations[i].id, i);
-        }
-        this.listElements.splice(spliceStart, 1);
-        this.updateListLength();
-        this.virtualListSource.changed!.dispatch([
-          { retainCount: spliceStart, deleteCount: 1, insertCount: 0 },
-        ]);
-      }
-    }
-    this.resetOnUpdate();
+    this.forceUpdateView();
   }
 
   private resetOnUpdate() {
@@ -1987,6 +2962,24 @@ export function UserLayerWithAnnotationsMixin<
     annotationProjectionRenderScaleTarget = trackableRenderScaleTarget(8);
     allowDependentAnnotationViewUpdate = new TrackableBoolean(true);
     static supportColorPickerInAnnotationTab = true;
+    // Set by AnnotationLayerView after each list rebuild; used by changeSelectedIndex
+    // to step through annotations in the sorted display order rather than source order.
+    annotationListOrder:
+      | ReadonlyArray<{ state: AnnotationLayerState; annotation: Annotation }>
+      | undefined = undefined;
+    // Persisted column-selector and sort state for the annotation list view.
+    // Written by AnnotationLayerView on every user interaction; serialized by
+    // AnnotationUserLayer.toJSON / restoreState.
+    annotationListShownColumns = new WatchableValue<string[]>([]);
+    annotationListSortState = new WatchableValue<{
+      propertyId: string;
+      order: "asc" | "desc";
+    } | null>(null);
+    annotationListQuery = new WatchableValue<string>("");
+    // When enabled, the annotation list also shows the currently-rendered
+    // annotations decoded from non-local (e.g. precomputed) sources.  Off by
+    // default so rendering performance is unaffected unless the user opts in.
+    listLoadedAnnotations = new TrackableBoolean(false);
 
     constructor(...args: any[]) {
       super(...args);
@@ -1997,6 +2990,16 @@ export function UserLayerWithAnnotationsMixin<
         this.specificationChanged.dispatch,
       );
       this.annotationDisplayState.shaderControls.changed.add(
+        this.specificationChanged.dispatch,
+      );
+      this.annotationListShownColumns.changed.add(
+        this.specificationChanged.dispatch,
+      );
+      this.annotationListSortState.changed.add(
+        this.specificationChanged.dispatch,
+      );
+      this.annotationListQuery.changed.add(this.specificationChanged.dispatch);
+      this.listLoadedAnnotations.changed.add(
         this.specificationChanged.dispatch,
       );
       this.tabs.add("annotations", {
@@ -2544,7 +3547,7 @@ export function UserLayerWithAnnotationsMixin<
                         }
                         select.value = String(value);
                         select.addEventListener("change", () => {
-                          changeFunction(select.value);
+                          changeFunction(Number(select.value));
                         });
                         valueElement = select;
                       } else {
@@ -2576,6 +3579,43 @@ export function UserLayerWithAnnotationsMixin<
                   }
                   label.appendChild(valueElementWrapper);
                   parent.appendChild(label);
+                }
+
+                // Derived (computed) geometric properties: show only those that
+                // apply to this annotation (finite value); skip NaN/non-applicable.
+                const derivedAnalysis =
+                  annotationLayer.displayState.derivedProperties;
+                if (
+                  derivedAnalysis !== undefined &&
+                  derivedAnalysis.schemas.length > 0 &&
+                  chunkTransform.error === undefined
+                ) {
+                  const derivedValues = derivedAnalysis.computeForAnnotation(
+                    annotation,
+                    chunkTransform,
+                  );
+                  for (const schema of derivedAnalysis.schemas) {
+                    const value = derivedValues.get(schema.identifier);
+                    if (value === undefined || !Number.isFinite(value))
+                      continue;
+                    const baseUnit = schema.baseUnit ?? "";
+                    const row = document.createElement("div");
+                    row.classList.add("neuroglancer-annotation-property");
+                    const nameEl = document.createElement("span");
+                    nameEl.classList.add(
+                      "neuroglancer-annotation-property-label",
+                    );
+                    nameEl.textContent = `${schema.identifier} (${prettyUnit(baseUnit)})`;
+                    if (schema.description) nameEl.title = schema.description;
+                    row.appendChild(nameEl);
+                    const valueEl = document.createElement("span");
+                    valueEl.classList.add(
+                      "neuroglancer-annotation-property-value",
+                    );
+                    valueEl.textContent = formatDerivedValue(value, baseUnit);
+                    row.appendChild(valueEl);
+                    parent.appendChild(row);
+                  }
                 }
 
                 const { relatedSegments } = annotation;
@@ -2816,6 +3856,69 @@ type UserLayerWithAnnotationsClass = ReturnType<
 export type UserLayerWithAnnotations =
   InstanceType<UserLayerWithAnnotationsClass>;
 
+function mergeAnnotationConstraints<T extends { fieldId: string }>(
+  textConstraints: T[],
+  guiConstraints: T[],
+): T[] {
+  const result = [...textConstraints];
+  for (const c of guiConstraints) {
+    if (!result.some((tc) => tc.fieldId === c.fieldId)) result.push(c);
+  }
+  return result;
+}
+
+// Compact per-cell formatter for the annotation list: enum → label only,
+// bool → +/–, float → 4 sig-figs, int → string.  Color properties excluded.
+function formatPropertyForList(
+  spec: AnnotationPropertySpec,
+  value: number,
+): string {
+  if (spec.type === "bool") return value ? "+" : "–";
+  if (spec.type === "rgb" || spec.type === "rgba") return "";
+  if (Number.isNaN(value)) return "NA";
+  const numSpec = spec as AnnotationNumericPropertySpec;
+  if (numSpec.enumValues !== undefined) {
+    const idx = numSpec.enumValues.indexOf(value);
+    if (idx !== -1) return numSpec.enumLabels![idx];
+  }
+  if (spec.type === "float32") return value.toPrecision(4);
+  return String(value);
+}
+
+/**
+ * Format a derived (computed) property value in SI base units.  Linear units
+ * (m, s) get an SI prefix; compound units (m^2, m^3) are shown in base units
+ * with the pretty unit appended.  NaN (not applicable) renders as "NA".
+ */
+function formatDerivedValue(
+  value: number | undefined,
+  baseUnit: string,
+): string {
+  if (value === undefined || Number.isNaN(value)) return "NA";
+  if (baseUnit === "m" || baseUnit === "s") {
+    if (value === 0) return `0 ${baseUnit}`;
+    // SI prefix selection uses log10, which is NaN for negative values; pick the
+    // prefix from the magnitude and re-apply the sign (delta_{dim} is signed).
+    const sign = value < 0 ? "-" : "";
+    return (
+      sign +
+      formatScaleWithUnitAsString(Math.abs(value), baseUnit, { precision: 4 })
+    );
+  }
+  return `${value.toPrecision(4)} ${prettyUnit(baseUnit)}`;
+}
+
+/** A column shown in the annotation list: a stored property or a derived metric. */
+export interface AnnotationListColumn {
+  identifier: string;
+  /** Stored property spec (value read from annotation.properties). */
+  spec?: AnnotationPropertySpec;
+  /** SI base unit for a derived column (value read from derivedValues). */
+  baseUnit?: string;
+  /** Derived value for this annotation, in SI base units (NaN/undefined → NA). */
+  derivedValue?: number;
+}
+
 export function makeAnnotationListElement(
   layer: UserLayerWithAnnotations,
   annotation: Annotation,
@@ -2823,6 +3926,10 @@ export function makeAnnotationListElement(
   gridTemplate: string,
   globalDimensionIndices: number[],
   localDimensionIndices: number[],
+  propertyColumns?: {
+    columns: readonly AnnotationListColumn[];
+    dimColumnCount: number;
+  },
 ): [HTMLDivElement, number[]] {
   const chunkTransform = state.chunkTransform.value as ChunkTransformParameters;
   const element = document.createElement("div");
@@ -2838,7 +3945,8 @@ export function makeAnnotationListElement(
   let deleteButton: HTMLElement | undefined;
 
   const maybeAddDeleteButton = () => {
-    if (state.source.readonly) return;
+    if (!(state.source instanceof AnnotationSource) || state.source.readonly)
+      return;
     if (deleteButton !== undefined) return;
     deleteButton = makeDeleteButton({
       title: "Delete annotation",
@@ -2900,6 +4008,40 @@ export function makeAnnotationListElement(
       maybeAddDeleteButton();
     },
   );
+  if (propertyColumns !== undefined && propertyColumns.columns.length > 0) {
+    const { columns, dimColumnCount } = propertyColumns;
+    const sourceProps = state.source.properties.value;
+    for (let j = 0; j < columns.length; j++) {
+      const column = columns[j];
+      const propCell = document.createElement("div");
+      propCell.classList.add("neuroglancer-annotation-list-property-value");
+      propCell.style.gridColumn = `prop ${j + 1}`;
+      propCell.style.gridRow = "1";
+      let text: string | undefined;
+      if (column.baseUnit !== undefined) {
+        // Derived (computed) property: value provided on the column descriptor.
+        text = formatDerivedValue(column.derivedValue, column.baseUnit);
+      } else if (column.spec !== undefined) {
+        const propIdx = sourceProps.findIndex(
+          (p) => p.identifier === column.identifier,
+        );
+        if (propIdx >= 0 && propIdx < annotation.properties.length) {
+          text = formatPropertyForList(
+            column.spec,
+            annotation.properties[propIdx] as number,
+          );
+        }
+      }
+      if (text !== undefined) {
+        propCell.textContent = text;
+        columnWidths[dimColumnCount + j] = Math.max(
+          columnWidths[dimColumnCount + j] || 0,
+          text.length,
+        );
+      }
+      element.appendChild(propCell);
+    }
+  }
   if (annotation.description) {
     ++numRows;
     const description = document.createElement("div");

--- a/src/ui/annotations.ts
+++ b/src/ui/annotations.ts
@@ -719,8 +719,8 @@ export class AnnotationLayerView extends Tab {
     );
     this.loadedNoticeElement.style.display = "none";
     this.queryStatistics.content.append(
-      this.categoricalSummaryContainer,
       this.numericalSummaryContainer,
+      this.categoricalSummaryContainer,
       this.derivedWarningElement,
       this.loadedNoticeElement,
     );
@@ -1102,6 +1102,7 @@ export class AnnotationLayerView extends Tab {
       columns.length > 0
         ? { columns, dimColumnCount: numDimColumns }
         : undefined,
+      this.layer.annotationListTypeColumnVisible.value,
     );
     for (const [column, width] of elementColumnWidths.entries()) {
       this.setColumnWidth(column, width);
@@ -1162,6 +1163,17 @@ export class AnnotationLayerView extends Tab {
       shownPropertyIds.add(fieldId);
     }
     this.layer.annotationListShownColumns.value = [...shownPropertyIds];
+    ++this.curColumnConfigGeneration;
+    this.forceUpdateView();
+  }
+
+  private toggleTypeColumn() {
+    const visible = !this.layer.annotationListTypeColumnVisible.value;
+    this.layer.annotationListTypeColumnVisible.value = visible;
+    if (!visible && this.sortState?.propertyId === "type") {
+      this.sortState = undefined;
+      this.layer.annotationListSortState.value = null;
+    }
     ++this.curColumnConfigGeneration;
     this.forceUpdateView();
   }
@@ -1435,8 +1447,14 @@ export class AnnotationLayerView extends Tab {
           key: `${fieldId}=${val}`,
           headerLabel: fieldId,
           label: `=${label}`,
-          headerActive: this.shownPropertyIds.has(fieldId),
-          onHeaderClick: () => this.togglePropertyColumn(fieldId),
+          headerActive:
+            fieldId === "type"
+              ? this.layer.annotationListTypeColumnVisible.value
+              : this.shownPropertyIds.has(fieldId),
+          onHeaderClick: () =>
+            fieldId === "type"
+              ? this.toggleTypeColumn()
+              : this.togglePropertyColumn(fieldId),
           count,
           totalCount: result.count,
           included: constraint?.include.includes(val) ?? false,
@@ -1568,15 +1586,19 @@ export class AnnotationLayerView extends Tab {
       removeChildren(headerRow);
 
       const TYPE_FIELD = "type";
-      const symbolHeader = document.createElement("div");
-      symbolHeader.style.gridColumn = "symbol";
-      symbolHeader.style.display = "flex";
-      symbolHeader.style.alignItems = "center";
-      symbolHeader.style.justifyContent = "center";
-      this.bindSortControl(symbolHeader, TYPE_FIELD);
-      headerRow.appendChild(symbolHeader);
+      const showTypeColumn = this.layer.annotationListTypeColumnVisible.value;
+      if (showTypeColumn) {
+        const symbolHeader = document.createElement("div");
+        symbolHeader.classList.add("neuroglancer-annotation-type-header");
+        symbolHeader.style.gridColumn = "symbol";
+        symbolHeader.style.display = "flex";
+        symbolHeader.style.alignItems = "center";
+        symbolHeader.style.justifyContent = "center";
+        this.bindSortControl(symbolHeader, TYPE_FIELD);
+        headerRow.appendChild(symbolHeader);
+      }
       let i = 0;
-      let gridTemplate = "[symbol] 2ch";
+      let gridTemplate = showTypeColumn ? "[symbol] 2ch" : "";
       const addDimension = (
         coordinateSpace: CoordinateSpace,
         dimIndex: number,
@@ -2892,6 +2914,7 @@ export function UserLayerWithAnnotationsMixin<
     // Written by AnnotationLayerView on every user interaction; serialized by
     // AnnotationUserLayer.toJSON / restoreState.
     annotationListShownColumns = new WatchableValue<string[]>([]);
+    annotationListTypeColumnVisible = new TrackableBoolean(true);
     annotationListSortState = new WatchableValue<{
       propertyId: string;
       order: "asc" | "desc";
@@ -2914,6 +2937,9 @@ export function UserLayerWithAnnotationsMixin<
         this.specificationChanged.dispatch,
       );
       this.annotationListShownColumns.changed.add(
+        this.specificationChanged.dispatch,
+      );
+      this.annotationListTypeColumnVisible.changed.add(
         this.specificationChanged.dispatch,
       );
       this.annotationListSortState.changed.add(
@@ -3851,6 +3877,7 @@ export function makeAnnotationListElement(
     columns: readonly AnnotationListColumn[];
     dimColumnCount: number;
   },
+  showTypeColumn = true,
 ): [HTMLDivElement, number[]] {
   const chunkTransform = state.chunkTransform.value as ChunkTransformParameters;
   const element = document.createElement("div");
@@ -3858,10 +3885,13 @@ export function makeAnnotationListElement(
   element.dataset.color = state.displayState.color.toString();
   element.dataset.annotationId = annotation.id;
   element.style.gridTemplateColumns = gridTemplate;
-  const icon = document.createElement("div");
-  icon.className = "neuroglancer-annotation-icon";
-  icon.textContent = annotationTypeHandlers[annotation.type].icon;
-  element.appendChild(icon);
+  let icon: HTMLDivElement | undefined;
+  if (showTypeColumn) {
+    icon = document.createElement("div");
+    icon.className = "neuroglancer-annotation-icon";
+    icon.textContent = annotationTypeHandlers[annotation.type].icon;
+    element.appendChild(icon);
+  }
 
   let deleteButton: HTMLElement | undefined;
 
@@ -3970,7 +4000,9 @@ export function makeAnnotationListElement(
     description.textContent = annotation.description;
     element.appendChild(description);
   }
-  icon.style.gridRow = `span ${numRows}`;
+  if (icon !== undefined) {
+    icon.style.gridRow = `span ${numRows}`;
+  }
   if (deleteButton !== undefined) {
     deleteButton.style.gridRow = `span ${numRows}`;
   }

--- a/src/ui/property_list.css
+++ b/src/ui/property_list.css
@@ -1,0 +1,65 @@
+.neuroglancer-property-list-header-label {
+  cursor: pointer;
+}
+
+.neuroglancer-property-list-header-sort {
+  visibility: hidden;
+  margin-left: 2px;
+  color: rgba(255, 255, 255, 0.75);
+  font-size: 9px;
+  line-height: 1;
+}
+
+.neuroglancer-property-list-header-label:hover
+  .neuroglancer-property-list-header-sort,
+.neuroglancer-property-list-header-sort[data-active="true"] {
+  visibility: visible;
+}
+
+.neuroglancer-property-list-header-sort[data-active="true"] {
+  color: #4e9ac0;
+}
+
+.neuroglancer-property-list-query {
+  box-sizing: border-box;
+  width: 100%;
+  padding: 2px;
+  border: 2px solid #333;
+  outline: 0;
+  background-color: #151515;
+  color: white;
+  font-family: monospace;
+  font-size: medium;
+}
+
+.neuroglancer-property-list-query:focus {
+  border-color: #4e9ac0;
+}
+
+.neuroglancer-property-list-query::placeholder {
+  color: #aaa;
+}
+
+.neuroglancer-property-list-statistics {
+  max-height: 30%;
+  flex-shrink: 0;
+  overflow: auto;
+  background-color: #333;
+}
+
+.neuroglancer-property-list-statistics:not(:empty) {
+  padding-top: 3px;
+}
+
+.neuroglancer-property-list-statistics-separator {
+  height: 3px;
+  flex-shrink: 0;
+  border-bottom: 1px solid white;
+  background-color: #333;
+}
+
+.neuroglancer-property-list-statistics-count {
+  padding: 1px 4px;
+  color: rgba(255, 255, 255, 0.72);
+  font-size: 11px;
+}

--- a/src/ui/property_list.css
+++ b/src/ui/property_list.css
@@ -11,8 +11,8 @@
 .neuroglancer-property-list-header-sort {
   visibility: hidden;
   margin-left: 2px;
-  color: rgba(255, 255, 255, 0.75);
-  font-size: 9px;
+  color: white;
+  font-size: 1em;
   line-height: 1;
 }
 
@@ -23,7 +23,7 @@
 }
 
 .neuroglancer-property-list-header-sort[data-active="true"] {
-  color: #4e9ac0;
+  color: white;
 }
 
 .neuroglancer-property-list-query {

--- a/src/ui/property_list.css
+++ b/src/ui/property_list.css
@@ -1,3 +1,9 @@
+.neuroglancer-property-list-header {
+  background-color: #666;
+  color: white;
+  font: 10pt sans-serif;
+}
+
 .neuroglancer-property-list-header-label {
   cursor: pointer;
 }
@@ -32,6 +38,11 @@
   font-size: medium;
 }
 
+.neuroglancer-property-list-query-container {
+  padding: 3px 4px;
+  border-bottom: 1px solid #2a2a2a;
+}
+
 .neuroglancer-property-list-query:focus {
   border-color: #4e9ac0;
 }
@@ -59,7 +70,27 @@
 }
 
 .neuroglancer-property-list-statistics-count {
-  padding: 1px 4px;
+  padding-inline: 4px;
+}
+
+.neuroglancer-property-list-summary-group {
+  display: flex;
+  flex-direction: column;
+}
+
+.neuroglancer-property-list-status {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  background-color: #333;
+}
+
+.neuroglancer-property-list-status-message {
+  min-width: 0;
+  overflow: hidden;
+  padding-block: 1px;
   color: rgba(255, 255, 255, 0.72);
   font-size: 11px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }

--- a/src/ui/property_list.spec.ts
+++ b/src/ui/property_list.spec.ts
@@ -1,0 +1,98 @@
+/**
+ * @license
+ * Copyright 2026 Google Inc.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, test, vi } from "vitest";
+import {
+  bindPropertyListSortControl,
+  createPropertyListQueryInput,
+  createPropertyListStatisticsShell,
+  getNextPropertyListSortDirection,
+  type PropertyListSortDirection,
+} from "#src/ui/property_list.js";
+
+describe("property-list sort controls", () => {
+  test("supports two-state and clearable transitions", () => {
+    expect(getNextPropertyListSortDirection(undefined, false)).toBe(
+      "ascending",
+    );
+    expect(getNextPropertyListSortDirection("ascending", false)).toBe(
+      "descending",
+    );
+    expect(getNextPropertyListSortDirection("descending", false)).toBe(
+      "ascending",
+    );
+    expect(
+      getNextPropertyListSortDirection("descending", true),
+    ).toBeUndefined();
+  });
+
+  test("updates visuals, accessibility, pointer, and keyboard activation", () => {
+    const label = document.createElement("span");
+    let direction: PropertyListSortDirection | undefined;
+    const onChange = vi.fn((value) => {
+      direction = value;
+    });
+    const control = bindPropertyListSortControl({
+      label,
+      fieldId: "score",
+      allowClear: true,
+      getDirection: () => direction,
+      onChange,
+    });
+    expect(control.sortIcon.textContent).toBe("▲");
+    expect(control.sortIcon.dataset.active).toBeUndefined();
+    expect(label.getAttribute("aria-pressed")).toBe("false");
+
+    label.click();
+    expect(onChange).toHaveBeenLastCalledWith("ascending");
+    expect(control.sortIcon.dataset.active).toBe("true");
+
+    label.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter" }));
+    expect(onChange).toHaveBeenLastCalledWith("descending");
+    expect(control.sortIcon.textContent).toBe("▼");
+
+    label.dispatchEvent(new KeyboardEvent("keydown", { key: " " }));
+    expect(onChange).toHaveBeenLastCalledWith(undefined);
+    expect(label.title).toBe("Sort by score in ascending order");
+  });
+});
+
+describe("property-list presentation", () => {
+  test("creates a consistently configured query input", () => {
+    const input = createPropertyListQueryInput({
+      placeholder: "Filter properties",
+      selectOnFocus: true,
+    });
+    const select = vi.spyOn(input, "select");
+    input.dispatchEvent(new FocusEvent("focus"));
+    expect(input.type).toBe("text");
+    expect(input.placeholder).toBe("Filter properties");
+    expect(input.autocomplete).toBe("off");
+    expect(input.spellcheck).toBe(false);
+    expect(select).toHaveBeenCalledOnce();
+  });
+
+  test("exposes statistics slots and controls shell visibility", () => {
+    const shell = createPropertyListStatisticsShell();
+    expect(shell.root.contains(shell.count)).toBe(true);
+    expect(shell.root.contains(shell.content)).toBe(true);
+    expect(shell.root.style.display).toBe("none");
+    expect(shell.separator.style.display).toBe("none");
+    shell.setVisible(true);
+    expect(shell.root.style.display).toBe("");
+    expect(shell.separator.style.display).toBe("");
+  });
+});

--- a/src/ui/property_list.spec.ts
+++ b/src/ui/property_list.spec.ts
@@ -17,7 +17,9 @@
 import { describe, expect, test, vi } from "vitest";
 import {
   bindPropertyListSortControl,
+  createPropertyListQueryContainer,
   createPropertyListQueryInput,
+  createPropertyListSummaryGroup,
   createPropertyListStatisticsShell,
   getNextPropertyListSortDirection,
   type PropertyListSortDirection,
@@ -85,14 +87,38 @@ describe("property-list presentation", () => {
     expect(select).toHaveBeenCalledOnce();
   });
 
+  test("wraps query inputs in the shared query container", () => {
+    const input = createPropertyListQueryInput({ placeholder: "Filter" });
+    const container = createPropertyListQueryContainer(input);
+    expect(container.classList).toContain(
+      "neuroglancer-property-list-query-container",
+    );
+    expect(container.firstElementChild).toBe(input);
+  });
+
   test("exposes statistics slots and controls shell visibility", () => {
     const shell = createPropertyListStatisticsShell();
     expect(shell.root.contains(shell.count)).toBe(true);
+    expect(shell.count.classList).toContain(
+      "neuroglancer-property-list-status-message",
+    );
     expect(shell.root.contains(shell.content)).toBe(true);
     expect(shell.root.style.display).toBe("none");
     expect(shell.separator.style.display).toBe("none");
     shell.setVisible(true);
     expect(shell.root.style.display).toBe("");
     expect(shell.separator.style.display).toBe("");
+  });
+
+  test("creates categorical property groups collapsed by default", () => {
+    const details = createPropertyListSummaryGroup({
+      content: document.createElement("div"),
+      propertyCount: 2,
+      propertyKind: "categorical",
+    });
+    expect(details.open).toBe(false);
+    expect(details.querySelector("summary")?.textContent).toBe(
+      "2 categorical properties",
+    );
   });
 });

--- a/src/ui/property_list.ts
+++ b/src/ui/property_list.ts
@@ -1,0 +1,120 @@
+/**
+ * @license
+ * Copyright 2026 Google Inc.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import "#src/ui/property_list.css";
+
+export type PropertyListSortDirection = "ascending" | "descending";
+
+export function getNextPropertyListSortDirection(
+  direction: PropertyListSortDirection | undefined,
+  allowClear: boolean,
+): PropertyListSortDirection | undefined {
+  if (direction === undefined) return "ascending";
+  if (direction === "ascending") return "descending";
+  return allowClear ? undefined : "ascending";
+}
+
+export interface PropertyListSortControl {
+  sortIcon: HTMLElement;
+  update: () => void;
+}
+
+export function bindPropertyListSortControl(options: {
+  label: HTMLElement;
+  sortIcon?: HTMLElement;
+  fieldId: string;
+  allowClear: boolean;
+  getDirection: () => PropertyListSortDirection | undefined;
+  onChange: (direction: PropertyListSortDirection | undefined) => void;
+}): PropertyListSortControl {
+  const { label, fieldId, allowClear, getDirection, onChange } = options;
+  label.classList.add("neuroglancer-property-list-header-label");
+  label.tabIndex = 0;
+  label.setAttribute("role", "button");
+  const sortIcon = options.sortIcon ?? document.createElement("span");
+  sortIcon.classList.add("neuroglancer-property-list-header-sort");
+  if (sortIcon.parentElement !== label) label.appendChild(sortIcon);
+
+  const update = () => {
+    const direction = getDirection();
+    sortIcon.textContent = direction === "descending" ? "▼" : "▲";
+    if (direction === undefined) {
+      delete sortIcon.dataset.active;
+      label.setAttribute("aria-pressed", "false");
+    } else {
+      sortIcon.dataset.active = "true";
+      label.setAttribute("aria-pressed", "true");
+    }
+    const next = getNextPropertyListSortDirection(direction, allowClear);
+    label.title =
+      next === undefined
+        ? `Clear sort by ${fieldId}`
+        : `Sort by ${fieldId} in ${next} order`;
+  };
+  const activate = () => {
+    onChange(getNextPropertyListSortDirection(getDirection(), allowClear));
+    update();
+  };
+  label.addEventListener("click", activate);
+  label.addEventListener("keydown", (event) => {
+    if (event.key !== "Enter" && event.key !== " ") return;
+    event.preventDefault();
+    activate();
+  });
+  update();
+  return { sortIcon, update };
+}
+
+export function createPropertyListQueryInput(options: {
+  placeholder: string;
+  selectOnFocus?: boolean;
+}): HTMLInputElement {
+  const input = document.createElement("input");
+  input.type = "text";
+  input.classList.add("neuroglancer-property-list-query");
+  input.placeholder = options.placeholder;
+  input.autocomplete = "off";
+  input.spellcheck = false;
+  if (options.selectOnFocus) {
+    input.addEventListener("focus", () => input.select());
+  }
+  return input;
+}
+
+export interface PropertyListStatisticsShell {
+  root: HTMLDivElement;
+  count: HTMLDivElement;
+  content: HTMLDivElement;
+  separator: HTMLDivElement;
+  setVisible: (visible: boolean) => void;
+}
+
+export function createPropertyListStatisticsShell(): PropertyListStatisticsShell {
+  const root = document.createElement("div");
+  root.classList.add("neuroglancer-property-list-statistics");
+  const count = document.createElement("div");
+  count.classList.add("neuroglancer-property-list-statistics-count");
+  const content = document.createElement("div");
+  root.append(count, content);
+  const separator = document.createElement("div");
+  separator.classList.add("neuroglancer-property-list-statistics-separator");
+  const setVisible = (visible: boolean) => {
+    root.style.display = visible ? "" : "none";
+    separator.style.display = visible ? "" : "none";
+  };
+  setVisible(false);
+  return { root, count, content, separator, setVisible };
+}

--- a/src/ui/property_list.ts
+++ b/src/ui/property_list.ts
@@ -94,6 +94,34 @@ export function createPropertyListQueryInput(options: {
   return input;
 }
 
+export function createPropertyListQueryContainer(
+  input: HTMLInputElement,
+): HTMLDivElement {
+  const container = document.createElement("div");
+  container.classList.add("neuroglancer-property-list-query-container");
+  container.appendChild(input);
+  return container;
+}
+
+export function createPropertyListSummaryGroup(options: {
+  content: HTMLElement;
+  propertyCount: number;
+  propertyKind: string;
+  open?: boolean;
+  onToggle?: (open: boolean) => void;
+}): HTMLDetailsElement {
+  const details = document.createElement("details");
+  details.classList.add("neuroglancer-property-list-summary-group");
+  details.open = options.open ?? false;
+  details.addEventListener("toggle", () => options.onToggle?.(details.open));
+  const summary = document.createElement("summary");
+  summary.textContent = `${options.propertyCount} ${options.propertyKind} propert${
+    options.propertyCount === 1 ? "y" : "ies"
+  }`;
+  details.append(summary, options.content);
+  return details;
+}
+
 export interface PropertyListStatisticsShell {
   root: HTMLDivElement;
   count: HTMLDivElement;
@@ -106,7 +134,10 @@ export function createPropertyListStatisticsShell(): PropertyListStatisticsShell
   const root = document.createElement("div");
   root.classList.add("neuroglancer-property-list-statistics");
   const count = document.createElement("div");
-  count.classList.add("neuroglancer-property-list-statistics-count");
+  count.classList.add(
+    "neuroglancer-property-list-statistics-count",
+    "neuroglancer-property-list-status-message",
+  );
   const content = document.createElement("div");
   root.append(count, content);
   const separator = document.createElement("div");

--- a/src/ui/property_query.spec.ts
+++ b/src/ui/property_query.spec.ts
@@ -1,0 +1,199 @@
+/**
+ * @license
+ * Copyright 2026 Google Inc.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, test } from "vitest";
+import type {
+  PropertyQueryDomainResolver,
+  ResolvedPropertyQueryBase,
+} from "#src/ui/property_query.js";
+import {
+  parsePropertyQuerySyntax,
+  resolvePropertyQuery,
+  serializePropertyQueryClauses,
+  tokenizePropertyQuery,
+} from "#src/ui/property_query.js";
+import { DataType } from "#src/util/data_type.js";
+import type { DataTypeInterval } from "#src/util/lerp.js";
+
+describe("tokenizePropertyQuery", () => {
+  test("uses all whitespace and preserves source ranges", () => {
+    expect(tokenizePropertyQuery("  <score\t#status=active\ntext ")).toEqual([
+      { text: "<score", begin: 2, end: 8 },
+      { text: "#status=active", begin: 9, end: 23 },
+      { text: "text", begin: 24, end: 28 },
+    ]);
+  });
+});
+
+describe("parsePropertyQuerySyntax", () => {
+  test("parses every shared clause without assigning domain meaning", () => {
+    const result = parsePropertyQuerySyntax(
+      "<score >count |length score>=0.5 #verified -#status=done /foo.*/ text",
+    );
+    expect(result.errors).toEqual([]);
+    expect(result.clauses.map(({ type }) => type)).toEqual([
+      "sort",
+      "sort",
+      "column",
+      "comparison",
+      "categorical",
+      "categorical",
+      "regexp",
+      "text",
+    ]);
+    expect(result.clauses[3]).toMatchObject({
+      field: "score",
+      operator: ">=",
+      value: "0.5",
+    });
+    expect(result.clauses[5]).toMatchObject({
+      exclude: true,
+      field: "status",
+      value: "done",
+    });
+    expect(result.clauses[6]).toMatchObject({
+      pattern: "foo.*",
+      closed: true,
+    });
+  });
+
+  test("accepts a regexp without a closing slash", () => {
+    expect(parsePropertyQuerySyntax("/foo").clauses[0]).toMatchObject({
+      type: "regexp",
+      pattern: "foo",
+      closed: false,
+    });
+  });
+
+  test("leaves non-numeric equality expressions for domain text handling", () => {
+    expect(parsePropertyQuerySyntax("label=foo").clauses[0]).toMatchObject({
+      type: "text",
+      value: "label=foo",
+    });
+  });
+
+  test("reports source-ranged missing fields", () => {
+    expect(parsePropertyQuerySyntax("x <  |").errors).toEqual([
+      { begin: 2, end: 3, message: "Sort field is missing" },
+      { begin: 5, end: 6, message: "Column field is missing" },
+    ]);
+  });
+});
+
+describe("serializePropertyQueryClauses", () => {
+  test("serializes the common canonical syntax", () => {
+    expect(
+      serializePropertyQueryClauses([
+        { type: "sort", field: "score", order: "<" },
+        { type: "column", field: "length" },
+        {
+          type: "comparison",
+          field: "score",
+          operator: ">=",
+          value: "0.5",
+        },
+        {
+          type: "categorical",
+          exclude: true,
+          field: "status",
+          value: "done",
+        },
+        { type: "regexp", pattern: "foo.*", closed: true },
+        { type: "text", value: "text" },
+      ]),
+    ).toBe("<score |length score>=0.5 -#status=done /foo.*/ text");
+  });
+});
+
+describe("resolvePropertyQuery", () => {
+  interface TestQuery extends ResolvedPropertyQueryBase {
+    categories: string[];
+  }
+
+  const makeResolver = (): PropertyQueryDomainResolver<TestQuery> => ({
+    createQuery: () => ({
+      prefix: undefined as string | undefined,
+      regexp: undefined as RegExp | undefined,
+      numericalConstraints: [],
+      sortBy: [],
+      includeColumns: [],
+      categories: [] as string[],
+    }),
+    resolveSortField: (clause: {
+      field: string;
+      begin: number;
+      end: number;
+    }) =>
+      clause.field === "score"
+        ? ({ value: "score" } as const)
+        : ({
+            error: {
+              begin: clause.begin + 1,
+              end: clause.end,
+              message: `Unknown sort field: ${clause.field}`,
+            },
+          } as const),
+    resolveColumnField: () => ({ value: "score" }) as const,
+    resolveNumericField: () =>
+      ({
+        value: {
+          fieldId: "score",
+          dataType: DataType.INT32,
+          bounds: [0, 10] as DataTypeInterval,
+        },
+      }) as const,
+    applyCategoricalClause: (query, clause) => {
+      query.categories.push(clause.field);
+    },
+    defaultSort: { fieldId: "index", order: "<" as const },
+    regexpFlags: "i",
+  });
+
+  test("resolves common clauses and narrows numerical intervals", () => {
+    const result = resolvePropertyQuery(
+      "score>=2 score<8 |score #active /foo/",
+      makeResolver(),
+    );
+    expect(result).toMatchObject({
+      regexp: /foo/i,
+      numericalConstraints: [{ fieldId: "score", bounds: [2, 7] }],
+      includeColumns: ["score"],
+      categories: ["active"],
+      sortBy: [{ fieldId: "index", order: "<" }],
+    });
+  });
+
+  test("reports duplicate sorts and regexp/text conflicts", () => {
+    expect(
+      resolvePropertyQuery("<score >score /foo/ text", makeResolver()),
+    ).toEqual({
+      errors: [
+        { begin: 8, end: 13, message: "Duplicate sort field: score" },
+        {
+          begin: 20,
+          end: 24,
+          message: "Prefix cannot be combined with regular expression",
+        },
+      ],
+    });
+  });
+
+  test("combines multiple text clauses", () => {
+    expect(resolvePropertyQuery("alpha beta", makeResolver())).toMatchObject({
+      prefix: "alpha beta",
+    });
+  });
+});

--- a/src/ui/property_query.spec.ts
+++ b/src/ui/property_query.spec.ts
@@ -163,7 +163,7 @@ describe("resolvePropertyQuery", () => {
   });
 
   test("resolves common clauses and narrows numerical intervals", () => {
-    const result = resolvePropertyQuery(
+    const result = resolvePropertyQuery<TestQuery>(
       "score>=2 score<8 |score #active /foo/",
       makeResolver(),
     );
@@ -178,7 +178,10 @@ describe("resolvePropertyQuery", () => {
 
   test("reports duplicate sorts and regexp/text conflicts", () => {
     expect(
-      resolvePropertyQuery("<score >score /foo/ text", makeResolver()),
+      resolvePropertyQuery<TestQuery>(
+        "<score >score /foo/ text",
+        makeResolver(),
+      ),
     ).toEqual({
       errors: [
         { begin: 8, end: 13, message: "Duplicate sort field: score" },
@@ -192,8 +195,8 @@ describe("resolvePropertyQuery", () => {
   });
 
   test("combines multiple text clauses", () => {
-    expect(resolvePropertyQuery("alpha beta", makeResolver())).toMatchObject({
-      prefix: "alpha beta",
-    });
+    expect(
+      resolvePropertyQuery<TestQuery>("alpha beta", makeResolver()),
+    ).toMatchObject({ prefix: "alpha beta" });
   });
 });

--- a/src/ui/property_query.ts
+++ b/src/ui/property_query.ts
@@ -22,6 +22,7 @@ import {
   dataTypeValueNextAfter,
   parseDataTypeValue,
 } from "#src/util/lerp.js";
+import { parseValueWithUnit } from "#src/util/si_units.js";
 
 export interface PropertyQueryToken {
   text: string;
@@ -116,6 +117,7 @@ export interface PropertyQueryNumericField {
   fieldId: string;
   dataType: DataType;
   bounds: DataTypeInterval;
+  baseUnit?: string;
 }
 
 export type PropertyQueryResolution<T> =
@@ -251,7 +253,14 @@ function applyNumericalComparison(
 ): PropertyQuerySyntaxError | undefined {
   let value: number;
   try {
-    value = parseDataTypeValue(field.dataType, clause.value) as number;
+    const parsedValue =
+      field.baseUnit === undefined
+        ? clause.value
+        : parseValueWithUnit(clause.value, field.baseUnit);
+    if (parsedValue === undefined) {
+      throw new Error(`Invalid value: ${JSON.stringify(clause.value)}`);
+    }
+    value = parseDataTypeValue(field.dataType, `${parsedValue}`) as number;
   } catch (error) {
     return {
       begin: clause.begin + clause.field.length + clause.operator.length,

--- a/src/ui/property_query.ts
+++ b/src/ui/property_query.ts
@@ -1,0 +1,439 @@
+/**
+ * @license
+ * Copyright 2026 Google Inc.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { DataType } from "#src/util/data_type.js";
+import type { DataTypeInterval } from "#src/util/lerp.js";
+import {
+  clampToInterval,
+  dataTypeCompare,
+  dataTypeValueNextAfter,
+  parseDataTypeValue,
+} from "#src/util/lerp.js";
+
+export interface PropertyQueryToken {
+  text: string;
+  begin: number;
+  end: number;
+}
+
+type PropertyQueryClauseBase = PropertyQueryToken;
+
+export interface PropertyQuerySortClause extends PropertyQueryClauseBase {
+  type: "sort";
+  field: string;
+  order: "<" | ">";
+}
+
+export interface PropertyQueryColumnClause extends PropertyQueryClauseBase {
+  type: "column";
+  field: string;
+}
+
+export interface PropertyQueryComparisonClause extends PropertyQueryClauseBase {
+  type: "comparison";
+  field: string;
+  operator: "<" | "<=" | "=" | ">=" | ">";
+  value: string;
+}
+
+export interface PropertyQueryCategoricalClause
+  extends PropertyQueryClauseBase {
+  type: "categorical";
+  exclude: boolean;
+  field: string;
+  value: string | undefined;
+}
+
+export interface PropertyQueryRegexpClause extends PropertyQueryClauseBase {
+  type: "regexp";
+  pattern: string;
+  closed: boolean;
+}
+
+export interface PropertyQueryTextClause extends PropertyQueryClauseBase {
+  type: "text";
+  value: string;
+}
+
+export type PropertyQueryClause =
+  | PropertyQuerySortClause
+  | PropertyQueryColumnClause
+  | PropertyQueryComparisonClause
+  | PropertyQueryCategoricalClause
+  | PropertyQueryRegexpClause
+  | PropertyQueryTextClause;
+
+type WithoutSourceRange<T> = T extends PropertyQueryClause
+  ? Omit<T, keyof PropertyQueryToken>
+  : never;
+
+export type SerializablePropertyQueryClause =
+  WithoutSourceRange<PropertyQueryClause>;
+
+export interface PropertyQuerySyntaxError {
+  begin: number;
+  end: number;
+  message: string;
+}
+
+export interface ParsedPropertyQuery {
+  clauses: PropertyQueryClause[];
+  errors: PropertyQuerySyntaxError[];
+}
+
+export interface ResolvedPropertyQuerySort {
+  fieldId: string;
+  order: "<" | ">";
+}
+
+export interface ResolvedPropertyQueryNumericalConstraint {
+  fieldId: string;
+  bounds: DataTypeInterval;
+}
+
+export interface ResolvedPropertyQueryBase {
+  prefix: string | undefined;
+  regexp: RegExp | undefined;
+  numericalConstraints: ResolvedPropertyQueryNumericalConstraint[];
+  sortBy: ResolvedPropertyQuerySort[];
+  includeColumns: string[];
+}
+
+export interface PropertyQueryNumericField {
+  fieldId: string;
+  dataType: DataType;
+  bounds: DataTypeInterval;
+}
+
+export type PropertyQueryResolution<T> =
+  | { value: T }
+  | { ignore: true }
+  | { error: PropertyQuerySyntaxError };
+
+export interface PropertyQueryResolverContext {
+  errors: PropertyQuerySyntaxError[];
+}
+
+export interface PropertyQueryDomainResolver<
+  Query extends ResolvedPropertyQueryBase,
+> {
+  createQuery: () => Query;
+  resolveSortField: (
+    clause: PropertyQuerySortClause,
+  ) => PropertyQueryResolution<string>;
+  resolveColumnField: (
+    clause: PropertyQueryColumnClause,
+  ) => PropertyQueryResolution<string>;
+  resolveNumericField: (
+    clause: PropertyQueryComparisonClause,
+  ) => PropertyQueryResolution<PropertyQueryNumericField>;
+  applyCategoricalClause: (
+    query: Query,
+    clause: PropertyQueryCategoricalClause,
+    context: PropertyQueryResolverContext,
+  ) => void;
+  defaultSort: ResolvedPropertyQuerySort;
+  regexpFlags?: string;
+  textUnavailableError?: string;
+  duplicateSortMessage?: (
+    clause: PropertyQuerySortClause,
+    fieldId: string,
+  ) => string;
+}
+
+export function tokenizePropertyQuery(text: string): PropertyQueryToken[] {
+  const tokens: PropertyQueryToken[] = [];
+  let index = 0;
+  while (index < text.length) {
+    while (index < text.length && /\s/.test(text[index])) ++index;
+    if (index === text.length) break;
+    const begin = index;
+    while (index < text.length && !/\s/.test(text[index])) ++index;
+    tokens.push({ text: text.slice(begin, index), begin, end: index });
+  }
+  return tokens;
+}
+
+const comparisonPattern = /^([a-zA-Z][a-zA-Z0-9_]*)(<=|>=|<|>|=)(-?[0-9.].*)$/;
+const categoricalPattern = /^(-?)#([a-zA-Z][a-zA-Z0-9_]*)(?:=(.*))?$/;
+
+export function parsePropertyQuerySyntax(text: string): ParsedPropertyQuery {
+  const clauses: PropertyQueryClause[] = [];
+  const errors: PropertyQuerySyntaxError[] = [];
+  for (const token of tokenizePropertyQuery(text)) {
+    const { text, begin, end } = token;
+    if (text.startsWith("<") || text.startsWith(">")) {
+      const field = text.slice(1);
+      if (field === "") {
+        errors.push({ begin, end, message: "Sort field is missing" });
+      } else {
+        clauses.push({
+          type: "sort",
+          text,
+          begin,
+          end,
+          field,
+          order: text[0] as "<" | ">",
+        });
+      }
+      continue;
+    }
+    if (text.startsWith("|")) {
+      const field = text.slice(1);
+      if (field === "") {
+        errors.push({ begin, end, message: "Column field is missing" });
+      } else {
+        clauses.push({ type: "column", text, begin, end, field });
+      }
+      continue;
+    }
+    if (text.startsWith("/")) {
+      const closed = text.length > 1 && text.endsWith("/");
+      clauses.push({
+        type: "regexp",
+        text,
+        begin,
+        end,
+        pattern: text.slice(1, closed ? -1 : undefined),
+        closed,
+      });
+      continue;
+    }
+    const categoricalMatch = text.match(categoricalPattern);
+    if (categoricalMatch !== null) {
+      clauses.push({
+        type: "categorical",
+        text,
+        begin,
+        end,
+        exclude: categoricalMatch[1] === "-",
+        field: categoricalMatch[2],
+        value: categoricalMatch[3],
+      });
+      continue;
+    }
+    const comparisonMatch = text.match(comparisonPattern);
+    if (comparisonMatch !== null) {
+      clauses.push({
+        type: "comparison",
+        text,
+        begin,
+        end,
+        field: comparisonMatch[1],
+        operator:
+          comparisonMatch[2] as PropertyQueryComparisonClause["operator"],
+        value: comparisonMatch[3],
+      });
+      continue;
+    }
+    clauses.push({ type: "text", text, begin, end, value: text });
+  }
+  return { clauses, errors };
+}
+
+function applyNumericalComparison(
+  constraints: ResolvedPropertyQueryNumericalConstraint[],
+  field: PropertyQueryNumericField,
+  clause: PropertyQueryComparisonClause,
+): PropertyQuerySyntaxError | undefined {
+  let value: number;
+  try {
+    value = parseDataTypeValue(field.dataType, clause.value) as number;
+  } catch (error) {
+    return {
+      begin: clause.begin + clause.field.length + clause.operator.length,
+      end: clause.end,
+      message: (error as Error).message,
+    };
+  }
+  let constraint = constraints.find((x) => x.fieldId === field.fieldId);
+  if (constraint === undefined) {
+    constraint = { fieldId: field.fieldId, bounds: field.bounds };
+    constraints.push(constraint);
+  }
+  const originalMin = clampToInterval(field.bounds, constraint.bounds[0]);
+  const originalMax = clampToInterval(field.bounds, constraint.bounds[1]);
+  let newMin = originalMin;
+  let newMax = originalMax;
+  switch (clause.operator) {
+    case "<":
+      newMax = dataTypeValueNextAfter(field.dataType, value, -1);
+      break;
+    case "<=":
+      newMax = value;
+      break;
+    case "=":
+      newMin = newMax = value;
+      break;
+    case ">=":
+      newMin = value;
+      break;
+    case ">":
+      newMin = dataTypeValueNextAfter(field.dataType, value, +1);
+      break;
+  }
+  newMin = dataTypeCompare(originalMin, newMin) > 0 ? originalMin : newMin;
+  newMax = dataTypeCompare(originalMax, newMax) < 0 ? originalMax : newMax;
+  if (dataTypeCompare(newMin, newMax) > 0) {
+    return {
+      begin: clause.begin,
+      end: clause.end,
+      message: "Constraint would not match any values",
+    };
+  }
+  constraint.bounds = [newMin, newMax] as DataTypeInterval;
+  return undefined;
+}
+
+export function resolvePropertyQuery<Query extends ResolvedPropertyQueryBase>(
+  text: string,
+  resolver: PropertyQueryDomainResolver<Query>,
+): Query | { errors: PropertyQuerySyntaxError[] } {
+  const query = resolver.createQuery();
+  const syntax = parsePropertyQuerySyntax(text);
+  const errors = [...syntax.errors];
+  const context = { errors };
+
+  for (const clause of syntax.clauses) {
+    if (clause.type === "categorical") {
+      resolver.applyCategoricalClause(query, clause, context);
+      continue;
+    }
+    if (clause.type === "sort") {
+      const resolution = resolver.resolveSortField(clause);
+      if ("error" in resolution) {
+        errors.push(resolution.error);
+      } else if (!("ignore" in resolution)) {
+        const fieldId = resolution.value;
+        if (query.sortBy.some((sort) => sort.fieldId === fieldId)) {
+          errors.push({
+            begin: clause.begin + 1,
+            end: clause.end,
+            message:
+              resolver.duplicateSortMessage?.(clause, fieldId) ??
+              `Duplicate sort field: ${fieldId}`,
+          });
+        } else {
+          query.sortBy.push({ fieldId, order: clause.order });
+        }
+      }
+      continue;
+    }
+    if (clause.type === "column") {
+      const resolution = resolver.resolveColumnField(clause);
+      if ("error" in resolution) {
+        errors.push(resolution.error);
+      } else if (!("ignore" in resolution)) {
+        const fieldId = resolution.value;
+        if (
+          !query.sortBy.some((sort) => sort.fieldId === fieldId) &&
+          !query.includeColumns.includes(fieldId)
+        ) {
+          query.includeColumns.push(fieldId);
+        }
+      }
+      continue;
+    }
+    if (clause.type === "comparison") {
+      const resolution = resolver.resolveNumericField(clause);
+      if ("error" in resolution) {
+        errors.push(resolution.error);
+      } else if (!("ignore" in resolution)) {
+        const error = applyNumericalComparison(
+          query.numericalConstraints,
+          resolution.value,
+          clause,
+        );
+        if (error !== undefined) errors.push(error);
+      }
+      continue;
+    }
+    if (resolver.textUnavailableError !== undefined) {
+      errors.push({
+        begin: clause.begin,
+        end: clause.end,
+        message: resolver.textUnavailableError,
+      });
+      continue;
+    }
+    if (clause.type === "regexp") {
+      if (query.regexp !== undefined || query.prefix !== undefined) {
+        errors.push({
+          begin: clause.begin,
+          end: clause.end,
+          message:
+            query.regexp !== undefined
+              ? "Only one regular expression allowed"
+              : "Prefix cannot be combined with regular expression",
+        });
+        continue;
+      }
+      try {
+        query.regexp = new RegExp(clause.pattern, resolver.regexpFlags);
+      } catch {
+        errors.push({
+          begin: clause.begin,
+          end: clause.end,
+          message: "Invalid regular expression syntax",
+        });
+      }
+    } else {
+      if (query.regexp !== undefined) {
+        errors.push({
+          begin: clause.begin,
+          end: clause.end,
+          message: "Prefix cannot be combined with regular expression",
+        });
+        continue;
+      }
+      query.prefix =
+        query.prefix === undefined
+          ? clause.value
+          : `${query.prefix} ${clause.value}`;
+    }
+  }
+
+  if (errors.length !== 0) return { errors };
+  if (query.sortBy.length === 0) query.sortBy.push(resolver.defaultSort);
+  return query;
+}
+
+export function serializePropertyQueryClause(
+  clause: SerializablePropertyQueryClause,
+): string {
+  switch (clause.type) {
+    case "sort":
+      return `${clause.order}${clause.field}`;
+    case "column":
+      return `|${clause.field}`;
+    case "comparison":
+      return `${clause.field}${clause.operator}${clause.value}`;
+    case "categorical":
+      return `${clause.exclude ? "-" : ""}#${clause.field}${
+        clause.value === undefined ? "" : `=${clause.value}`
+      }`;
+    case "regexp":
+      return `/${clause.pattern}/`;
+    case "text":
+      return clause.value;
+  }
+}
+
+export function serializePropertyQueryClauses(
+  clauses: SerializablePropertyQueryClause[],
+): string {
+  return clauses.map(serializePropertyQueryClause).join(" ");
+}

--- a/src/ui/property_summary.ts
+++ b/src/ui/property_summary.ts
@@ -29,6 +29,7 @@ import type {
 } from "#src/segmentation_display_state/property_map.js";
 import type { WatchableValueInterface } from "#src/trackable_value.js";
 import { WatchableValue } from "#src/trackable_value.js";
+import { createPropertyListSummaryGroup } from "#src/ui/property_list.js";
 import { animationFrameDebounce } from "#src/util/animation_frame_debounce.js";
 import type { DataType } from "#src/util/data_type.js";
 import { RefCounted } from "#src/util/disposable.js";
@@ -43,6 +44,13 @@ import {
   getIntervalBoundsEffectiveFraction,
   parseDataTypeValue,
 } from "#src/util/lerp.js";
+import {
+  type DisplayUnit,
+  formatValueWithUnit,
+  parseValueWithUnit,
+  pickDisplayUnit,
+  roundValueToDisplayUnit,
+} from "#src/util/si_units.js";
 import { neverSignal } from "#src/util/signal.js";
 import { CheckboxIcon } from "#src/widget/checkbox_icon.js";
 import type { RangeAndWindowIntervals } from "#src/widget/invlerp.js";
@@ -58,11 +66,17 @@ export interface NumericalSummaryProperty {
   dataType: DataType;
   bounds: DataTypeInterval;
   description?: string;
+  baseUnit?: string;
+  applicableAnnotationTypes?: readonly number[];
 }
 
 /** Implemented by segment and annotation callers to provide histogram data. */
 export interface NumericalSummaryDataSource {
   properties: NumericalSummaryProperty[];
+  isPropertyApplicable?: (
+    property: NumericalSummaryProperty,
+    queryResult: NumericalSummaryQueryResult | undefined,
+  ) => boolean;
   updateHistograms(
     queryResult:
       | {
@@ -145,6 +159,8 @@ interface NumericalPropertySummaryWidget {
   bounds: RangeAndWindowIntervals;
   columnCheckbox: HTMLInputElement;
   sortIcon: HTMLElement;
+  displayUnit: DisplayUnit | undefined;
+  applicable: boolean;
 }
 
 function updateInputBoundWidth(inputElement: HTMLInputElement) {
@@ -154,7 +170,21 @@ function updateInputBoundWidth(inputElement: HTMLInputElement) {
   );
 }
 
-function updateInputBoundValue(inputElement: HTMLInputElement, bound: number) {
+function updateInputBoundValue(
+  inputElement: HTMLInputElement,
+  bound: number,
+  displayUnit?: DisplayUnit,
+  roundingDirection?: "down" | "up",
+) {
+  if (displayUnit !== undefined) {
+    inputElement.value = formatValueWithUnit(
+      bound,
+      displayUnit,
+      roundingDirection,
+    );
+    updateInputBoundWidth(inputElement);
+    return;
+  }
   let boundString: string;
   if (Number.isInteger(bound)) {
     boundString = bound.toString();
@@ -265,6 +295,7 @@ export function updateColumnSortIcon(
  */
 export class NumericalPropertiesSummary extends RefCounted {
   listElement: HTMLElement | undefined;
+  summaryElement: HTMLElement | undefined;
   properties: NumericalPropertySummaryWidget[];
   propertyHistograms: NumericalPropertyHistogram[] = [];
   bounds = {
@@ -293,9 +324,10 @@ export class NumericalPropertiesSummary extends RefCounted {
     const { properties } = dataSource;
     const propertySummaries: NumericalPropertySummaryWidget[] = [];
     let listElement: HTMLElement | undefined;
+    let summaryElement: HTMLElement | undefined;
     if (properties.length > 0) {
       listElement = document.createElement("details");
-      const summaryElement = document.createElement("summary");
+      summaryElement = document.createElement("summary");
       summaryElement.textContent = `${properties.length} numerical propert${
         properties.length > 1 ? "ies" : "y"
       }`;
@@ -313,6 +345,7 @@ export class NumericalPropertiesSummary extends RefCounted {
       }
     }
     this.listElement = listElement;
+    this.summaryElement = summaryElement;
     this.properties = propertySummaries;
     this.registerDisposer(
       this.queryResult.changed.add(() => this.handleNewQueryResult()),
@@ -367,6 +400,20 @@ export class NumericalPropertiesSummary extends RefCounted {
       this.bounds.range.value[propertyIndex] = newRange;
       this.bounds.range.changed.dispatch();
     }
+  }
+
+  private roundBoundsToDisplayUnit(
+    propertyIndex: number,
+    value: RangeAndWindowIntervals,
+  ): RangeAndWindowIntervals {
+    const displayUnit = this.properties[propertyIndex].displayUnit;
+    if (displayUnit === undefined) return value;
+    const round = (bound: number | bigint) =>
+      roundValueToDisplayUnit(bound, displayUnit);
+    return {
+      range: [round(value.range[0]), round(value.range[1])],
+      window: [round(value.window[0]), round(value.window[1])],
+    };
   }
 
   private setBound(
@@ -438,12 +485,25 @@ export class NumericalPropertiesSummary extends RefCounted {
     }
     listElement.style.display = "";
     const { properties } = this;
+    let applicablePropertyCount = 0;
     for (let i = 0, n = properties.length; i < n; ++i) {
       this.updatePropertySummaryRendering(
         i,
         properties[i],
         propertyHistograms[i],
       );
+      if (properties[i].applicable) ++applicablePropertyCount;
+    }
+    const { summaryElement } = this;
+    if (summaryElement !== undefined) {
+      const totalPropertyCount = properties.length;
+      const countText =
+        applicablePropertyCount === totalPropertyCount
+          ? `${totalPropertyCount}`
+          : `${applicablePropertyCount}/${totalPropertyCount}`;
+      summaryElement.textContent = `${countText} numerical propert${
+        totalPropertyCount === 1 ? "y" : "ies"
+      }`;
     }
   }
 
@@ -461,7 +521,12 @@ export class NumericalPropertiesSummary extends RefCounted {
       plotImg,
       property.dataType,
       () => this.getBounds(propertyIndex),
-      (bounds) => this.setBounds(propertyIndex, bounds),
+      (bounds) =>
+        propertySummary.applicable &&
+        this.setBounds(
+          propertyIndex,
+          this.roundBoundsToDisplayUnit(propertyIndex, bounds),
+        ),
     );
     const sortIcon = document.createElement("span");
     sortIcon.classList.add(
@@ -470,6 +535,7 @@ export class NumericalPropertiesSummary extends RefCounted {
     const columnCheckbox = document.createElement("input");
     columnCheckbox.type = "checkbox";
     columnCheckbox.addEventListener("click", () => {
+      if (!propertySummary.applicable) return;
       const q = this.queryResult.value?.query;
       if (q === undefined) return;
       toggleIncludeColumn(q, this.setQuery, property.id);
@@ -487,10 +553,25 @@ export class NumericalPropertiesSummary extends RefCounted {
       const makeBoundElement = (endpointIndex: 0 | 1) => {
         const e = createBoundInput(boundType, endpointIndex);
         e.addEventListener("change", () => {
+          if (!propertySummary.applicable) return;
           const existingBounds = this.bounds[boundType].value[propertyIndex];
           if (existingBounds === undefined) return;
           try {
-            const value = parseDataTypeValue(property.dataType, e.value);
+            const parsedValue =
+              property.baseUnit === undefined
+                ? Number(e.value)
+                : parseValueWithUnit(
+                    e.value,
+                    property.baseUnit,
+                    propertySummary.displayUnit,
+                  );
+            if (parsedValue === undefined || !Number.isFinite(parsedValue)) {
+              throw new Error("Invalid bound");
+            }
+            const value = parseDataTypeValue(
+              property.dataType,
+              `${parsedValue}`,
+            );
             this.setBound(
               boundType,
               endpointIndex,
@@ -506,6 +587,7 @@ export class NumericalPropertiesSummary extends RefCounted {
             this.bounds[boundType].value[propertyIndex][
               endpointIndex
             ] as number,
+            propertySummary.displayUnit,
           );
         });
         return e;
@@ -532,6 +614,7 @@ export class NumericalPropertiesSummary extends RefCounted {
         label.appendChild(document.createTextNode(property.id));
         label.appendChild(sortIcon);
         label.addEventListener("click", () => {
+          if (!propertySummary.applicable) return;
           const q = this.queryResult.value?.query;
           if (q === undefined) return;
           toggleSortOrder(q, this.setQuery, property.id);
@@ -570,7 +653,7 @@ export class NumericalPropertiesSummary extends RefCounted {
     plotContainer.appendChild(boundElements.range.container);
     plotContainer.appendChild(plotImg);
     plotContainer.appendChild(boundElements.window.container);
-    return {
+    const propertySummary: NumericalPropertySummaryWidget = {
       property,
       controller,
       element: plotContainer,
@@ -583,7 +666,10 @@ export class NumericalPropertiesSummary extends RefCounted {
       propertyHistogram: undefined,
       columnCheckbox,
       sortIcon,
+      displayUnit: undefined,
+      applicable: true,
     };
+    return propertySummary;
   }
 
   private updatePropertySummaryRendering(
@@ -596,6 +682,32 @@ export class NumericalPropertiesSummary extends RefCounted {
     const prevConstraintBounds = summary.bounds.range;
     const constraintBounds = this.bounds.range.value[propertyIndex]!;
     const { property } = summary;
+    const nextDisplayUnit =
+      property.baseUnit === undefined
+        ? undefined
+        : pickDisplayUnit(
+            property.bounds as [number, number],
+            property.baseUnit,
+          );
+    const displayUnitChanged =
+      nextDisplayUnit?.scale !== summary.displayUnit?.scale ||
+      nextDisplayUnit?.suffix !== summary.displayUnit?.suffix;
+    summary.displayUnit = nextDisplayUnit;
+    const applicable =
+      this.dataSource.isPropertyApplicable?.(
+        property,
+        this.queryResult.value,
+      ) ?? true;
+    const applicabilityChanged = applicable !== summary.applicable;
+    summary.applicable = applicable;
+    summary.element.style.display = applicable ? "" : "none";
+    summary.element.setAttribute("aria-disabled", `${!applicable}`);
+    summary.columnCheckbox.disabled = !applicable;
+    for (const boundType of ["range", "window"] as const) {
+      for (const input of summary.boundElements[boundType].inputs) {
+        input.disabled = !applicable;
+      }
+    }
     const query = this.queryResult.value?.query;
     const isIncluded = queryIncludesColumn(query, property.id);
     summary.columnCheckbox.checked = isIncluded;
@@ -606,7 +718,9 @@ export class NumericalPropertiesSummary extends RefCounted {
     if (
       summary.propertyHistogram === propertyHistogram &&
       dataTypeIntervalEqual(prevWindowBounds, windowBounds) &&
-      dataTypeIntervalEqual(prevConstraintBounds, constraintBounds)
+      dataTypeIntervalEqual(prevConstraintBounds, constraintBounds) &&
+      !displayUnitChanged &&
+      !applicabilityChanged
     ) {
       return;
     }
@@ -708,15 +822,30 @@ export class NumericalPropertiesSummary extends RefCounted {
     summary.plotImg.src = `data:image/svg+xml;base64,${btoa(xml)}`;
     summary.propertyHistogram = propertyHistogram;
     for (let endpointIndex = 0; endpointIndex < 2; ++endpointIndex) {
+      const roundingDirection = endpointIndex === 0 ? "down" : "up";
       prevWindowBounds[endpointIndex] = windowBounds[endpointIndex];
       updateInputBoundValue(
         summary.boundElements.window.inputs[endpointIndex],
         windowBounds[endpointIndex] as number,
+        summary.displayUnit,
+        dataTypeCompare(
+          windowBounds[endpointIndex],
+          property.bounds[endpointIndex],
+        ) === 0
+          ? roundingDirection
+          : undefined,
       );
       prevConstraintBounds[endpointIndex] = constraintBounds[endpointIndex];
       updateInputBoundValue(
         summary.boundElements.range.inputs[endpointIndex],
         constraintBounds[endpointIndex] as number,
+        summary.displayUnit,
+        dataTypeCompare(
+          constraintBounds[endpointIndex],
+          property.bounds[endpointIndex],
+        ) === 0
+          ? roundingDirection
+          : undefined,
       );
     }
 
@@ -831,4 +960,21 @@ export function renderIncludeExcludeChips(
     list.appendChild(chipElement);
   }
   return list;
+}
+
+export function renderCategoricalPropertiesSummary(options: {
+  chips: IncludeExcludeChip[];
+  propertyCount: number;
+  open?: boolean;
+  onToggle?: (open: boolean) => void;
+}): HTMLDetailsElement | undefined {
+  const chipsElement = renderIncludeExcludeChips(options.chips);
+  if (chipsElement === undefined) return undefined;
+  return createPropertyListSummaryGroup({
+    content: chipsElement,
+    propertyCount: options.propertyCount,
+    propertyKind: "categorical",
+    open: options.open,
+    onToggle: options.onToggle,
+  });
 }

--- a/src/ui/property_summary.ts
+++ b/src/ui/property_summary.ts
@@ -1,0 +1,834 @@
+/**
+ * @license
+ * Copyright 2024 Google Inc.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Shared widgets for property query UIs used by both the segment list and
+// annotation list panels.  These are extracted from segment_list.ts so that
+// annotation_list can reuse the CDF histogram panel and include/exclude chip
+// grid without depending on the segment-specific query engine.
+
+import "#src/ui/segment_list.css";
+
+import type { DebouncedFunc } from "lodash-es";
+import { debounce, throttle } from "lodash-es";
+import type {
+  NumericalPropertyConstraint,
+  SortBy,
+} from "#src/segmentation_display_state/property_map.js";
+import type { WatchableValueInterface } from "#src/trackable_value.js";
+import { WatchableValue } from "#src/trackable_value.js";
+import { animationFrameDebounce } from "#src/util/animation_frame_debounce.js";
+import type { DataType } from "#src/util/data_type.js";
+import { RefCounted } from "#src/util/disposable.js";
+import { updateInputFieldWidth } from "#src/util/dom.js";
+import type { DataTypeInterval } from "#src/util/lerp.js";
+import {
+  clampToInterval,
+  computeInvlerp,
+  dataTypeCompare,
+  dataTypeIntervalEqual,
+  getClampedInterval,
+  getIntervalBoundsEffectiveFraction,
+  parseDataTypeValue,
+} from "#src/util/lerp.js";
+import { neverSignal } from "#src/util/signal.js";
+import { CheckboxIcon } from "#src/widget/checkbox_icon.js";
+import type { RangeAndWindowIntervals } from "#src/widget/invlerp.js";
+import {
+  CdfController,
+  getUpdatedRangeAndWindowParameters,
+} from "#src/widget/invlerp.js";
+
+// --- Interfaces ---------------------------------------------------------------
+
+export interface NumericalSummaryProperty {
+  id: string;
+  dataType: DataType;
+  bounds: DataTypeInterval;
+  description?: string;
+}
+
+/** Implemented by segment and annotation callers to provide histogram data. */
+export interface NumericalSummaryDataSource {
+  properties: NumericalSummaryProperty[];
+  updateHistograms(
+    queryResult:
+      | {
+          intermediateIndices?: ArrayLike<number>;
+          intermediateIndicesMask?:
+            | Uint32Array
+            | Uint16Array
+            | Uint8Array
+            | undefined;
+          indices?: ArrayLike<number>;
+        }
+      | undefined,
+    histograms: NumericalPropertyHistogram[],
+    windowBounds: DataTypeInterval[],
+  ): void;
+}
+
+/** Minimal query shape used by the numerical summary panel. */
+export interface NumericalSummaryQuery {
+  sortBy: SortBy[];
+  includeColumns: string[];
+  numericalConstraints: NumericalPropertyConstraint[];
+}
+
+/** Minimal query-result shape used by the numerical summary panel. */
+export interface NumericalSummaryQueryResult {
+  query: NumericalSummaryQuery;
+  indices?: ArrayLike<number>;
+  intermediateIndices?: ArrayLike<number>;
+  intermediateIndicesMask?: Uint32Array | Uint16Array | Uint8Array;
+}
+
+/** Per-property histogram produced by the data source. */
+export interface NumericalPropertyHistogram {
+  window: DataTypeInterval;
+  histogram: Uint32Array;
+}
+
+// Chip descriptor for the generic include/exclude chip grid.
+export interface IncludeExcludeChip {
+  /** Unique key (e.g. `${propId}=${value}`) — used as a stable id. */
+  key: string;
+  /** Text displayed in the chip. */
+  label: string;
+  /** Optional tooltip. */
+  desc?: string;
+  /** Number of items that have this value in the current result set. */
+  count: number;
+  /**
+   * Total count used to derive the "exclude" side count.
+   * The exclude-side shows `totalCount - count`.
+   */
+  totalCount: number;
+  included: boolean;
+  excluded: boolean;
+  onToggle: (target: "include" | "exclude", value: boolean) => void;
+  headerLabel?: string;
+  headerActive?: boolean;
+  onHeaderClick?: () => void;
+}
+
+// --- Private helpers ----------------------------------------------------------
+
+interface NumericalBoundElements {
+  container: HTMLElement;
+  inputs: [HTMLInputElement, HTMLInputElement];
+  spacers: [HTMLElement, HTMLElement, HTMLElement] | undefined;
+}
+
+interface NumericalPropertySummaryWidget {
+  element: HTMLElement;
+  controller: CdfController<RangeAndWindowIntervals>;
+  property: NumericalSummaryProperty;
+  boundElements: {
+    window: NumericalBoundElements;
+    range: NumericalBoundElements;
+  };
+  plotImg: HTMLImageElement;
+  propertyHistogram: NumericalPropertyHistogram | undefined;
+  bounds: RangeAndWindowIntervals;
+  columnCheckbox: HTMLInputElement;
+  sortIcon: HTMLElement;
+}
+
+function updateInputBoundWidth(inputElement: HTMLInputElement) {
+  updateInputFieldWidth(
+    inputElement,
+    Math.max(1, inputElement.value.length + 0.1),
+  );
+}
+
+function updateInputBoundValue(inputElement: HTMLInputElement, bound: number) {
+  let boundString: string;
+  if (Number.isInteger(bound)) {
+    boundString = bound.toString();
+  } else {
+    const sFull = bound.toString();
+    const sPrecision = bound.toPrecision(6);
+    boundString = sFull.length < sPrecision.length ? sFull : sPrecision;
+  }
+  inputElement.value = boundString;
+  updateInputBoundWidth(inputElement);
+}
+
+function createBoundInput(boundType: "range" | "window", endpointIndex: 0 | 1) {
+  const e = document.createElement("input");
+  e.addEventListener("focus", () => {
+    e.select();
+  });
+  e.classList.add(
+    `neuroglancer-segment-query-result-numerical-plot-${boundType}-bound`,
+  );
+  e.classList.add("neuroglancer-segment-query-result-numerical-plot-bound");
+  e.type = "text";
+  e.spellcheck = false;
+  e.autocomplete = "off";
+  e.title =
+    (endpointIndex === 0 ? "Lower" : "Upper") +
+    " bound " +
+    (boundType === "range" ? "range" : "for distribution");
+  e.addEventListener("input", () => {
+    updateInputBoundWidth(e);
+  });
+  return e;
+}
+
+// --- Exported sort/column helpers ---------------------------------------------
+
+/** Returns true when `fieldId` is in the query's `includeColumns` list. */
+export function queryIncludesColumn(
+  query: { includeColumns?: string[] } | undefined,
+  fieldId: string,
+): boolean {
+  return query?.includeColumns?.includes(fieldId) ?? false;
+}
+
+/** Toggles inclusion of a column, removing its sort if it was being excluded. */
+export function toggleIncludeColumn(
+  query: NumericalSummaryQuery | undefined,
+  setQuery: (q: NumericalSummaryQuery) => void,
+  fieldId: string,
+) {
+  if (query === undefined) return;
+  let { sortBy, includeColumns } = query;
+  const included = queryIncludesColumn(query, fieldId);
+  if (included) {
+    sortBy = sortBy.filter((x) => x.fieldId !== fieldId);
+    includeColumns = includeColumns.filter((x) => x !== fieldId);
+  } else {
+    includeColumns = [...includeColumns, fieldId];
+  }
+  setQuery({ ...query, sortBy, includeColumns });
+}
+
+/** Cycles the sort order for a field; also promotes it to a display column. */
+export function toggleSortOrder(
+  query: NumericalSummaryQuery | undefined,
+  setQuery: (q: NumericalSummaryQuery) => void,
+  id: string,
+) {
+  if (query === undefined) return;
+  const { sortBy, includeColumns } = query;
+  const prevOrder = sortBy.find((x) => x.fieldId === id)?.order;
+  const newOrder = prevOrder === "<" ? ">" : "<";
+  const newIncludeColumns = includeColumns.filter((x) => x !== id);
+  for (const s of sortBy) {
+    if (s.fieldId !== id) {
+      newIncludeColumns.push(s.fieldId);
+    }
+  }
+  setQuery({
+    ...query,
+    sortBy: [{ fieldId: id, order: newOrder }],
+    includeColumns: newIncludeColumns,
+  });
+}
+
+/** Updates a sort icon element to reflect the current sort order for `id`. */
+export function updateColumnSortIcon(
+  query: { sortBy?: SortBy[] } | undefined,
+  sortIcon: HTMLElement,
+  id: string,
+) {
+  const sortBy = query?.sortBy;
+  const order = sortBy?.find((s) => s.fieldId === id)?.order;
+  sortIcon.textContent = order === ">" ? "▼" : "▲";
+  sortIcon.style.visibility = order === undefined ? "" : "visible";
+  sortIcon.title = `Sort by ${id} in ${
+    order === "<" ? "descending" : "ascending"
+  } order`;
+}
+
+// --- NumericalPropertiesSummary -----------------------------------------------
+
+/**
+ * Renders a collapsible panel with one CDF histogram + range/window bound
+ * inputs per numerical property.  Both the segment list and the annotation
+ * list use this widget; they supply different `NumericalSummaryDataSource`
+ * implementations.
+ */
+export class NumericalPropertiesSummary extends RefCounted {
+  listElement: HTMLElement | undefined;
+  properties: NumericalPropertySummaryWidget[];
+  propertyHistograms: NumericalPropertyHistogram[] = [];
+  bounds = {
+    window: new WatchableValue<DataTypeInterval[]>([]),
+    range: new WatchableValue<DataTypeInterval[]>([]),
+  };
+
+  throttledUpdate: DebouncedFunc<() => void> = this.registerCancellable(
+    throttle(() => this.updateHistograms(), 100),
+  );
+  debouncedRender: DebouncedFunc<() => void> = this.registerCancellable(
+    animationFrameDebounce(() => this.updateHistogramRenderings()),
+  );
+  debouncedSetQuery: DebouncedFunc<() => void> = this.registerCancellable(
+    debounce(() => this.setQueryFromBounds(), 200),
+  );
+
+  constructor(
+    public dataSource: NumericalSummaryDataSource,
+    public queryResult: WatchableValueInterface<
+      NumericalSummaryQueryResult | undefined
+    >,
+    public setQuery: (query: NumericalSummaryQuery) => void,
+  ) {
+    super();
+    const { properties } = dataSource;
+    const propertySummaries: NumericalPropertySummaryWidget[] = [];
+    let listElement: HTMLElement | undefined;
+    if (properties.length > 0) {
+      listElement = document.createElement("details");
+      const summaryElement = document.createElement("summary");
+      summaryElement.textContent = `${properties.length} numerical propert${
+        properties.length > 1 ? "ies" : "y"
+      }`;
+      listElement.appendChild(summaryElement);
+      listElement.classList.add(
+        "neuroglancer-segment-query-result-numerical-list",
+      );
+      const windowBounds = this.bounds.window.value;
+      for (let i = 0, n = properties.length; i < n; ++i) {
+        const property = properties[i];
+        const summary = this.makePropertySummary(i, property);
+        propertySummaries.push(summary);
+        listElement.appendChild(summary.element);
+        windowBounds[i] = property.bounds;
+      }
+    }
+    this.listElement = listElement;
+    this.properties = propertySummaries;
+    this.registerDisposer(
+      this.queryResult.changed.add(() => this.handleNewQueryResult()),
+    );
+    this.registerDisposer(this.bounds.window.changed.add(this.throttledUpdate));
+    this.registerDisposer(this.bounds.window.changed.add(this.debouncedRender));
+    this.registerDisposer(this.bounds.range.changed.add(this.debouncedRender));
+    this.registerDisposer(
+      this.bounds.range.changed.add(this.debouncedSetQuery),
+    );
+    this.handleNewQueryResult();
+  }
+
+  private setQueryFromBounds() {
+    const queryResult = this.queryResult.value;
+    if (queryResult === undefined) return;
+    if (queryResult.indices === undefined) return;
+    const { query } = queryResult;
+    const numericalConstraints: NumericalPropertyConstraint[] = [];
+    const constraintBounds = this.bounds.range.value;
+    const { properties } = this;
+    for (let i = 0, n = properties.length; i < n; ++i) {
+      numericalConstraints.push({
+        fieldId: properties[i].property.id,
+        bounds: constraintBounds[i],
+      });
+    }
+    this.setQuery({ ...query, numericalConstraints });
+  }
+
+  private getBounds(propertyIndex: number) {
+    const { bounds } = this;
+    return {
+      range: bounds.range.value[propertyIndex],
+      window: bounds.window.value[propertyIndex],
+    };
+  }
+
+  private setBounds(propertyIndex: number, value: RangeAndWindowIntervals) {
+    const { property } = this.properties[propertyIndex];
+    let newRange = getClampedInterval(property.bounds, value.range);
+    if (dataTypeCompare(newRange[0], newRange[1]) > 0) {
+      newRange = [newRange[1], newRange[0]] as DataTypeInterval;
+    }
+    const newWindow = getClampedInterval(property.bounds, value.window);
+    const oldValue = this.getBounds(propertyIndex);
+    if (!dataTypeIntervalEqual(newWindow, oldValue.window)) {
+      this.bounds.window.value[propertyIndex] = newWindow;
+      this.bounds.window.changed.dispatch();
+    }
+    if (!dataTypeIntervalEqual(newRange, oldValue.range)) {
+      this.bounds.range.value[propertyIndex] = newRange;
+      this.bounds.range.changed.dispatch();
+    }
+  }
+
+  private setBound(
+    boundType: "range" | "window",
+    endpoint: 0 | 1,
+    propertyIndex: number,
+    value: number,
+  ) {
+    const property = this.dataSource.properties[propertyIndex];
+    const baseBounds = property.bounds;
+    value = clampToInterval(baseBounds, value) as number;
+    const params = this.getBounds(propertyIndex);
+    const newParams = getUpdatedRangeAndWindowParameters(
+      params,
+      boundType,
+      endpoint,
+      value,
+      /*fitRangeInWindow=*/ true,
+    );
+    this.setBounds(propertyIndex, newParams);
+  }
+
+  private handleNewQueryResult() {
+    const queryResult = this.queryResult.value;
+    const { listElement } = this;
+    if (listElement === undefined) return;
+    if (queryResult?.indices !== undefined) {
+      const { numericalConstraints } = queryResult.query;
+      const numericalProperties = this.dataSource.properties;
+      const constraintBounds = this.bounds.range.value;
+      const numProperties = numericalProperties.length;
+      constraintBounds.length = numProperties;
+      for (let i = 0; i < numProperties; ++i) {
+        constraintBounds[i] = numericalProperties[i].bounds;
+      }
+      for (const constraint of numericalConstraints) {
+        const propertyIndex = numericalProperties.findIndex(
+          (p) => p.id === constraint.fieldId,
+        );
+        if (propertyIndex !== -1) {
+          constraintBounds[propertyIndex] = constraint.bounds;
+        }
+      }
+    }
+    this.updateHistograms();
+    this.throttledUpdate.cancel();
+  }
+
+  private updateHistograms() {
+    const queryResult = this.queryResult.value;
+    const { listElement } = this;
+    if (listElement === undefined) return;
+    this.dataSource.updateHistograms(
+      queryResult,
+      this.propertyHistograms,
+      this.bounds.window.value,
+    );
+    this.updateHistogramRenderings();
+  }
+
+  private updateHistogramRenderings() {
+    this.debouncedRender.cancel();
+    const { listElement } = this;
+    if (listElement === undefined) return;
+    const { propertyHistograms } = this;
+    if (propertyHistograms.length === 0) {
+      listElement.style.display = "none";
+      return;
+    }
+    listElement.style.display = "";
+    const { properties } = this;
+    for (let i = 0, n = properties.length; i < n; ++i) {
+      this.updatePropertySummaryRendering(
+        i,
+        properties[i],
+        propertyHistograms[i],
+      );
+    }
+  }
+
+  private makePropertySummary(
+    propertyIndex: number,
+    property: NumericalSummaryProperty,
+  ): NumericalPropertySummaryWidget {
+    const plotContainer = document.createElement("div");
+    plotContainer.classList.add(
+      "neuroglancer-segment-query-result-numerical-plot-container",
+    );
+    const plotImg = document.createElement("img");
+    plotImg.classList.add("neuroglancer-segment-query-result-numerical-plot");
+    const controller = new CdfController(
+      plotImg,
+      property.dataType,
+      () => this.getBounds(propertyIndex),
+      (bounds) => this.setBounds(propertyIndex, bounds),
+    );
+    const sortIcon = document.createElement("span");
+    sortIcon.classList.add(
+      "neuroglancer-segment-query-result-numerical-plot-sort",
+    );
+    const columnCheckbox = document.createElement("input");
+    columnCheckbox.type = "checkbox";
+    columnCheckbox.addEventListener("click", () => {
+      const q = this.queryResult.value?.query;
+      if (q === undefined) return;
+      toggleIncludeColumn(q, this.setQuery, property.id);
+    });
+    const makeBoundElements = (
+      boundType: "window" | "range",
+    ): NumericalBoundElements => {
+      const container = document.createElement("div");
+      container.classList.add(
+        "neuroglancer-segment-query-result-numerical-plot-bounds",
+      );
+      container.classList.add(
+        `neuroglancer-segment-query-result-numerical-plot-bounds-${boundType}`,
+      );
+      const makeBoundElement = (endpointIndex: 0 | 1) => {
+        const e = createBoundInput(boundType, endpointIndex);
+        e.addEventListener("change", () => {
+          const existingBounds = this.bounds[boundType].value[propertyIndex];
+          if (existingBounds === undefined) return;
+          try {
+            const value = parseDataTypeValue(property.dataType, e.value);
+            this.setBound(
+              boundType,
+              endpointIndex,
+              propertyIndex,
+              value as number,
+            );
+            this.bounds[boundType].changed.dispatch();
+          } catch {
+            // Ignore invalid input.
+          }
+          updateInputBoundValue(
+            e,
+            this.bounds[boundType].value[propertyIndex][
+              endpointIndex
+            ] as number,
+          );
+        });
+        return e;
+      };
+      const inputs: [HTMLInputElement, HTMLInputElement] = [
+        makeBoundElement(0),
+        makeBoundElement(1),
+      ];
+      let spacers: [HTMLElement, HTMLElement, HTMLElement] | undefined;
+      if (boundType === "range") {
+        spacers = [
+          document.createElement("div"),
+          document.createElement("div"),
+          document.createElement("div"),
+        ];
+        spacers[1].classList.add(
+          "neuroglancer-segment-query-result-numerical-plot-bound-constraint-spacer",
+        );
+        spacers[1].appendChild(columnCheckbox);
+        const label = document.createElement("span");
+        label.classList.add(
+          "neuroglancer-segment-query-result-numerical-plot-label",
+        );
+        label.appendChild(document.createTextNode(property.id));
+        label.appendChild(sortIcon);
+        label.addEventListener("click", () => {
+          const q = this.queryResult.value?.query;
+          if (q === undefined) return;
+          toggleSortOrder(q, this.setQuery, property.id);
+        });
+        spacers[1].appendChild(label);
+        if (property.description) {
+          spacers[1].title = property.description;
+        }
+        container.appendChild(spacers[0]);
+        container.appendChild(inputs[0]);
+        const lessEqual1 = document.createElement("div");
+        lessEqual1.textContent = "≤";
+        lessEqual1.classList.add(
+          "neuroglancer-segment-query-result-numerical-plot-bound-constraint-symbol",
+        );
+        container.appendChild(lessEqual1);
+        container.appendChild(spacers[1]);
+        const lessEqual2 = document.createElement("div");
+        lessEqual2.textContent = "≤";
+        lessEqual2.classList.add(
+          "neuroglancer-segment-query-result-numerical-plot-bound-constraint-symbol",
+        );
+        container.appendChild(lessEqual2);
+        container.appendChild(inputs[1]);
+        container.appendChild(spacers[2]);
+      } else {
+        container.appendChild(inputs[0]);
+        container.appendChild(inputs[1]);
+      }
+      return { container, spacers, inputs };
+    };
+    const boundElements = {
+      range: makeBoundElements("range"),
+      window: makeBoundElements("window"),
+    };
+    plotContainer.appendChild(boundElements.range.container);
+    plotContainer.appendChild(plotImg);
+    plotContainer.appendChild(boundElements.window.container);
+    return {
+      property,
+      controller,
+      element: plotContainer,
+      plotImg,
+      boundElements,
+      bounds: {
+        window: [NaN, NaN],
+        range: [NaN, NaN],
+      },
+      propertyHistogram: undefined,
+      columnCheckbox,
+      sortIcon,
+    };
+  }
+
+  private updatePropertySummaryRendering(
+    propertyIndex: number,
+    summary: NumericalPropertySummaryWidget,
+    propertyHistogram: NumericalPropertyHistogram,
+  ) {
+    const prevWindowBounds = summary.bounds.window;
+    const windowBounds = this.bounds.window.value[propertyIndex]!;
+    const prevConstraintBounds = summary.bounds.range;
+    const constraintBounds = this.bounds.range.value[propertyIndex]!;
+    const { property } = summary;
+    const query = this.queryResult.value?.query;
+    const isIncluded = queryIncludesColumn(query, property.id);
+    summary.columnCheckbox.checked = isIncluded;
+    summary.columnCheckbox.title = isIncluded
+      ? "Remove column from result table"
+      : "Add column to result table";
+    updateColumnSortIcon(query, summary.sortIcon, property.id);
+    if (
+      summary.propertyHistogram === propertyHistogram &&
+      dataTypeIntervalEqual(prevWindowBounds, windowBounds) &&
+      dataTypeIntervalEqual(prevConstraintBounds, constraintBounds)
+    ) {
+      return;
+    }
+    const { histogram } = propertyHistogram;
+    const svgNs = "http://www.w3.org/2000/svg";
+    const plotElement = document.createElementNS(svgNs, "svg");
+    plotElement.setAttribute("width", "1");
+    plotElement.setAttribute("height", "1");
+    plotElement.setAttribute("preserveAspectRatio", "none");
+    const rect = document.createElementNS(svgNs, "rect");
+    const constraintStartX = computeInvlerp(windowBounds, constraintBounds[0]);
+    const constraintEndX = computeInvlerp(windowBounds, constraintBounds[1]);
+    rect.setAttribute("x", `${constraintStartX}`);
+    rect.setAttribute("y", "0");
+    rect.setAttribute("width", `${constraintEndX - constraintStartX}`);
+    rect.setAttribute("height", "1");
+    rect.setAttribute("fill", "#4f4f4f");
+    plotElement.appendChild(rect);
+    const numBins = histogram.length;
+    const makeCdfLine = (
+      startBinIndex: number,
+      endBinIndex: number,
+      endBinIndexForTotal: number,
+    ) => {
+      const polyLine = document.createElementNS(svgNs, "polyline");
+      let points = "";
+      let totalCount = 0;
+      for (let i = startBinIndex; i < endBinIndexForTotal; ++i) {
+        totalCount += histogram[i];
+      }
+      if (totalCount === 0) return undefined;
+      const startBinX = computeInvlerp(
+        windowBounds,
+        propertyHistogram.window[0],
+      );
+      const endBinX = computeInvlerp(windowBounds, propertyHistogram.window[1]);
+      const addPoint = (i: number, height: number) => {
+        const fraction = i / (numBins - 2);
+        const x = startBinX * (1 - fraction) + endBinX * fraction;
+        points += ` ${x},${1 - height}`;
+      };
+      if (startBinIndex !== 0) {
+        addPoint(startBinIndex, 0);
+      }
+      let cumSum = 0;
+      for (let i = startBinIndex; i < endBinIndex; ++i) {
+        const count = histogram[i];
+        cumSum += count;
+        addPoint(i, cumSum / totalCount);
+      }
+      polyLine.setAttribute("fill", "none");
+      polyLine.setAttribute("stroke-width", "1px");
+      polyLine.setAttribute("points", points);
+      polyLine.setAttribute("vector-effect", "non-scaling-stroke");
+      return polyLine;
+    };
+
+    {
+      const polyLine = makeCdfLine(0, numBins - 1, numBins);
+      if (polyLine !== undefined) {
+        polyLine.setAttribute("stroke", "cyan");
+        plotElement.appendChild(polyLine);
+      }
+    }
+
+    if (!dataTypeIntervalEqual(property.bounds, constraintBounds)) {
+      const constraintStartBin = Math.floor(
+        Math.max(
+          0,
+          Math.min(
+            1,
+            computeInvlerp(propertyHistogram.window, constraintBounds[0]),
+          ),
+        ) *
+          (numBins - 2),
+      );
+      const constraintEndBin = Math.ceil(
+        Math.max(
+          0,
+          Math.min(
+            1,
+            computeInvlerp(propertyHistogram.window, constraintBounds[1]),
+          ),
+        ) *
+          (numBins - 2),
+      );
+      const polyLine = makeCdfLine(
+        constraintStartBin,
+        constraintEndBin,
+        constraintEndBin,
+      );
+      if (polyLine !== undefined) {
+        polyLine.setAttribute("stroke", "white");
+        plotElement.appendChild(polyLine);
+      }
+    }
+
+    const xml = new XMLSerializer().serializeToString(plotElement);
+    summary.plotImg.src = `data:image/svg+xml;base64,${btoa(xml)}`;
+    summary.propertyHistogram = propertyHistogram;
+    for (let endpointIndex = 0; endpointIndex < 2; ++endpointIndex) {
+      prevWindowBounds[endpointIndex] = windowBounds[endpointIndex];
+      updateInputBoundValue(
+        summary.boundElements.window.inputs[endpointIndex],
+        windowBounds[endpointIndex] as number,
+      );
+      prevConstraintBounds[endpointIndex] = constraintBounds[endpointIndex];
+      updateInputBoundValue(
+        summary.boundElements.range.inputs[endpointIndex],
+        constraintBounds[endpointIndex] as number,
+      );
+    }
+
+    const spacers = summary.boundElements.range.spacers!;
+    const clampedRange = getClampedInterval(windowBounds, constraintBounds);
+    const effectiveFraction = getIntervalBoundsEffectiveFraction(
+      property.dataType,
+      windowBounds,
+    );
+    const leftOffset =
+      computeInvlerp(windowBounds, clampedRange[0]) * effectiveFraction;
+    const rightOffset =
+      computeInvlerp(windowBounds, clampedRange[1]) * effectiveFraction +
+      (1 - effectiveFraction);
+    spacers[0].style.width = `${leftOffset * 100}%`;
+    spacers[2].style.width = `${(1 - rightOffset) * 100}%`;
+  }
+}
+
+// --- renderIncludeExcludeChips ------------------------------------------------
+
+/**
+ * Renders a grid of include/exclude toggle chips (e.g. for enum values or
+ * tags).  Each chip shows a +/- CheckboxIcon pair and a label with count.
+ *
+ * Reuses `neuroglancer-segment-query-result-tag-*` CSS classes so both the
+ * segment tag panel and the annotation enum/bool panel look identical.
+ */
+export function renderIncludeExcludeChips(
+  chips: IncludeExcludeChip[],
+): HTMLElement | undefined {
+  if (chips.length === 0) return undefined;
+  const list = document.createElement("div");
+  list.classList.add("neuroglancer-segment-query-result-tag-list");
+  for (const chip of chips) {
+    const chipElement = document.createElement("div");
+    chipElement.classList.add("neuroglancer-segment-query-result-tag");
+    const inQuery = chip.included || chip.excluded;
+    const addToggleButton = (include: boolean) => {
+      const sideCount = include ? chip.count : chip.totalCount - chip.count;
+      const toggleEl = document.createElement("div");
+      toggleEl.classList.add("neuroglancer-segment-query-result-tag-toggle");
+      toggleEl.classList.add(
+        `neuroglancer-segment-query-result-tag-${include ? "include" : "exclude"}`,
+      );
+      chipElement.appendChild(toggleEl);
+      if (!inQuery && sideCount === 0) return;
+      const selected = include ? chip.included : chip.excluded;
+      toggleEl.appendChild(
+        new CheckboxIcon(
+          {
+            get value() {
+              return selected;
+            },
+            set value(v: boolean) {
+              chip.onToggle(include ? "include" : "exclude", v);
+            },
+            changed: neverSignal,
+          },
+          {
+            text: include ? "+" : "-",
+            enableTitle: `Add to ${include ? "required" : "exclusion"} set`,
+            disableTitle: `Remove from ${include ? "required" : "exclusion"} set`,
+            backgroundScheme: "dark",
+          },
+        ).element,
+      );
+    };
+    addToggleButton(true);
+    addToggleButton(false);
+
+    if (chip.headerLabel !== undefined) {
+      const tagArea = document.createElement("span");
+      tagArea.style.gridColumn = "tag";
+      tagArea.style.whiteSpace = "nowrap";
+      const headerBtn = document.createElement("button");
+      headerBtn.classList.add(
+        "neuroglancer-segment-query-result-tag-header-btn",
+      );
+      headerBtn.textContent = chip.headerLabel;
+      headerBtn.dataset.active = chip.headerActive ? "true" : "false";
+      if (chip.desc) headerBtn.title = chip.desc;
+      headerBtn.addEventListener("click", (e) => {
+        e.stopPropagation();
+        chip.onHeaderClick?.();
+      });
+      tagArea.appendChild(headerBtn);
+      if (chip.label) {
+        const valSpan = document.createElement("span");
+        valSpan.textContent = chip.label;
+        valSpan.style.color = "rgba(255,255,255,0.6)";
+        tagArea.appendChild(valSpan);
+      }
+      chipElement.appendChild(tagArea);
+    } else {
+      const labelEl = document.createElement("span");
+      labelEl.classList.add("neuroglancer-segment-query-result-tag-name");
+      labelEl.textContent = chip.label;
+      if (chip.desc) labelEl.title = chip.desc;
+      labelEl.addEventListener("click", () => {
+        chip.onToggle("include", !chip.included && !chip.excluded);
+      });
+      chipElement.appendChild(labelEl);
+    }
+
+    const countEl = document.createElement("span");
+    countEl.classList.add("neuroglancer-segment-query-result-tag-count");
+    if (!inQuery) {
+      countEl.textContent = String(chip.count);
+    }
+    chipElement.appendChild(countEl);
+    list.appendChild(chipElement);
+  }
+  return list;
+}

--- a/src/ui/property_summary.ts
+++ b/src/ui/property_summary.ts
@@ -66,6 +66,7 @@ export interface NumericalSummaryProperty {
   dataType: DataType;
   bounds: DataTypeInterval;
   description?: string;
+  columnToggleable?: boolean;
   baseUnit?: string;
   applicableAnnotationTypes?: readonly number[];
 }
@@ -534,8 +535,13 @@ export class NumericalPropertiesSummary extends RefCounted {
     );
     const columnCheckbox = document.createElement("input");
     columnCheckbox.type = "checkbox";
+    if (property.columnToggleable === false) {
+      columnCheckbox.style.visibility = "hidden";
+    }
     columnCheckbox.addEventListener("click", () => {
-      if (!propertySummary.applicable) return;
+      if (!propertySummary.applicable || property.columnToggleable === false) {
+        return;
+      }
       const q = this.queryResult.value?.query;
       if (q === undefined) return;
       toggleIncludeColumn(q, this.setQuery, property.id);
@@ -709,11 +715,16 @@ export class NumericalPropertiesSummary extends RefCounted {
       }
     }
     const query = this.queryResult.value?.query;
-    const isIncluded = queryIncludesColumn(query, property.id);
+    const isIncluded =
+      property.columnToggleable === false ||
+      queryIncludesColumn(query, property.id);
     summary.columnCheckbox.checked = isIncluded;
-    summary.columnCheckbox.title = isIncluded
-      ? "Remove column from result table"
-      : "Add column to result table";
+    summary.columnCheckbox.title =
+      property.columnToggleable === false
+        ? ""
+        : isIncluded
+          ? "Remove column from result table"
+          : "Add column to result table";
     updateColumnSortIcon(query, summary.sortIcon, property.id);
     if (
       summary.propertyHistogram === propertyHistogram &&

--- a/src/ui/segment_list.css
+++ b/src/ui/segment_list.css
@@ -154,6 +154,27 @@
   font-weight: normal;
 }
 
+.neuroglancer-segment-query-result-tag-header-btn {
+  background: transparent;
+  border: 1px solid #555;
+  color: rgba(255, 255, 255, 0.45);
+  padding: 1px 4px;
+  cursor: pointer;
+  font-size: 11px;
+  border-radius: 2px;
+  line-height: 1.4;
+}
+
+.neuroglancer-segment-query-result-tag-header-btn:hover {
+  border-color: rgba(255, 255, 255, 0.6);
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.neuroglancer-segment-query-result-tag-header-btn[data-active="true"] {
+  border-color: #4e9ac0;
+  color: #4e9ac0;
+}
+
 .neuroglancer-segment-query-result-tag-toggle {
   display: inline-block;
   white-space: nowrap;

--- a/src/ui/segment_list.css
+++ b/src/ui/segment_list.css
@@ -71,13 +71,6 @@
   white-space: nowrap;
 }
 
-.neuroglancer-segment-list-status {
-  display: flex;
-  flex-direction: row;
-  align-items: center;
-  background-color: #333;
-}
-
 .neuroglancer-segment-list-entry-copy {
   order: -2;
   visibility: hidden;
@@ -272,27 +265,13 @@
   pointer-events: none;
 }
 
-.neuroglancer-segment-list-entry.neuroglancer-segment-list-header {
-  background-color: #666;
-}
-
 .neuroglancer-segment-list-header .neuroglancer-segment-list-entry-id {
   background-color: inherit;
   color: white;
   text-align: center;
 }
 
-.neuroglancer-segment-list-header-label {
-  cursor: pointer;
-  font: 10pt sans-serif;
-}
-
 .neuroglancer-segment-list-header
   .neuroglancer-segment-list-entry-extra-property {
   text-align: center;
-}
-
-.neuroglancer-segment-list-status-message {
-  overflow: hidden;
-  white-space: nowrap;
 }

--- a/src/ui/segment_list.css
+++ b/src/ui/segment_list.css
@@ -71,20 +71,6 @@
   white-space: nowrap;
 }
 
-.neuroglancer-segment-list-query {
-  background-color: #151515;
-  color: white;
-  font-family: monospace;
-  font-size: medium;
-  border: 2px solid #333;
-  padding: 2px;
-  outline: 0px;
-}
-
-.neuroglancer-segment-list-query::placeholder {
-  color: #aaa;
-}
-
 .neuroglancer-segment-list-status {
   display: flex;
   flex-direction: row;
@@ -188,28 +174,6 @@
   grid-column: exclude;
 }
 
-.neuroglancer-segment-query-result-statistics {
-  background-color: #333;
-  max-height: 30%;
-  flex-shrink: 0;
-  overflow: auto;
-}
-
-.neuroglancer-segment-query-result-statistics:not(:empty) {
-  padding-top: 3px;
-}
-
-.neuroglancer-segment-query-result-statistics:not(:empty)
-  + .neuroglancer-segment-list-status {
-  border-top: 1px solid white;
-}
-
-.neuroglancer-segment-query-result-statistics-separator {
-  height: 3px;
-  background-color: #333;
-  border-bottom: 1px solid white;
-}
-
 .neuroglancer-segment-query-result-tag-count {
   grid-column: count;
   text-align: right;
@@ -287,15 +251,12 @@
   cursor: pointer;
 }
 
-.neuroglancer-segment-query-result-numerical-plot-sort,
-.neuroglancer-segment-list-header-label-sort {
+.neuroglancer-segment-query-result-numerical-plot-sort {
   visibility: hidden;
 }
 
 .neuroglancer-segment-query-result-numerical-plot-label:hover
-  .neuroglancer-segment-query-result-numerical-plot-sort,
-.neuroglancer-segment-list-header-label:hover
-  .neuroglancer-segment-list-header-label-sort {
+  .neuroglancer-segment-query-result-numerical-plot-sort {
   visibility: visible;
 }
 

--- a/src/ui/segment_list.ts
+++ b/src/ui/segment_list.ts
@@ -49,6 +49,7 @@ import { observeWatchable, WatchableValue } from "#src/trackable_value.js";
 import { getDefaultSelectBindings } from "#src/ui/default_input_event_bindings.js";
 import {
   bindPropertyListSortControl,
+  createPropertyListQueryContainer,
   createPropertyListQueryInput,
   createPropertyListStatisticsShell,
 } from "#src/ui/property_list.js";
@@ -61,7 +62,7 @@ import type {
 import {
   NumericalPropertiesSummary,
   queryIncludesColumn,
-  renderIncludeExcludeChips,
+  renderCategoricalPropertiesSummary,
   toggleSortOrder,
 } from "#src/ui/property_summary.js";
 import { SELECT_SEGMENTS_TOOLS_ID } from "#src/ui/segment_select_tools.js";
@@ -461,8 +462,12 @@ abstract class SegmentListGroupBase extends RefCounted {
     const { selectionStatusContainer } = this;
     this.selectionStatusMessage.classList.add(
       "neuroglancer-segment-list-status-message",
+      "neuroglancer-property-list-status-message",
     );
-    selectionStatusContainer.classList.add("neuroglancer-segment-list-status");
+    selectionStatusContainer.classList.add(
+      "neuroglancer-segment-list-status",
+      "neuroglancer-property-list-status",
+    );
     selectionStatusContainer.appendChild(this.copyAllSegmentsButton);
     selectionStatusContainer.appendChild(this.starAllButton);
     selectionStatusContainer.appendChild(this.visibilityToggleAllButton);
@@ -577,6 +582,8 @@ class SegmentListGroupSelected extends SegmentListGroupBase {
 }
 
 class SegmentListGroupQuery extends SegmentListGroupBase {
+  private categoricalDetailsOpen = false;
+
   updateQuery() {
     const { listSource, debouncedUpdateQueryModel } = this;
     debouncedUpdateQueryModel();
@@ -712,7 +719,10 @@ class SegmentListGroupQuery extends SegmentListGroupBase {
       removeChildren(list.header);
       if (segmentPropertyMap !== undefined) {
         const header = listSource.segmentWidgetFactory.getHeader();
-        header.container.classList.add("neuroglancer-segment-list-header");
+        header.container.classList.add(
+          "neuroglancer-segment-list-header",
+          "neuroglancer-property-list-header",
+        );
         for (const headerLabel of header.propertyLabels) {
           const { label, sortIcon, id } = headerLabel;
           bindPropertyListSortControl({
@@ -774,7 +784,14 @@ class SegmentListGroupQuery extends SegmentListGroupBase {
             },
           }),
         );
-        tagSummary = renderIncludeExcludeChips(chips);
+        tagSummary = renderCategoricalPropertiesSummary({
+          chips,
+          propertyCount: 1,
+          open: this.categoricalDetailsOpen,
+          onToggle: (open) => {
+            this.categoricalDetailsOpen = open;
+          },
+        });
       }
       if (tagSummary !== undefined) {
         queryStatisticsContainer.appendChild(tagSummary);
@@ -876,7 +893,7 @@ export class SegmentDisplayTab extends Tab {
       }, this.layer.segmentQueryFocusTime),
     );
 
-    element.appendChild(queryElement);
+    element.appendChild(createPropertyListQueryContainer(queryElement));
     element.appendChild(
       this.registerDisposer(
         new DependentViewWidget(

--- a/src/ui/segment_list.ts
+++ b/src/ui/segment_list.ts
@@ -17,7 +17,7 @@
 import "#src/ui/segment_list.css";
 
 import type { DebouncedFunc } from "lodash-es";
-import { debounce, throttle } from "lodash-es";
+import { debounce } from "lodash-es";
 import type {
   SegmentationUserLayer,
   SegmentationUserLayerGroupState,
@@ -30,8 +30,6 @@ import {
 import type {
   ExplicitIdQuery,
   FilterQuery,
-  InlineSegmentNumericalProperty,
-  NumericalPropertyConstraint,
   PreprocessedSegmentPropertyMap,
   PropertyHistogram,
   QueryResult,
@@ -43,13 +41,25 @@ import {
   forEachQueryResultSegmentIdGenerator,
   isQueryUnconstrained,
   parseSegmentQuery,
-  queryIncludesColumn,
   unparseSegmentQuery,
   updatePropertyHistograms,
 } from "#src/segmentation_display_state/property_map.js";
 import type { WatchableValueInterface } from "#src/trackable_value.js";
 import { observeWatchable, WatchableValue } from "#src/trackable_value.js";
 import { getDefaultSelectBindings } from "#src/ui/default_input_event_bindings.js";
+import type {
+  IncludeExcludeChip,
+  NumericalSummaryDataSource,
+  NumericalSummaryQuery,
+  NumericalSummaryQueryResult,
+} from "#src/ui/property_summary.js";
+import {
+  NumericalPropertiesSummary,
+  queryIncludesColumn,
+  renderIncludeExcludeChips,
+  toggleSortOrder,
+  updateColumnSortIcon,
+} from "#src/ui/property_summary.js";
 import { SELECT_SEGMENTS_TOOLS_ID } from "#src/ui/segment_select_tools.js";
 import {
   ANNOTATE_MERGE_SEGMENTS_TOOL_ID,
@@ -62,33 +72,17 @@ import { getFixedOrderMergeSplices } from "#src/util/array.js";
 import { bigintCompare } from "#src/util/bigint.js";
 import { setClipboard } from "#src/util/clipboard.js";
 import { RefCounted } from "#src/util/disposable.js";
-import { removeChildren, updateInputFieldWidth } from "#src/util/dom.js";
+import { removeChildren } from "#src/util/dom.js";
 import {
   EventActionMap,
   KeyboardEventBinder,
   registerActionListener,
 } from "#src/util/keyboard_bindings.js";
-import type { DataTypeInterval } from "#src/util/lerp.js";
-import {
-  clampToInterval,
-  computeInvlerp,
-  dataTypeCompare,
-  dataTypeIntervalEqual,
-  getClampedInterval,
-  getIntervalBoundsEffectiveFraction,
-  parseDataTypeValue,
-} from "#src/util/lerp.js";
 import { MouseEventBinder } from "#src/util/mouse_bindings.js";
-import { neverSignal, NullarySignal, Signal } from "#src/util/signal.js";
-import { CheckboxIcon } from "#src/widget/checkbox_icon.js";
+import { NullarySignal, Signal } from "#src/util/signal.js";
 import { makeCopyButton } from "#src/widget/copy_button.js";
 import { DependentViewWidget } from "#src/widget/dependent_view_widget.js";
 import { makeEyeButton } from "#src/widget/eye_button.js";
-import type { RangeAndWindowIntervals } from "#src/widget/invlerp.js";
-import {
-  CdfController,
-  getUpdatedRangeAndWindowParameters,
-} from "#src/widget/invlerp.js";
 import { makeStarButton } from "#src/widget/star_button.js";
 import { Tab } from "#src/widget/tab_view.js";
 import type { VirtualListSource } from "#src/widget/virtual_list.js";
@@ -351,712 +345,6 @@ const keyMap = EventActionMap.fromObject({
   "control+enter": { action: "hide-all" },
   escape: { action: "cancel" },
 });
-
-interface NumericalBoundElements {
-  container: HTMLElement;
-  inputs: [HTMLInputElement, HTMLInputElement];
-  spacers: [HTMLElement, HTMLElement, HTMLElement] | undefined;
-}
-
-interface NumericalPropertySummary {
-  element: HTMLElement;
-  controller: CdfController<RangeAndWindowIntervals>;
-  property: InlineSegmentNumericalProperty;
-  boundElements: {
-    window: NumericalBoundElements;
-    range: NumericalBoundElements;
-  };
-  plotImg: HTMLImageElement;
-  propertyHistogram: PropertyHistogram | undefined;
-  bounds: RangeAndWindowIntervals;
-  columnCheckbox: HTMLInputElement;
-  sortIcon: HTMLElement;
-}
-
-function updateInputBoundWidth(inputElement: HTMLInputElement) {
-  updateInputFieldWidth(
-    inputElement,
-    Math.max(1, inputElement.value.length + 0.1),
-  );
-}
-
-function updateInputBoundValue(inputElement: HTMLInputElement, bound: number) {
-  let boundString: string;
-  if (Number.isInteger(bound)) {
-    boundString = bound.toString();
-  } else {
-    const sFull = bound.toString();
-    const sPrecision = bound.toPrecision(6);
-    boundString = sFull.length < sPrecision.length ? sFull : sPrecision;
-  }
-  inputElement.value = boundString;
-  updateInputBoundWidth(inputElement);
-}
-
-function createBoundInput(boundType: "range" | "window", endpointIndex: 0 | 1) {
-  const e = document.createElement("input");
-  e.addEventListener("focus", () => {
-    e.select();
-  });
-  e.classList.add(
-    `neuroglancer-segment-query-result-numerical-plot-${boundType}-bound`,
-  );
-  e.classList.add("neuroglancer-segment-query-result-numerical-plot-bound");
-  e.type = "text";
-  e.spellcheck = false;
-  e.autocomplete = "off";
-  e.title =
-    (endpointIndex === 0 ? "Lower" : "Upper") +
-    " bound " +
-    (boundType === "range" ? "range" : "for distribution");
-  e.addEventListener("input", () => {
-    updateInputBoundWidth(e);
-  });
-  return e;
-}
-
-function toggleIncludeColumn(
-  queryResult: QueryResult | undefined,
-  setQuery: (query: FilterQuery) => void,
-  fieldId: string,
-) {
-  if (queryResult === undefined) return;
-  if (queryResult.indices === undefined) return;
-  const query = queryResult.query as FilterQuery;
-  let { sortBy, includeColumns } = query;
-  const included = queryIncludesColumn(query, fieldId);
-  if (included) {
-    sortBy = sortBy.filter((x) => x.fieldId !== fieldId);
-    includeColumns = includeColumns.filter((x) => x !== fieldId);
-  } else {
-    includeColumns.push(fieldId);
-  }
-  setQuery({ ...query, sortBy, includeColumns });
-}
-
-function toggleSortOrder(
-  queryResult: QueryResult | undefined,
-  setQuery: (query: FilterQuery) => void,
-  id: string,
-) {
-  const query = queryResult?.query;
-  const sortBy = query?.sortBy;
-  if (sortBy === undefined) return;
-  const { includeColumns } = query as FilterQuery;
-  const prevOrder = sortBy.find((x) => x.fieldId === id)?.order;
-  const newOrder = prevOrder === "<" ? ">" : "<";
-  const newIncludeColumns = includeColumns.filter((x) => x !== id);
-  for (const s of sortBy) {
-    if (s.fieldId !== "id" && s.fieldId !== "label" && s.fieldId !== id) {
-      newIncludeColumns.push(s.fieldId);
-    }
-  }
-  setQuery({
-    ...(query as FilterQuery),
-    sortBy: [{ fieldId: id, order: newOrder }],
-    includeColumns: newIncludeColumns,
-  });
-}
-
-function updateColumnSortIcon(
-  queryResult: QueryResult | undefined,
-  sortIcon: HTMLElement,
-  id: string,
-) {
-  const sortBy = queryResult?.query?.sortBy;
-  const order = sortBy?.find((s) => s.fieldId === id)?.order;
-  sortIcon.textContent = order === ">" ? "▼" : "▲";
-  sortIcon.style.visibility = order === undefined ? "" : "visible";
-  sortIcon.title = `Sort by ${id} in ${
-    order === "<" ? "descending" : "ascending"
-  } order`;
-}
-
-class NumericalPropertiesSummary extends RefCounted {
-  listElement: HTMLElement | undefined;
-  properties: NumericalPropertySummary[];
-  propertyHistograms: PropertyHistogram[] = [];
-  bounds = {
-    window: new WatchableValue<DataTypeInterval[]>([]),
-    range: new WatchableValue<DataTypeInterval[]>([]),
-  };
-
-  throttledUpdate = this.registerCancellable(
-    throttle(() => this.updateHistograms(), 100),
-  );
-  debouncedRender = this.registerCancellable(
-    animationFrameDebounce(() => this.updateHistogramRenderings()),
-  );
-  debouncedSetQuery = this.registerCancellable(
-    debounce(() => this.setQueryFromBounds(), 200),
-  );
-
-  constructor(
-    public segmentPropertyMap: PreprocessedSegmentPropertyMap | undefined,
-    public queryResult: WatchableValueInterface<QueryResult | undefined>,
-    public setQuery: (query: FilterQuery) => void,
-  ) {
-    super();
-    const properties = segmentPropertyMap?.numericalProperties;
-    const propertySummaries: NumericalPropertySummary[] = [];
-    let listElement: HTMLElement | undefined;
-    if (properties !== undefined && properties.length > 0) {
-      listElement = document.createElement("details");
-      const summaryElement = document.createElement("summary");
-      summaryElement.textContent = `${properties.length} numerical propert${
-        properties.length > 1 ? "ies" : "y"
-      }`;
-      listElement.appendChild(summaryElement);
-      listElement.classList.add(
-        "neuroglancer-segment-query-result-numerical-list",
-      );
-      const windowBounds = this.bounds.window.value;
-      for (
-        let i = 0, numProperties = properties.length;
-        i < numProperties;
-        ++i
-      ) {
-        const property = properties[i];
-        const summary = this.makeNumericalPropertySummary(i, property);
-        propertySummaries.push(summary);
-        listElement.appendChild(summary.element);
-        windowBounds[i] = property.bounds;
-      }
-    }
-    this.listElement = listElement;
-    this.properties = propertySummaries;
-    this.registerDisposer(
-      this.queryResult.changed.add(() => {
-        this.handleNewQueryResult();
-      }),
-    );
-    // When window bounds change, we need to recompute histograms.  Throttle this to avoid
-    // excessive computation time.
-    this.registerDisposer(this.bounds.window.changed.add(this.throttledUpdate));
-    // When window bounds or constraint bounds change, re-render the plot on the next animation
-    // frame.
-    this.registerDisposer(this.bounds.window.changed.add(this.debouncedRender));
-    this.registerDisposer(this.bounds.range.changed.add(this.debouncedRender));
-    this.registerDisposer(
-      this.bounds.range.changed.add(this.debouncedSetQuery),
-    );
-    this.handleNewQueryResult();
-  }
-
-  private setQueryFromBounds() {
-    const queryResult = this.queryResult.value;
-    if (queryResult === undefined) return;
-    if (queryResult.indices === undefined) return;
-    const query = queryResult.query as FilterQuery;
-    const numericalConstraints: NumericalPropertyConstraint[] = [];
-    const constraintBounds = this.bounds.range.value;
-    const { properties } = this;
-    for (let i = 0, numProperties = properties.length; i < numProperties; ++i) {
-      const property = properties[i].property;
-      numericalConstraints.push({
-        fieldId: property.id,
-        bounds: constraintBounds[i],
-      });
-    }
-    this.setQuery({ ...query, numericalConstraints });
-  }
-
-  private getBounds(propertyIndex: number) {
-    const { bounds } = this;
-    return {
-      range: bounds.range.value[propertyIndex],
-      window: bounds.window.value[propertyIndex],
-    };
-  }
-
-  private setBounds(propertyIndex: number, value: RangeAndWindowIntervals) {
-    const { property } = this.properties[propertyIndex];
-    let newRange = getClampedInterval(property.bounds, value.range);
-    if (dataTypeCompare(newRange[0], newRange[1]) > 0) {
-      newRange = [newRange[1], newRange[0]] as DataTypeInterval;
-    }
-    const newWindow = getClampedInterval(property.bounds, value.window);
-    const oldValue = this.getBounds(propertyIndex);
-    if (!dataTypeIntervalEqual(newWindow, oldValue.window)) {
-      this.bounds.window.value[propertyIndex] = newWindow;
-      this.bounds.window.changed.dispatch();
-    }
-    if (!dataTypeIntervalEqual(newRange, oldValue.range)) {
-      this.bounds.range.value[propertyIndex] = newRange;
-      this.bounds.range.changed.dispatch();
-    }
-  }
-
-  private setBound(
-    boundType: "range" | "window",
-    endpoint: 0 | 1,
-    propertyIndex: number,
-    value: number,
-  ) {
-    const property =
-      this.segmentPropertyMap!.numericalProperties[propertyIndex];
-    const baseBounds = property.bounds;
-    value = clampToInterval(baseBounds, value) as number;
-    const params = this.getBounds(propertyIndex);
-    const newParams = getUpdatedRangeAndWindowParameters(
-      params,
-      boundType,
-      endpoint,
-      value,
-      /*fitRangeInWindow=*/ true,
-    );
-    this.setBounds(propertyIndex, newParams);
-  }
-
-  private handleNewQueryResult() {
-    const queryResult = this.queryResult.value;
-    const { listElement } = this;
-    if (listElement === undefined) return;
-    if (queryResult?.indices !== undefined) {
-      const { numericalConstraints } = queryResult!.query as FilterQuery;
-      const { numericalProperties } = this.segmentPropertyMap!;
-      const constraintBounds = this.bounds.range.value;
-      const numConstraints = numericalConstraints.length;
-      const numProperties = numericalProperties.length;
-      constraintBounds.length = numProperties;
-      for (let i = 0; i < numProperties; ++i) {
-        constraintBounds[i] = numericalProperties[i].bounds;
-      }
-      for (let i = 0; i < numConstraints; ++i) {
-        const constraint = numericalConstraints[i];
-        const propertyIndex = numericalProperties.findIndex(
-          (p) => p.id === constraint.fieldId,
-        );
-        constraintBounds[propertyIndex] = constraint.bounds;
-      }
-    }
-    this.updateHistograms();
-    this.throttledUpdate.cancel();
-  }
-
-  private updateHistograms() {
-    const queryResult = this.queryResult.value;
-    const { listElement } = this;
-    if (listElement === undefined) return;
-    updatePropertyHistograms(
-      this.segmentPropertyMap,
-      queryResult,
-      this.propertyHistograms,
-      this.bounds.window.value,
-    );
-    this.updateHistogramRenderings();
-  }
-
-  private updateHistogramRenderings() {
-    this.debouncedRender.cancel();
-    const { listElement } = this;
-    if (listElement === undefined) return;
-    const { propertyHistograms } = this;
-    if (propertyHistograms.length === 0) {
-      listElement.style.display = "none";
-      return;
-    }
-    listElement.style.display = "";
-    const { properties } = this;
-    for (let i = 0, n = properties.length; i < n; ++i) {
-      this.updateNumericalPropertySummary(
-        i,
-        properties[i],
-        propertyHistograms[i],
-      );
-    }
-  }
-
-  private makeNumericalPropertySummary(
-    propertyIndex: number,
-    property: InlineSegmentNumericalProperty,
-  ): NumericalPropertySummary {
-    const plotContainer = document.createElement("div");
-    plotContainer.classList.add(
-      "neuroglancer-segment-query-result-numerical-plot-container",
-    );
-    const plotImg = document.createElement("img");
-    plotImg.classList.add("neuroglancer-segment-query-result-numerical-plot");
-    const controller = new CdfController(
-      plotImg,
-      property.dataType,
-      () => this.getBounds(propertyIndex),
-      (bounds) => this.setBounds(propertyIndex, bounds),
-    );
-    const sortIcon = document.createElement("span");
-    sortIcon.classList.add(
-      "neuroglancer-segment-query-result-numerical-plot-sort",
-    );
-    const columnCheckbox = document.createElement("input");
-    columnCheckbox.type = "checkbox";
-    columnCheckbox.addEventListener("click", () => {
-      toggleIncludeColumn(this.queryResult.value, this.setQuery, property.id);
-    });
-    const makeBoundElements = (
-      boundType: "window" | "range",
-    ): NumericalBoundElements => {
-      const container = document.createElement("div");
-      container.classList.add(
-        "neuroglancer-segment-query-result-numerical-plot-bounds",
-      );
-      container.classList.add(
-        `neuroglancer-segment-query-result-numerical-plot-bounds-${boundType}`,
-      );
-      const makeBoundElement = (endpointIndex: 0 | 1) => {
-        const e = createBoundInput(boundType, endpointIndex);
-        e.addEventListener("change", () => {
-          const existingBounds = this.bounds[boundType].value[propertyIndex];
-          if (existingBounds === undefined) return;
-          try {
-            const value = parseDataTypeValue(property.dataType, e.value);
-            this.setBound(
-              boundType,
-              endpointIndex,
-              propertyIndex,
-              value as number,
-            );
-            this.bounds[boundType].changed.dispatch();
-          } catch {
-            // Ignore invalid input.
-          }
-          updateInputBoundValue(
-            e,
-            this.bounds[boundType].value[propertyIndex][
-              endpointIndex
-            ] as number,
-          );
-        });
-        return e;
-      };
-      const inputs: [HTMLInputElement, HTMLInputElement] = [
-        makeBoundElement(0),
-        makeBoundElement(1),
-      ];
-
-      let spacers: [HTMLElement, HTMLElement, HTMLElement] | undefined;
-      if (boundType === "range") {
-        spacers = [
-          document.createElement("div"),
-          document.createElement("div"),
-          document.createElement("div"),
-        ];
-        spacers[1].classList.add(
-          "neuroglancer-segment-query-result-numerical-plot-bound-constraint-spacer",
-        );
-        spacers[1].appendChild(columnCheckbox);
-        const label = document.createElement("span");
-        label.classList.add(
-          "neuroglancer-segment-query-result-numerical-plot-label",
-        );
-        label.appendChild(document.createTextNode(property.id));
-        label.appendChild(sortIcon);
-        label.addEventListener("click", () => {
-          toggleSortOrder(this.queryResult.value, this.setQuery, property.id);
-        });
-        spacers[1].appendChild(label);
-        const { description } = property;
-        if (description) {
-          spacers[1].title = description;
-        }
-        container.appendChild(spacers[0]);
-        container.appendChild(inputs[0]);
-        const lessEqual1 = document.createElement("div");
-        lessEqual1.textContent = "≤";
-        lessEqual1.classList.add(
-          "neuroglancer-segment-query-result-numerical-plot-bound-constraint-symbol",
-        );
-        container.appendChild(lessEqual1);
-        container.appendChild(spacers[1]);
-        const lessEqual2 = document.createElement("div");
-        lessEqual2.textContent = "≤";
-        lessEqual2.classList.add(
-          "neuroglancer-segment-query-result-numerical-plot-bound-constraint-symbol",
-        );
-        container.appendChild(lessEqual2);
-        container.appendChild(inputs[1]);
-        container.appendChild(spacers[2]);
-      } else {
-        container.appendChild(inputs[0]);
-        container.appendChild(inputs[1]);
-      }
-      return { container, spacers, inputs };
-    };
-    const boundElements = {
-      range: makeBoundElements("range"),
-      window: makeBoundElements("window"),
-    };
-    plotContainer.appendChild(boundElements.range.container);
-    plotContainer.appendChild(plotImg);
-    plotContainer.appendChild(boundElements.window.container);
-    return {
-      property,
-      controller,
-      element: plotContainer,
-      plotImg,
-      boundElements,
-      bounds: {
-        window: [NaN, NaN],
-        range: [NaN, NaN],
-      },
-      propertyHistogram: undefined,
-      columnCheckbox,
-      sortIcon,
-    };
-  }
-
-  private updateNumericalPropertySummary(
-    propertyIndex: number,
-    summary: NumericalPropertySummary,
-    propertyHistogram: PropertyHistogram,
-  ) {
-    const prevWindowBounds = summary.bounds.window;
-    const windowBounds = this.bounds.window.value[propertyIndex]!;
-    const prevConstraintBounds = summary.bounds.range;
-    const constraintBounds = this.bounds.range.value[propertyIndex]!;
-    const { property } = summary;
-    const queryResult = this.queryResult.value;
-    const isIncluded = queryIncludesColumn(queryResult?.query, property.id);
-    summary.columnCheckbox.checked = isIncluded;
-    summary.columnCheckbox.title = isIncluded
-      ? "Remove column from result table"
-      : "Add column to result table";
-    updateColumnSortIcon(queryResult, summary.sortIcon, property.id);
-    // Check if we need to update the image.
-    if (
-      summary.propertyHistogram === propertyHistogram &&
-      dataTypeIntervalEqual(prevWindowBounds, windowBounds) &&
-      dataTypeIntervalEqual(prevConstraintBounds, constraintBounds)
-    ) {
-      return;
-    }
-    const { histogram } = propertyHistogram;
-    const svgNs = "http://www.w3.org/2000/svg";
-    const plotElement = document.createElementNS(svgNs, "svg");
-    plotElement.setAttribute("width", "1");
-    plotElement.setAttribute("height", "1");
-    plotElement.setAttribute("preserveAspectRatio", "none");
-    const rect = document.createElementNS(svgNs, "rect");
-    const constraintStartX = computeInvlerp(windowBounds, constraintBounds[0]);
-    const constraintEndX = computeInvlerp(windowBounds, constraintBounds[1]);
-    rect.setAttribute("x", `${constraintStartX}`);
-    rect.setAttribute("y", "0");
-    rect.setAttribute("width", `${constraintEndX - constraintStartX}`);
-    rect.setAttribute("height", "1");
-    rect.setAttribute("fill", "#4f4f4f");
-    plotElement.appendChild(rect);
-    const numBins = histogram.length;
-    const makeCdfLine = (
-      startBinIndex: number,
-      endBinIndex: number,
-      endBinIndexForTotal: number,
-    ) => {
-      const polyLine = document.createElementNS(svgNs, "polyline");
-      let points = "";
-      let totalCount = 0;
-      for (let i = startBinIndex; i < endBinIndexForTotal; ++i) {
-        totalCount += histogram[i];
-      }
-      if (totalCount === 0) return undefined;
-      const startBinX = computeInvlerp(
-        windowBounds,
-        propertyHistogram.window[0],
-      );
-      const endBinX = computeInvlerp(windowBounds, propertyHistogram.window[1]);
-      const addPoint = (i: number, height: number) => {
-        const fraction = i / (numBins - 2);
-        const x = startBinX * (1 - fraction) + endBinX * fraction;
-        points += ` ${x},${1 - height}`;
-      };
-      if (startBinIndex !== 0) {
-        addPoint(startBinIndex, 0);
-      }
-      let cumSum = 0;
-      for (let i = startBinIndex; i < endBinIndex; ++i) {
-        const count = histogram[i];
-        cumSum += count;
-        addPoint(i, cumSum / totalCount);
-      }
-      polyLine.setAttribute("fill", "none");
-      polyLine.setAttribute("stroke-width", "1px");
-      polyLine.setAttribute("points", points);
-      polyLine.setAttribute("vector-effect", "non-scaling-stroke");
-      return polyLine;
-    };
-
-    {
-      const polyLine = makeCdfLine(0, numBins - 1, numBins);
-      if (polyLine !== undefined) {
-        polyLine.setAttribute("stroke", "cyan");
-        plotElement.appendChild(polyLine);
-      }
-    }
-
-    if (!dataTypeIntervalEqual(property.bounds, constraintBounds)) {
-      // Also plot CDF restricted to data that satisfies the constraint.
-      const constraintStartBin = Math.floor(
-        Math.max(
-          0,
-          Math.min(
-            1,
-            computeInvlerp(propertyHistogram.window, constraintBounds[0]),
-          ),
-        ) *
-          (numBins - 2),
-      );
-      const constraintEndBin = Math.ceil(
-        Math.max(
-          0,
-          Math.min(
-            1,
-            computeInvlerp(propertyHistogram.window, constraintBounds[1]),
-          ),
-        ) *
-          (numBins - 2),
-      );
-      const polyLine = makeCdfLine(
-        constraintStartBin,
-        constraintEndBin,
-        constraintEndBin,
-      );
-      if (polyLine !== undefined) {
-        polyLine.setAttribute("stroke", "white");
-        plotElement.appendChild(polyLine);
-      }
-    }
-
-    // Embed the svg as an img rather than embedding it directly, in order to
-    // allow it to be scaled using CSS.
-    const xml = new XMLSerializer().serializeToString(plotElement);
-    summary.plotImg.src = `data:image/svg+xml;base64,${btoa(xml)}`;
-    summary.propertyHistogram = propertyHistogram;
-    for (let endpointIndex = 0; endpointIndex < 2; ++endpointIndex) {
-      prevWindowBounds[endpointIndex] = windowBounds[endpointIndex];
-      updateInputBoundValue(
-        summary.boundElements.window.inputs[endpointIndex],
-        windowBounds[endpointIndex] as number,
-      );
-      prevConstraintBounds[endpointIndex] = constraintBounds[endpointIndex];
-      updateInputBoundValue(
-        summary.boundElements.range.inputs[endpointIndex],
-        constraintBounds[endpointIndex] as number,
-      );
-    }
-
-    const spacers = summary.boundElements.range.spacers!;
-    const clampedRange = getClampedInterval(windowBounds, constraintBounds);
-    const effectiveFraction = getIntervalBoundsEffectiveFraction(
-      property.dataType,
-      windowBounds,
-    );
-    const leftOffset =
-      computeInvlerp(windowBounds, clampedRange[0]) * effectiveFraction;
-    const rightOffset =
-      computeInvlerp(windowBounds, clampedRange[1]) * effectiveFraction +
-      (1 - effectiveFraction);
-    spacers[0].style.width = `${leftOffset * 100}%`;
-    spacers[2].style.width = `${(1 - rightOffset) * 100}%`;
-  }
-}
-
-function renderTagSummary(
-  queryResult: QueryResult,
-  setQuery: (query: FilterQuery) => void,
-): HTMLElement | undefined {
-  const { tags } = queryResult;
-  if (tags === undefined || tags.length === 0) return undefined;
-  const filterQuery = queryResult.query as FilterQuery;
-  const tagList = document.createElement("div");
-  tagList.classList.add("neuroglancer-segment-query-result-tag-list");
-  for (const { tag, count, desc } of tags) {
-    const tagElement = document.createElement("div");
-    tagElement.classList.add("neuroglancer-segment-query-result-tag");
-    const tagName = document.createElement("span");
-    tagName.classList.add("neuroglancer-segment-query-result-tag-name");
-    // if the tag is different than desc, show both
-    if (tag !== desc && desc !== undefined && desc !== "") {
-      tagName.textContent = tag + " (" + desc + ")";
-    } else {
-      tagName.textContent = tag;
-    }
-
-    tagList.appendChild(tagElement);
-    const included = filterQuery.includeTags.includes(tag);
-    const excluded = filterQuery.excludeTags.includes(tag);
-    let toggleTooltip: string;
-    if (included) {
-      toggleTooltip = "Remove tag from required set";
-    } else if (excluded) {
-      toggleTooltip = "Remove tag from excluded set";
-    } else {
-      toggleTooltip = "Add tag to required set";
-    }
-    tagName.addEventListener("click", () => {
-      setQuery(
-        changeTagConstraintInSegmentQuery(
-          filterQuery,
-          tag,
-          true,
-          !included && !excluded,
-        ),
-      );
-    });
-    tagName.title = toggleTooltip;
-    const inQuery = included || excluded;
-    const addIncludeExcludeButton = (include: boolean) => {
-      const includeExcludeCount = include ? count : queryResult.count - count;
-      const includeElement = document.createElement("div");
-      includeElement.classList.add(
-        "neuroglancer-segment-query-result-tag-toggle",
-      );
-      includeElement.classList.add(
-        `neuroglancer-segment-query-result-tag-${
-          include ? "include" : "exclude"
-        }`,
-      );
-      tagElement.appendChild(includeElement);
-      if (!inQuery && includeExcludeCount === 0) return;
-      const selected = include ? included : excluded;
-      includeElement.appendChild(
-        new CheckboxIcon(
-          {
-            get value() {
-              return selected;
-            },
-            set value(value: boolean) {
-              setQuery(
-                changeTagConstraintInSegmentQuery(
-                  filterQuery,
-                  tag,
-                  include,
-                  value,
-                ),
-              );
-            },
-            changed: neverSignal,
-          },
-          {
-            text: include ? "+" : "-",
-            enableTitle: `Add tag to ${include ? "required" : "exclusion"} set`,
-            disableTitle: `Remove tag from ${
-              include ? "required" : "exclusion"
-            } set`,
-            backgroundScheme: "dark",
-          },
-        ).element,
-      );
-    };
-    addIncludeExcludeButton(true);
-    addIncludeExcludeButton(false);
-    tagElement.appendChild(tagName);
-    const numElement = document.createElement("span");
-    numElement.classList.add("neuroglancer-segment-query-result-tag-count");
-    if (!inQuery) {
-      numElement.textContent = count.toString();
-    }
-    tagElement.appendChild(numElement);
-  }
-  return tagList;
-}
 
 abstract class SegmentListGroupBase extends RefCounted {
   element = document.createElement("div");
@@ -1372,11 +660,29 @@ class SegmentListGroupQuery extends SegmentListGroupBase {
         }
       }),
     );
+    const segmentDataSource: NumericalSummaryDataSource = {
+      properties: (segmentPropertyMap?.numericalProperties ?? []).map((p) => ({
+        id: p.id,
+        dataType: p.dataType,
+        bounds: p.bounds,
+        description: p.description,
+      })),
+      updateHistograms(qr, histograms, windowBounds) {
+        updatePropertyHistograms(
+          segmentPropertyMap,
+          qr as QueryResult | undefined,
+          histograms as PropertyHistogram[],
+          windowBounds,
+        );
+      },
+    };
     const numericalPropertySummaries = this.registerDisposer(
       new NumericalPropertiesSummary(
-        segmentPropertyMap,
-        listSource.queryResult,
-        setQuery,
+        segmentDataSource,
+        listSource.queryResult as unknown as WatchableValueInterface<
+          NumericalSummaryQueryResult | undefined
+        >,
+        setQuery as unknown as (q: NumericalSummaryQuery) => void,
       ),
     );
     {
@@ -1412,9 +718,15 @@ class SegmentListGroupQuery extends SegmentListGroupBase {
         for (const headerLabel of header.propertyLabels) {
           const { label, sortIcon, id } = headerLabel;
           label.addEventListener("click", () => {
-            toggleSortOrder(listSource.queryResult.value, setQuery, id);
+            toggleSortOrder(
+              listSource.queryResult.value?.query as
+                | NumericalSummaryQuery
+                | undefined,
+              setQuery as unknown as (q: NumericalSummaryQuery) => void,
+              id,
+            );
           });
-          updateColumnSortIcon(queryResult, sortIcon, id);
+          updateColumnSortIcon(queryResult?.query, sortIcon, id);
         }
         list.header.appendChild(header.container);
       }
@@ -1424,14 +736,37 @@ class SegmentListGroupQuery extends SegmentListGroupBase {
       if (queryResult === undefined) return;
       const { query } = queryResult;
       if (query.errors !== undefined || query.ids !== undefined) return;
-      tagSummary = renderTagSummary(queryResult, setQuery);
+      if (queryResult.tags !== undefined && queryResult.tags.length > 0) {
+        const filterQuery = queryResult.query as FilterQuery;
+        const chips: IncludeExcludeChip[] = queryResult.tags.map(
+          ({ tag, count, desc }) => ({
+            key: tag,
+            label:
+              desc !== undefined && desc !== "" && tag !== desc
+                ? `${tag} (${desc})`
+                : tag,
+            count,
+            totalCount: queryResult.count,
+            included: filterQuery.includeTags.includes(tag),
+            excluded: filterQuery.excludeTags.includes(tag),
+            onToggle: (target, value) => {
+              setQuery(
+                changeTagConstraintInSegmentQuery(
+                  filterQuery,
+                  tag,
+                  target === "include",
+                  value,
+                ),
+              );
+            },
+          }),
+        );
+        tagSummary = renderIncludeExcludeChips(chips);
+      }
       if (tagSummary !== undefined) {
         queryStatisticsContainer.appendChild(tagSummary);
       }
-      if (
-        numericalPropertySummaries.properties.length > 0 ||
-        tagSummary !== undefined
-      ) {
+      if (segmentDataSource.properties.length > 0 || tagSummary !== undefined) {
         queryStatisticsSeparator.style.display = "";
       }
     }, listSource.queryResult);

--- a/src/ui/segment_list.ts
+++ b/src/ui/segment_list.ts
@@ -47,6 +47,11 @@ import {
 import type { WatchableValueInterface } from "#src/trackable_value.js";
 import { observeWatchable, WatchableValue } from "#src/trackable_value.js";
 import { getDefaultSelectBindings } from "#src/ui/default_input_event_bindings.js";
+import {
+  bindPropertyListSortControl,
+  createPropertyListQueryInput,
+  createPropertyListStatisticsShell,
+} from "#src/ui/property_list.js";
 import type {
   IncludeExcludeChip,
   NumericalSummaryDataSource,
@@ -58,7 +63,6 @@ import {
   queryIncludesColumn,
   renderIncludeExcludeChips,
   toggleSortOrder,
-  updateColumnSortIcon,
 } from "#src/ui/property_summary.js";
 import { SELECT_SEGMENTS_TOOLS_ID } from "#src/ui/segment_select_tools.js";
 import {
@@ -608,21 +612,15 @@ class SegmentListGroupQuery extends SegmentListGroupBase {
       segmentQuery.value = value;
       queryElement.select();
     };
-    const queryStatisticsContainer = document.createElement("div");
-    queryStatisticsContainer.classList.add(
-      "neuroglancer-segment-query-result-statistics",
-    );
-    const queryStatisticsSeparator = document.createElement("div");
-    queryStatisticsSeparator.classList.add(
-      "neuroglancer-segment-query-result-statistics-separator",
-    );
+    const queryStatistics = createPropertyListStatisticsShell();
+    const queryStatisticsContainer = queryStatistics.content;
     const queryErrors = document.createElement("ul");
     queryErrors.classList.add("neuroglancer-segment-query-errors");
     // push them in front of the base list elements
     this.element.prepend(
       queryErrors,
-      queryStatisticsContainer,
-      queryStatisticsSeparator,
+      queryStatistics.root,
+      queryStatistics.separator,
     );
     this.registerEventListener(queryElement, "input", () => {
       debouncedUpdateQueryModel();
@@ -717,21 +715,36 @@ class SegmentListGroupQuery extends SegmentListGroupBase {
         header.container.classList.add("neuroglancer-segment-list-header");
         for (const headerLabel of header.propertyLabels) {
           const { label, sortIcon, id } = headerLabel;
-          label.addEventListener("click", () => {
-            toggleSortOrder(
-              listSource.queryResult.value?.query as
-                | NumericalSummaryQuery
-                | undefined,
-              setQuery as unknown as (q: NumericalSummaryQuery) => void,
-              id,
-            );
+          bindPropertyListSortControl({
+            label,
+            sortIcon,
+            fieldId: id,
+            allowClear: false,
+            getDirection: () => {
+              const order = queryResult?.query?.sortBy?.find(
+                (sort) => sort.fieldId === id,
+              )?.order;
+              return order === "<"
+                ? "ascending"
+                : order === ">"
+                  ? "descending"
+                  : undefined;
+            },
+            onChange: () => {
+              toggleSortOrder(
+                listSource.queryResult.value?.query as
+                  | NumericalSummaryQuery
+                  | undefined,
+                setQuery as unknown as (q: NumericalSummaryQuery) => void,
+                id,
+              );
+            },
           });
-          updateColumnSortIcon(queryResult?.query, sortIcon, id);
         }
         list.header.appendChild(header.container);
       }
       updateQueryErrors(queryResult);
-      queryStatisticsSeparator.style.display = "none";
+      queryStatistics.setVisible(false);
       tagSummary?.remove();
       if (queryResult === undefined) return;
       const { query } = queryResult;
@@ -767,7 +780,7 @@ class SegmentListGroupQuery extends SegmentListGroupBase {
         queryStatisticsContainer.appendChild(tagSummary);
       }
       if (segmentDataSource.properties.length > 0 || tagSummary !== undefined) {
-        queryStatisticsSeparator.style.display = "";
+        queryStatistics.setVisible(true);
       }
     }, listSource.queryResult);
   }
@@ -832,10 +845,9 @@ export class SegmentDisplayTab extends Tab {
     );
     element.appendChild(toolbox);
 
-    const queryElement = document.createElement("input");
-    queryElement.classList.add("neuroglancer-segment-list-query");
-    queryElement.addEventListener("focus", () => {
-      queryElement.select();
+    const queryElement = createPropertyListQueryInput({
+      placeholder: "Enter ID, name prefix or /regexp",
+      selectOnFocus: true,
     });
     const keyboardHandler = this.registerDisposer(
       new KeyboardEventBinder(queryElement, keyMap),
@@ -847,10 +859,7 @@ export class SegmentDisplayTab extends Tab {
         segmentQuery.value = queryElement.value;
       }, 200),
     );
-    queryElement.autocomplete = "off";
     queryElement.title = keyMap.describe();
-    queryElement.spellcheck = false;
-    queryElement.placeholder = "Enter ID, name prefix or /regexp";
     this.registerDisposer(
       observeWatchable((q) => {
         queryElement.value = q;

--- a/src/util/si_units.spec.ts
+++ b/src/util/si_units.spec.ts
@@ -16,10 +16,55 @@
 
 import { describe, it, expect } from "vitest";
 import {
+  formatValueWithUnit,
+  parseValueWithUnit,
+  pickDisplayUnit,
+  roundValueToDisplayUnit,
   parseScale,
   scaleByExp10,
   formatScaleWithUnit,
 } from "#src/util/si_units.js";
+
+describe("property value units", () => {
+  it("selects and converts a linear SI display unit", () => {
+    const unit = pickDisplayUnit([5e-9, 30e-9], "m");
+    expect(unit).toEqual({ scale: 1e-9, suffix: "nm" });
+    expect(formatValueWithUnit(5e-9, unit)).toBe("5.00nm");
+    expect(parseValueWithUnit("5nm", "m")).toBe(5e-9);
+    expect(parseValueWithUnit("5", "m", unit)).toBe(5e-9);
+  });
+
+  it("applies SI prefixes to powered units", () => {
+    const unit = pickDisplayUnit([1e-12, 25e-12], "m^2");
+    expect(unit).toEqual({ scale: 1e-12, suffix: "µm^2" });
+    expect(formatValueWithUnit(25e-12, unit)).toBe("25.00µm^2");
+    expect(parseValueWithUnit("25um^2", "m^2")).toBe(25e-12);
+  });
+
+  it("rejects units that do not match the property", () => {
+    expect(parseValueWithUnit("5ns", "m")).toBeUndefined();
+  });
+
+  it("defaults widget interactions to two decimals", () => {
+    const unit = { scale: 1e-9, suffix: "nm" };
+    const rounded = roundValueToDisplayUnit(26.049236e-9, unit);
+    expect(formatValueWithUnit(rounded, unit)).toBe("26.05nm");
+  });
+
+  it("rounds initial unlimited bounds outward", () => {
+    const unit = { scale: 1e-9, suffix: "nm" };
+    expect(formatValueWithUnit(25.001e-9, unit, "down")).toBe("25.00nm");
+    expect(formatValueWithUnit(29.999e-9, unit, "up")).toBe("30.00nm");
+    expect(formatValueWithUnit(25e-9, unit, "down")).toBe("25.00nm");
+    expect(formatValueWithUnit(30e-9, unit, "up")).toBe("30.00nm");
+  });
+
+  it("preserves manually entered additional decimal places", () => {
+    const unit = { scale: 1e-9, suffix: "nm" };
+    const value = parseValueWithUnit("26.1234nm", "m", unit)!;
+    expect(formatValueWithUnit(value, unit)).toBe("26.1234nm");
+  });
+});
 
 describe("parseScale", () => {
   const patterns: [string, { scale: number; unit: string } | undefined][] = [

--- a/src/util/si_units.ts
+++ b/src/util/si_units.ts
@@ -79,6 +79,92 @@ export function pickSiPrefix(x: number): SiPrefix {
   return preferredSiPrefixes[Math.min(i, numPrefixes - 1)];
 }
 
+export interface DisplayUnit {
+  /** SI base units per displayed unit. */
+  scale: number;
+  /** Unit suffix shown to the user, such as `nm` or `µm^2`. */
+  suffix: string;
+}
+
+function splitPoweredUnit(unit: string) {
+  const match = unit.match(/^(.*?)(?:\^(\d+))?$/)!;
+  return { unit: match[1], power: Number(match[2] ?? 1) };
+}
+
+export function pickDisplayUnit(
+  bounds: readonly [number, number],
+  baseUnit: string,
+): DisplayUnit {
+  if (baseUnit === "") return { scale: 1, suffix: "" };
+  const { unit, power } = splitPoweredUnit(baseUnit);
+  const magnitude = Math.max(Math.abs(bounds[0]), Math.abs(bounds[1]));
+  const prefix = pickSiPrefix(
+    magnitude > 0 && Number.isFinite(magnitude) ? magnitude ** (1 / power) : 1,
+  );
+  return {
+    scale: 10 ** (prefix.exponent * power),
+    suffix: `${prefix.prefix}${unit}${power === 1 ? "" : `^${power}`}`,
+  };
+}
+
+export function parseValueWithUnit(
+  value: string,
+  baseUnit: string,
+  defaultUnit?: DisplayUnit,
+): number | undefined {
+  const match = value.match(
+    /^([+-]?(?:(?:\d+(?:\.\d*)?|\.\d+)(?:[eE][+-]?\d+)?))(.*)$/,
+  );
+  if (match === null) return undefined;
+  const numericValue = Number(match[1]);
+  if (!Number.isFinite(numericValue)) return undefined;
+  const suffix = match[2];
+  if (suffix === "") return numericValue * (defaultUnit?.scale ?? 1);
+  const { unit, power } = splitPoweredUnit(baseUnit);
+  for (const prefix of siPrefixesWithAlternatives) {
+    const expectedSuffix = `${prefix.prefix}${unit}${
+      power === 1 ? "" : `^${power}`
+    }`;
+    if (suffix === expectedSuffix) {
+      return numericValue * 10 ** (prefix.exponent * power);
+    }
+  }
+  return undefined;
+}
+
+export function formatValueWithUnit(
+  value: number,
+  displayUnit: DisplayUnit,
+  roundingDirection?: "down" | "up",
+): string {
+  const adjustedValue = value / displayUnit.scale;
+  if (roundingDirection !== undefined) {
+    const scaledValue = adjustedValue * 100;
+    const tolerance = Math.max(1, Math.abs(scaledValue)) * 1e-12;
+    const roundedValue =
+      roundingDirection === "down"
+        ? Math.floor(scaledValue + tolerance)
+        : Math.ceil(scaledValue - tolerance);
+    return `${(roundedValue / 100).toFixed(2)}${displayUnit.suffix}`;
+  }
+  const roundedValue = Number(adjustedValue.toFixed(2));
+  const tolerance = Math.max(1, Math.abs(adjustedValue)) * 1e-6;
+  const valueString =
+    Math.abs(adjustedValue - roundedValue) <= tolerance
+      ? adjustedValue.toFixed(2)
+      : adjustedValue.toString();
+  return `${valueString}${displayUnit.suffix}`;
+}
+
+export function roundValueToDisplayUnit(
+  value: number | bigint,
+  displayUnit: DisplayUnit,
+): number {
+  return (
+    Number((Number(value) / displayUnit.scale).toFixed(2)) * displayUnit.scale
+  );
+}
+
 interface FormatScaleWithUnitOptions {
   precision?: number;
   elide1?: boolean;

--- a/src/widget/invlerp.ts
+++ b/src/widget/invlerp.ts
@@ -76,7 +76,7 @@ import { Tab } from "#src/widget/tab_view.js";
 const inputEventMap = EventActionMap.fromObject({
   "shift?+mousedown0": { action: "set" },
   "shift?+alt+mousedown0": { action: "adjust-window-via-drag" },
-  "shift?+wheel": { action: "zoom-via-wheel" },
+  "shift+wheel": { action: "zoom-via-wheel" },
 });
 
 export function createCDFLineShader(gl: GL, textureUnit: symbol) {


### PR DESCRIPTION
[example](https://neuroglancer--pr1105-x7l3zeib.web.app/#!%7B%22dimensions%22:%7B%22x%22:%5B4e-9%2C%22m%22%5D%2C%22y%22:%5B4e-9%2C%22m%22%5D%2C%22z%22:%5B3.3e-8%2C%22m%22%5D%7D%2C%22position%22:%5B515892%2C356400%2C2646%5D%2C%22crossSectionScale%22:8%2C%22projectionScale%22:8192%2C%22layers%22:%5B%7B%22type%22:%22image%22%2C%22source%22:%22precomputed://gs://h01-release/data/20210601/4nm_raw%22%2C%22tab%22:%22source%22%2C%22name%22:%22H01%20EM%22%7D%2C%7B%22type%22:%22segmentation%22%2C%22source%22:%22precomputed://gs://h01-release/data/20210601/c3%22%2C%22tab%22:%22segments%22%2C%22segments%22:%5B%22258279044%22%2C%22272206514%22%2C%22272264889%22%2C%22272367447%22%2C%22272500389%22%5D%2C%22segmentQuery%22:%22%3CNSO%20%7CNVx%20%7CNSI%20%7CSp%22%2C%22name%22:%22C3%20segmentation%22%7D%2C%7B%22type%22:%22annotation%22%2C%22source%22:%7B%22url%22:%22local://annotations%22%2C%22transform%22:%7B%22outputDimensions%22:%7B%22x%22:%5B4e-9%2C%22m%22%5D%2C%22y%22:%5B4e-9%2C%22m%22%5D%2C%22z%22:%5B3.3e-8%2C%22m%22%5D%7D%7D%7D%2C%22tab%22:%22annotations%22%2C%22annotations%22:%5B%7B%22point%22:%5B515892%2C356400%2C2646%5D%2C%22type%22:%22point%22%2C%22id%22:%22point-1%22%2C%22description%22:%22Soma%20candidate%22%2C%22props%22:%5B0.92%2C2%2C1%5D%7D%2C%7B%22pointA%22:%5B515700%2C356300%2C2646%5D%2C%22pointB%22:%5B516050%2C356550%2C2646%5D%2C%22type%22:%22line%22%2C%22id%22:%22line-1%22%2C%22description%22:%22Reviewed%20neurite%22%2C%22props%22:%5B0.78%2C1%2C1%5D%7D%2C%7B%22pointA%22:%5B515500%2C356100%2C2638%5D%2C%22pointB%22:%5B516200%2C356800%2C2654%5D%2C%22type%22:%22axis_aligned_bounding_box%22%2C%22id%22:%22box-1%22%2C%22description%22:%22Review%20region%22%2C%22props%22:%5B0.35%2C0%2C0%5D%7D%5D%2C%22annotationProperties%22:%5B%7B%22id%22:%22confidence%22%2C%22description%22:%22Review%20confidence%22%2C%22type%22:%22float32%22%7D%2C%7B%22id%22:%22status%22%2C%22type%22:%22uint8%22%2C%22enum_labels%22:%5B%22todo%22%2C%22review%22%2C%22done%22%5D%2C%22enum_values%22:%5B0%2C1%2C2%5D%7D%2C%7B%22id%22:%22verified%22%2C%22type%22:%22uint8%22%2C%22enum_labels%22:%5B%22no%22%2C%22yes%22%5D%2C%22enum_values%22:%5B0%2C1%5D%7D%5D%2C%22annotationListColumns%22:%5B%22x%22%2C%22y%22%2C%22z%22%2C%22length%22%2C%22confidence%22%2C%22status%22%2C%22verified%22%5D%2C%22annotationListSort%22:%7B%22propertyId%22:%22confidence%22%2C%22order%22:%22desc%22%7D%2C%22name%22:%22Annotation%20list%20demo%22%7D%5D%2C%22selectedLayer%22:%7B%22visible%22:true%2C%22layer%22:%22Annotation%20list%20demo%22%7D%2C%22layout%22:%22xy%22%2C%22uiControlVisibility%22:%7B%7D%7D)

Focusing on the UX for now.

This branch adds a similar query field with a UX to modify it similar to segmentation properties, I made some minor changes to segment properties, most notably that you need to hold shift to scroll zoom the numerical plots.

One major difference between the segmentation and annotation filter behaviors is that the annotations are visually filtered as well.
